### PR TITLE
administraion: storage: update to match env key names change in deployments

### DIFF
--- a/06.Administration/05.Storage/docs.md
+++ b/06.Administration/05.Storage/docs.md
@@ -28,7 +28,7 @@ This can be achieved using a separate compose file with the following entry:
 ```yaml
     mender-deployments:
         environment:
-            AWS_ACCESS_KEY_ID: <your-aws-access-key-id>
-            AWS_SECRET_ACCESS_KEY: <your-aws-secret-access-key>
-            AWS_URI: https://s3.amazonaws.com
+            DEPLOYMENTS_AWS_AUTH_KEY: <your-aws-access-key-id>
+            DEPLOYMENTS_AWS_AUTH_SECRET: <your-aws-secret-access-key>
+            DEPLOYMENTS_AWS_URI: https://s3.amazonaws.com
 ```


### PR DESCRIPTION
Deployments service key names were changed to include DEPLOYMENTS_* prefix. Some
keys were completely renamed, ex AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY became
DEPLOYMENTS_AWS_AUTH_KEY, DEPLOYMENTS_AWS_AUTH_SECRET

https://github.com/mendersoftware/deployments/pull/203
https://github.com/mendersoftware/integration/pull/137

@mendersoftware/rndity @maciejmrowiec @eysteins 