### PR TITLE
Fix invalid formatting

### DIFF
--- a/03.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/03.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -115,7 +115,7 @@ DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
-IMAGE_FSTYPES = 'ext4' # or ext2, ext3
+IMAGE_FSTYPES = "ext4"
 ```
 
 Please replace `<YOUR-MACHINE>` with the correct machine for your device.


### PR DESCRIPTION
Inline comments in config is invalid and won't build.  Use double-quotes for consistency.