### PR TITLE
Clarify documentation of IMAGE_ROOTFS_SIZE variable.

### DIFF
--- a/04.Artifacts/06.Variables/docs.md
+++ b/04.Artifacts/06.Variables/docs.md
@@ -15,7 +15,9 @@ Influences which file system type Mender will build for the rootfs partitions in
 
 #### IMAGE_ROOTFS_SIZE
 
-The allocated size of each of the two rootfs partitions. We recommend leaving some space in the initial rootfs partitions so that you allow your rootfs to grow over time as you deploy updates with Mender. See [Configuring the partition sizes](../../Devices/Partition-layout#configuring-the-partition-sizes) and [the Yocto Project documentation](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
+The size of the generated rootfs. This will be the size that is shipped in a `.mender` update. This variable is a standard Yocto Project variable and is influenced by several other factors. See [the Yocto Project documentation](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
+
+Note that this variable has no effect when generating an SD card image (`sdimg`), since in that case the size is autodetermined. See  [`MENDER_STORAGE_TOTAL_SIZE_MB`](#mender_storage_total_size_mb) for more information.
 
 
 #### MENDER_ARTIFACT_NAME


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>