### PR TITLE
SYSTEMD_AUTO_ENABLE is a package-local variable, don't set it globally.

### DIFF
--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -117,7 +117,7 @@ Add these lines to the start of your `conf/local.conf`:
 ```
 INHERIT += "mender-full"
 MACHINE = "<YOUR-MACHINE>"
-SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_AUTO_ENABLE_pn-mender = "enable"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"

--- a/04.Artifacts/06.Variables/docs.md
+++ b/04.Artifacts/06.Variables/docs.md
@@ -88,6 +88,6 @@ The storage device, as referred to by U-Boot (e.g. `1`). This variable can be us
 The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can be used in cases where the Linux kernel and U-Boot refer to the same device with different names. See [U-Boot and the Linux kernel do not agree about the indexes of storage devices](../../Troubleshooting/Yocto-project-build#u-boot-and-the-linux-kernel-do-not-agree-about-the-indexes-of-st) for more information.
 
 
-#### SYSTEMD_AUTO_ENABLE
+#### SYSTEMD_AUTO_ENABLE_pn-mender
 
 Controls whether to run Mender as a systemd service. See [Modes of operations](../../Architecture/overview#modes-of-operation) and [Build customizations](../../Artifacts/Build-customizations) for more information.


### PR DESCRIPTION
Not only will you trigger a rebuild of a lot of packages by changing
it, but you will influence a lot of packages you didn't intend.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>