### PR TITLE
Mender daemon now autostarts: Remove explicit Mender daemon setting.

### DIFF
--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -117,7 +117,6 @@ Add these lines to the start of your `conf/local.conf`:
 ```
 INHERIT += "mender-full"
 MACHINE = "<YOUR-MACHINE>"
-SYSTEMD_AUTO_ENABLE_pn-mender = "enable"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>