### PR TITLE
Master docs emergency fixes

### DIFF
--- a/01.Getting-started/05.Standalone-deployments/docs.md
+++ b/01.Getting-started/05.Standalone-deployments/docs.md
@@ -32,12 +32,13 @@ suffix, so they are easy to recognize. This file contains
 all the partitions of the given storage device, as
 described in [Partition layout](../../Devices/Partition-layout).
 In addition, you need a rootfs image to update to. The suffix
-of this file is `.mender`.
+of this file depends on the file system used for rootfs,
+for example `.ext4`.
 
 You can build the required images by following the steps
 described in [Building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image).
 
-!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the latest prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/latest/latest.tar.gz)**. The `.sdimg` and `.mender` images are found in the `vexpress-qemu` and `beaglebone` directories.
+!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the latest prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/latest/latest.tar.gz)**. The `.sdimg` and `.ext4` images are found in the `vexpress-qemu` and `beaglebone` directories.
 
 
 ### Network connectivity
@@ -76,7 +77,7 @@ This will take you to the login prompt, and you should see a message similar to 
 
 ## Serve a rootfs image to the device over http
 
-To deploy a new rootfs to the device, you need to start a http server on your workstation to serve the image. Open a new terminal **on your workstation** and change into the directory with your rootfs image (e.g. `*.mender`). Start a simple Python webserver in that directory, like so:
+To deploy a new rootfs to the device, you need to start a http server on your workstation to serve the image. Open a new terminal **on your workstation** and change into the directory with your rootfs image (e.g. `*.ext4`). Start a simple Python webserver in that directory, like so:
 
 ```
 python -m SimpleHTTPServer
@@ -102,7 +103,7 @@ To deploy the new rootfs image to your device, run the following command in its 
 mender -log-level info -rootfs http://<IP-OF-WORKSTATION>:8000/<ROOTFS-IMAGE>
 ```
 
-Use the appropriate rootfs image file in place of `<ROOTFS-IMAGE>`, e.g. `core-image-full-cmdline.mender`.
+Use the appropriate rootfs image file in place of `<ROOTFS-IMAGE>`, e.g. `core-image-full-cmdline.ext4`.
 You can find the right name by opening a browser at [http://localhost:8000](http://localhost:8000?target=_blank).
 
 Mender will download the new image, write it to the inactive rootfs partition and configure the bootloader to boot into it on the next reboot. This should take about 2 minutes to complete.

--- a/03.Devices/02.Partition-layout/docs.md
+++ b/03.Devices/02.Partition-layout/docs.md
@@ -59,7 +59,7 @@ Popular file systems for MTD devices include UBIFS, JFFS2, and YAFFS.
 
 ##File system types
 
-When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.mender` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
+When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.ext4` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
 
 In general Mender does not have dependencies on a specific file system type as long as it is for a [block device](#flash-memory-types), but the version of U-Boot you are using must support the file system type used for rootfs because it needs to read the Linux kernel from the file system and start the Linux boot process.
 

--- a/03.Devices/02.Partition-layout/docs.md
+++ b/03.Devices/02.Partition-layout/docs.md
@@ -100,7 +100,7 @@ MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}3"
 
 ##Configuring the partition sizes
 
-When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) Mender defines and uses certain OpenEmbedded variables which are used to define the sizes of the partitions. They are defined in `meta-mender-core` under `classes/mender-sdimg.bbclass`.
+When [building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image) Mender defines and uses certain OpenEmbedded variables which are used to define the sizes of the partitions. They are defined in `meta-mender` under `classes/mender-sdimg.bbclass`.
 
 | Mount point | Purpose                                                 | Default size | Variable to configure size    |
 |-------------|---------------------------------------------------------|--------------|-------------------------------|

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -120,21 +120,14 @@ part of your Yocto Project build environment.
 Add these lines to the start of your `conf/local.conf`:
 
 ```
-MENDER_ARTIFACT_NAME = "my-mender-image-1.0"
-
 INHERIT += "mender-full"
-
 MACHINE = "<YOUR-MACHINE>"
-
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
-
 IMAGE_FSTYPES = "ext4"
 ```
-
-`MENDER_ARTIFACT_NAME` is name of the image or update that will be built. This is what the device will report that it is running, and different updates must have different names because Mender will skip installation of an artifact if it is already installed.
 
 Please replace `<YOUR-MACHINE>` with the correct machine for your device.
 

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -34,7 +34,7 @@ The other layers provide support for specific devices. Detailed instructions and
 
 ## Prerequisites
 
-! We use the Yocto Project's **morty** branch below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* We use the `stable` branch in `meta-mender`, which builds a stable version of Mender for the latest Yocto Project release. `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases , but these branches are no longer maintained by Mender developers. Please reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank#!forum/mender) if you would like help with getting Mender to work on other versions of the Yocto Project.
+! We use the Yocto Project's **krogoth** branch below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* We use the `stable` branch in `meta-mender`, which builds a stable version of Mender for the latest Yocto Project release. `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases , but these branches are no longer maintained by Mender developers. Please reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank#!forum/mender) if you would like help with getting Mender to work on other versions of the Yocto Project.
 
 
 !!! The meta-mender-core layer and the web-server are bundled with a default certificate and key. If you are intending on using Mender in production, it is highly recommend to generate your own certificate using OpenSSL (`openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256`), and replacing the [server certificate](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-core/recipes-mender/mender/files) found in the meta-mender layer, and [server certificate and key](https://github.com/mendersoftware/mender-api-gateway-docker/tree/master/cert) in the nginx gateway.
@@ -43,7 +43,7 @@ The required meta layers are found in the following repositories:
 
 ```
 URI: git://git.yoctoproject.org/poky
-branch: morty
+branch: krogoth
 
 URI: git://github.com/mendersoftware/meta-mender
 branch: stable
@@ -61,7 +61,7 @@ On the other hand, if you want to start from a clean environment,
 you need to clone the latest poky and go into the directory:
 
 ```
-git clone -b morty git://git.yoctoproject.org/poky
+git clone -b krogoth git://git.yoctoproject.org/poky
 ```
 
 ```
@@ -153,7 +153,7 @@ Once all the configuration steps are done, an image can be built with bitbake:
 bitbake <YOUR-TARGET>
 ```
 
-!!! Please replace `<YOUR-TARGET>` with the desired target or image name. If you are building for `vexpress-qemu`, set the target to `core-image-full-cmdline`. If you are building for the `beaglebone`, set the target to `core-image-base`. For more information about the differences with image types on the BeagleBone Black please see [the official Yocto Project BeagleBone support page](https://www.yoctoproject.org/downloads/bsps/morty22/beaglebone?target=_blank).
+!!! Please replace `<YOUR-TARGET>` with the desired target or image name. If you are building for `vexpress-qemu`, set the target to `core-image-full-cmdline`. If you are building for the `beaglebone`, set the target to `core-image-base`. For more information about the differences with image types on the BeagleBone Black please see [the official Yocto Project BeagleBone support page](https://www.yoctoproject.org/downloads/bsps/krogoth21/beaglebone?target=_blank).
 
 !!! The first time you build a Yocto Project image, the build process can take several hours. The successive builds will only take a few minutes, so please be patient this first time.
 

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -18,9 +18,9 @@ to enable your device to support atomic image-based deployments with rollback.
 
 ## What is *meta-mender*?
 
-[meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank) is a set of layers that enable the creation of a Yocto Project image where the Mender client is part of the image. With Mender installed and configured on the image, you can deploy image updates and benefit from features like automatic roll-back, remote management, logging and reporting. The *meta-mender* layers contain all the recipes required to build the Mender Go binary and configure the Yocto Project image.
+[meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank) is a layer that enables the creation of a Yocto Project image where the Mender client is part of the image. With Mender installed and configured on the image, you can deploy image updates and benefit from features like automatic roll-back, remote management, logging and reporting. The *meta-mender* layer contains all the recipes required to build the Mender Go binary and configure the Yocto Project image.
 
-Inside *meta-mender* there are several layers. The most important one is *meta-mender-core*, which is required by all builds that use Mender. *meta-mender-core* takes care of:
+The *meta-mender* layer takes care of:
 
 * Cross-compiling Mender for ARM devices using Go 1.6.
 * [Partitioning the image correctly](../../Devices/Partition-layout).
@@ -28,7 +28,8 @@ Inside *meta-mender* there are several layers. The most important one is *meta-m
 
 Each one of these steps can be configured further, see the linked sections for more details.
 
-The other layers provide support for specific devices. Detailed instructions and recipes needed for building a self-contained image follow.
+Detailed instructions and recipes needed for building a self-contained image follow.
+
 
 !!! For general information about getting started with Yocto Project, it is recommended to read the [Yocto Project Quick Start guide](http://www.yoctoproject.org/docs/2.1/yocto-project-qs/yocto-project-qs.html?target=_blank).
 
@@ -37,7 +38,7 @@ The other layers provide support for specific devices. Detailed instructions and
 ! We use the Yocto Project's **krogoth** branch below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* We use the `stable` branch in `meta-mender`, which builds a stable version of Mender for the latest Yocto Project release. `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases , but these branches are no longer maintained by Mender developers. Please reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank#!forum/mender) if you would like help with getting Mender to work on other versions of the Yocto Project.
 
 
-!!! The meta-mender-core layer and the web-server are bundled with a default certificate and key. If you are intending on using Mender in production, it is highly recommend to generate your own certificate using OpenSSL (`openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256`), and replacing the [server certificate](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-core/recipes-mender/mender/files) found in the meta-mender layer, and [server certificate and key](https://github.com/mendersoftware/mender-api-gateway-docker/tree/master/cert) in the nginx gateway.
+!!! The meta-mender layer and the web-server are bundled with a default certificate and key. If you are intending on using Mender in production, it is highly recommend to generate your own certificate using OpenSSL (`openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256`), and replacing the [server certificate](https://github.com/mendersoftware/meta-mender/tree/master/recipes-mender/mender/files) found in the meta-mender layer, and [server certificate and key](https://github.com/mendersoftware/mender-api-gateway-docker/tree/master/cert) in the nginx gateway.
 
 The required meta layers are found in the following repositories:
 
@@ -91,22 +92,14 @@ source oe-init-build-env
 This creates a build directory with the default name, ```build```, and makes it the
 current working directory.
 
-We then need to incorporate the two layers, meta-mender-core and oe-meta-go, into
+We then need to incorporate the two layers, meta-mender and oe-meta-go, into
 our project:
 
 ```
-bitbake-layers add-layer ../meta-mender/meta-mender-core
+bitbake-layers add-layer ../meta-mender
 ```
 ```
 bitbake-layers add-layer ../oe-meta-go
-```
-
-Finally, you need to incorporate the layer specific to your device. Mender currently comes with two supported devices: vexpress-qemu and beaglebone, residing in `meta-mender/meta-mender-qemu` and `meta-mender/meta-mender-beaglebone`, respectively. Other devices may also exist that are contributed by the community, or you may need to create a board specific layer yourself for your particular hardware.
-
-If you wish to test using the QEMU emulator, run the following:
-
-```
-bitbake-layers add-layer ../meta-mender/meta-mender-qemu
 ```
 
 At this point, all the layers required for Mender should be
@@ -166,4 +159,4 @@ using this build, you should use files with the suffix of your selected filesyst
 image in managed mode with the Mender server as described in [Deploy to physical devices](../../Getting-started/Deploy-to-physical-devices)
 or by using the Mender client only in [Standalone deployments](../../Getting-started/Standalone-deployments).
 
-!!! If you built for the Mender reference device `vexpress-qemu`, you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.
+!!! If you built for the Mender reference device `vexpress-qemu`, you can start up your newly built image with the script in `../meta-mender/scripts/mender-qemu` and log in as *root* without password.

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 This document outlines the steps needed to build a [Yocto Project](https://www.yoctoproject.org/?target=_blank) image for a device.
 The build output will most notably include:
 * a file that can be flashed to the device storage during initial provisioning, it has suffix `.sdimg`
-* an update image containing a rootfs filesystem that Mender can deploy to your provisioned device, it has suffix `.mender`
+* a rootfs filesystem image file that Mender can deploy to your provisioned device, it normally has suffix `.ext4`, but this depends on the file system type you build
 
 Mender has two [reference devices](../../Getting-started/What-is-Mender#mender-reference-devices): a virtual QEMU device for testing without the need for hardware, and the BeagleBone Black.
 Building for these devices is well tested with Mender. If you are building for your own device
@@ -160,6 +160,10 @@ The files with suffix `.sdimg` are used to provision the device storage for devi
 Mender running already. Please proceed to [Provisioning a new device](../Provisioning-a-new-device)
 for steps to do this.
 
-On the other hand, if you already have Mender running on your device and want to deploy a rootfs update using this build, you should use files with the `.mender` suffix. You can either deploy this update in managed mode with the Mender server as described in [Deploy to physical devices](../../Getting-started/Deploy-to-physical-devices) or by using the Mender client only in [Standalone deployments](../../Getting-started/Standalone-deployments).
+On the other hand, if you already have Mender running on your device and want to deploy a rootfs update
+using this build, you should use files with the suffix of your selected filesystem
+(as set in `IMAGE_FSTYPES`), for example `.ext4`. You can either deploy this rootfs
+image in managed mode with the Mender server as described in [Deploy to physical devices](../../Getting-started/Deploy-to-physical-devices)
+or by using the Mender client only in [Standalone deployments](../../Getting-started/Standalone-deployments).
 
 !!! If you built for the Mender reference device `vexpress-qemu`, you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.

--- a/04.Artifacts/03.Provisioning-a-new-device/docs.md
+++ b/04.Artifacts/03.Provisioning-a-new-device/docs.md
@@ -15,7 +15,7 @@ the flash of the device.
 ### A disk image for the device storage
 
 You need an image file to flash to the entire storage of the
-device. `meta-mender-core` creates these files with a `.sdimg`
+device. `meta-mender` creates these files with a `.sdimg`
 suffix, so they are easy to recognize. This file contains
 all the partitions of the given storage device, as
 described in [Partition layout](../../Devices/Partition-layout).

--- a/04.Artifacts/06.Variables/docs.md
+++ b/04.Artifacts/06.Variables/docs.md
@@ -18,11 +18,6 @@ Influences which file system type Mender will build for the rootfs partitions in
 The allocated size of each of the two rootfs partitions. We recommend leaving some space in the initial rootfs partitions so that you allow your rootfs to grow over time as you deploy updates with Mender. See [Configuring the partition sizes](../../Devices/Partition-layout#configuring-the-partition-sizes) and [the Yocto Project documentation](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
 
 
-#### MENDER_ARTIFACT_NAME
-
-The name of the image or update that will be built. This is what the device will report that it is running, and different updates must have different names. This variable must be defined or the build will fail.
-
-
 #### MENDER_BOOT_PART
 
 The partition Mender uses as the boot partition. See [More detailed storage configuration](../../Devices/Partition-layout#more-detailed-storage-configuration) for more information.
@@ -41,20 +36,6 @@ The partition Mender uses as the persistent data partition. See [More detailed s
 #### MENDER_DATA_PART_SIZE_MB
 
 The size of the persistent data partition in the generated `.sdimg` file. See [Configuring the partition sizes](../../Devices/Partition-layout#configuring-the-partition-sizes) for more information.
-
-
-#### MENDER_DEVICE_TYPE
-
-A string that defines the type of device this image will be installed on. This variable is only relevant when building a complete partitioned image (`.sdimg` suffix). Once a device is flashed with this, it will not change, even if the device is updated.
-
-It defaults to the value of `${MACHINE}`.
-
-
-#### MENDER_DEVICE_TYPES_COMPATIBLE
-
-A space separated string of device types that determine which types of devices this update is suitable for. This complements the `MENDER_DEVICE_TYPE` variable, and is only relevant when building a `.mender` update, not when building a `.sdimg` partitioned image.
-
-It defaults to the value of `${MACHINE}`.
 
 
 #### MENDER_PARTITIONING_OVERHEAD_MB

--- a/07.Troubleshooting/03.Mender-cli/docs.md
+++ b/07.Troubleshooting/03.Mender-cli/docs.md
@@ -9,7 +9,7 @@ taxonomy:
 You have the Mender binary on your device and try to trigger a rootfs update but you get output similar to the following:
 
 ```
-mender -rootfs /media/rootfs-image-mydevice.mender
+mender -rootfs /media/rootfs-image-mydevice.ext4
 
 ERRO[0000] exit status 1                                 module=partitions
 ERRO[0000] No match between boot and root partitions.    module=main


### PR DESCRIPTION
Temporarily revert a few commits that refer to master code.
The real problem is that we publish docs from the master branch, however revert these commits until we publish stable branch.