### PR TITLE
artifacts/devices: use MENDER_SDIMG_* variable names instead of deprecated SDIMG_*

### DIFF
--- a/03.Artifacts/05.Variables/docs.md
+++ b/03.Artifacts/05.Variables/docs.md
@@ -53,12 +53,12 @@ The storage device, as referred to by U-Boot (e.g. `1`). This variable can be us
 The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can be used in cases where the Linux kernel and U-Boot refer to the same device with different names. See [U-Boot and the Linux kernel do not agree about the indexes of storage devices](../../Troubleshooting/Yocto-project-build#u-boot-and-the-linux-kernel-do-not-agree-about-the-indexes-of-st) for more information.
 
 
-#### SDIMG_BOOT_PART_SIZE_MB
+#### MENDER_BOOT_PART_SIZE_MB
 
 The size of the boot partition in the generated `.sdimg` file. See [Configuring the partition sizes](../../Devices/Partition-layout#configuring-the-partition-sizes) for more information.
 
 
-#### SDIMG_DATA_PART_SIZE_MB
+#### MENDER_DATA_PART_SIZE_MB
 
 The size of the persistent data partition in the generated `.sdimg` file. See [Configuring the partition sizes](../../Devices/Partition-layout#configuring-the-partition-sizes) for more information.
 

--- a/04.Devices/02.Partition-layout/docs.md
+++ b/04.Devices/02.Partition-layout/docs.md
@@ -102,11 +102,11 @@ MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}3"
 
 When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) Mender defines and uses certain OpenEmbedded variables which are used to define the sizes of the partitions. They are defined in `meta-mender` under `classes/mender-sdimg.bbclass`.
 
-| Mount point | Purpose                                                 | Default size | Variable to configure size |
-|-------------|---------------------------------------------------------|--------------|----------------------------|
-| `/`         | Store the root file system and kernel.                  | N/A          | `IMAGE_ROOTFS_SIZE`        |
-| `/uboot`    | Store the bootloader.                                   | 16 MB        | `SDIMG_BOOT_PART_SIZE_MB`  |
-| `/data`     | Store persistent data, preserved during Mender updates. | 128 MB       | `SDIMG_DATA_PART_SIZE_MB`  |
+| Mount point | Purpose                                                 | Default size | Variable to configure size  |
+|-------------|---------------------------------------------------------|--------------|-----------------------------|
+| `/`         | Store the root file system and kernel.                  | N/A          | `IMAGE_ROOTFS_SIZE`         |
+| `/uboot`    | Store the bootloader.                                   | 16 MB        | `MENDER_BOOT_PART_SIZE_MB`  |
+| `/data`     | Store persistent data, preserved during Mender updates. | 128 MB       | `MENDER_DATA_PART_SIZE_MB`  |
 
 
 You can override these default values in your `local.conf`.


### PR DESCRIPTION
There's a corresponding PR in mender Yocto layer https://github.com/mendersoftware/meta-mender/pull/154
