### PR TITLE
Update all updates to refer to `.mender` instead of `.ext4`.

### DIFF
--- a/01.Getting-started/05.Standalone-deployments/docs.md
+++ b/01.Getting-started/05.Standalone-deployments/docs.md
@@ -32,13 +32,12 @@ suffix, so they are easy to recognize. This file contains
 all the partitions of the given storage device, as
 described in [Partition layout](../../Devices/Partition-layout).
 In addition, you need a rootfs image to update to. The suffix
-of this file depends on the file system used for rootfs,
-for example `.ext4`.
+of this file is `.mender`.
 
 You can build the required images by following the steps
 described in [Building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image).
 
-!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the latest prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/latest/latest.tar.gz)**. The `.sdimg` and `.ext4` images are found in the `vexpress-qemu` and `beaglebone` directories.
+!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the latest prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/latest/latest.tar.gz)**. The `.sdimg` and `.mender` images are found in the `vexpress-qemu` and `beaglebone` directories.
 
 
 ### Network connectivity
@@ -77,7 +76,7 @@ This will take you to the login prompt, and you should see a message similar to 
 
 ## Serve a rootfs image to the device over http
 
-To deploy a new rootfs to the device, you need to start a http server on your workstation to serve the image. Open a new terminal **on your workstation** and change into the directory with your rootfs image (e.g. `*.ext4`). Start a simple Python webserver in that directory, like so:
+To deploy a new rootfs to the device, you need to start a http server on your workstation to serve the image. Open a new terminal **on your workstation** and change into the directory with your rootfs image (e.g. `*.mender`). Start a simple Python webserver in that directory, like so:
 
 ```
 python -m SimpleHTTPServer
@@ -103,7 +102,7 @@ To deploy the new rootfs image to your device, run the following command in its 
 mender -log-level info -rootfs http://<IP-OF-WORKSTATION>:8000/<ROOTFS-IMAGE>
 ```
 
-Use the appropriate rootfs image file in place of `<ROOTFS-IMAGE>`, e.g. `core-image-full-cmdline.ext4`.
+Use the appropriate rootfs image file in place of `<ROOTFS-IMAGE>`, e.g. `core-image-full-cmdline.mender`.
 You can find the right name by opening a browser at [http://localhost:8000](http://localhost:8000?target=_blank).
 
 Mender will download the new image, write it to the inactive rootfs partition and configure the bootloader to boot into it on the next reboot. This should take about 2 minutes to complete.

--- a/03.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/03.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 This document outlines the steps needed to build a [Yocto Project](https://www.yoctoproject.org/?target=_blank) image for a device.
 The build output will most notably include:
 * a file that can be flashed to the device storage during initial provisioning, it has suffix `.sdimg`
-* a rootfs filesystem image file that Mender can deploy to your provisioned device, it normally has suffix `.ext4`, but this depends on the file system type you build
+* an update image containing a rootfs filesystem that Mender can deploy to your provisioned device, it has suffix `.mender`
 
 Mender has two [reference devices](../../Getting-started/What-is-Mender#mender-reference-devices): a virtual QEMU device for testing without the need for hardware, and the BeagleBone Black.
 Building for these devices is well tested with Mender. If you are building for your own device
@@ -160,10 +160,6 @@ The files with suffix `.sdimg` are used to provision the device storage for devi
 Mender running already. Please proceed to [Provisioning a new device](../Provisioning-a-new-device)
 for steps to do this.
 
-On the other hand, if you already have Mender running on your device and want to deploy a rootfs update
-using this build, you should use files with the suffix of your selected filesystem
-(as set in `IMAGE_FSTYPES`), for example `.ext4`. You can either deploy this rootfs
-image in managed mode with the Mender server as described in [Deploy to physical devices](../../Getting-started/Deploy-to-physical-devices)
-or by using the Mender client only in [Standalone deployments](../../Getting-started/Standalone-deployments).
+On the other hand, if you already have Mender running on your device and want to deploy a rootfs update using this build, you should use files with the `.mender` suffix. You can either deploy this update in managed mode with the Mender server as described in [Deploy to physical devices](../../Getting-started/Deploy-to-physical-devices) or by using the Mender client only in [Standalone deployments](../../Getting-started/Standalone-deployments).
 
 !!! If you built for the Mender reference device `vexpress-qemu`, you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.

--- a/04.Devices/02.Partition-layout/docs.md
+++ b/04.Devices/02.Partition-layout/docs.md
@@ -59,7 +59,7 @@ Popular file systems for MTD devices include UBIFS, JFFS2, and YAFFS.
 
 ##File system types
 
-When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.ext4` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
+When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.mender` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
 
 In general Mender does not have dependencies on a specific file system type as long as it is for a [block device](#flash-memory-types), but the version of U-Boot you are using must support the file system type used for rootfs because it needs to read the Linux kernel from the file system and start the Linux boot process.
 

--- a/07.Troubleshooting/03.Mender-cli/docs.md
+++ b/07.Troubleshooting/03.Mender-cli/docs.md
@@ -9,7 +9,7 @@ taxonomy:
 You have the Mender binary on your device and try to trigger a rootfs update but you get output similar to the following:
 
 ```
-mender -rootfs /media/rootfs-image-mydevice.ext4
+mender -rootfs /media/rootfs-image-mydevice.mender
 
 ERRO[0000] exit status 1                                 module=partitions
 ERRO[0000] No match between boot and root partitions.    module=main


### PR DESCRIPTION
The latter doesn't work anymore after we changed to the mender
artifact format.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>