### PR TITLE
MEN-735: Add link to blog post about non-Yocto build systems.

### DIFF
--- a/04.Devices/01.System-requirements/docs.md
+++ b/04.Devices/01.System-requirements/docs.md
@@ -9,6 +9,10 @@ Although it is possible to compile and install Mender independently, we have opt
 
 Mender's meta layer, [meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank), has several branches that map to given releases of the Yocto Project. However, note that Mender is tested and maintained against the **latest release branch of the Yocto Project** only. Older branches for the Yocto Project are still kept in [meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank), but they might not work seamlessly as they are not continuously tested by Mender. We appreciate [community contributions](https://mender.io/community?target=_blank) to help maintain older branches!
 
+### Other build systems
+
+Mender has no official support for other build systems. However, by following the right steps, it is possible to adapt other build systems to Mender's needs. Please see [this blog post](https://mender.io/blog/porting-mender-to-a-non-yocto-build-system) for an example (note that some of Mender's needs may have changed since the blog post was made).
+
 ##Device capacity
 The client binaries, which are written in Go, are around 7 MiB in size. 
 


### PR DESCRIPTION
Do not merge until https://tracker.mender.io/browse/MEN-852 is done.