### PR TITLE
MEN-932: Document that we use standard https port now, not 8080.

### DIFF
--- a/01.Getting-started/02.Create-a-test-environment/docs.md
+++ b/01.Getting-started/02.Create-a-test-environment/docs.md
@@ -115,7 +115,7 @@ by your web browser.
 
 !! Currently Mender uses a default certificate for its gateway. This is insecure because anyone can gain access to the private key corresponding to the certificate (it is stored on the gateway and the same for all installations). This will shortly be remediated by auto-generating keys as Mender is installed.
 
-The Mender UI can now be found on [https://localhost:8080/](https://localhost:8080/?target=_blank) -
+The Mender UI can now be found on [https://localhost/](https://localhost/?target=_blank) -
 simply open it in your web browser and **accept the certificate**. In Chrome it should look
 like the following:
 

--- a/01.Getting-started/03.Deploy-to-virtual-devices/docs.md
+++ b/01.Getting-started/03.Deploy-to-virtual-devices/docs.md
@@ -24,7 +24,7 @@ as described in [Create a test environment](../Create-a-test-environment).
 
 Open the Mender UI in the same browser as you accepted the certificate
 in as part of [Create a test environment](../Create-a-test-environment).
-It is available at [https://localhost:8080/](https://localhost:8080/?target=_blank).
+It is available at [https://localhost/](https://localhost/?target=_blank).
 
 There should be a virtual device that is waiting authorization.
 This means that the Mender client, which runs as a daemon on the device,

--- a/01.Getting-started/04.Deploy-to-physical-devices/docs.md
+++ b/01.Getting-started/04.Deploy-to-physical-devices/docs.md
@@ -88,14 +88,6 @@ You should see output similar to the following:
 
 > 192.168.10.1 docker.mender.io s3.docker.mender.io
 
-We also need to modify `ServerURL` in the rootfs partitions at `/etc/mender/mender.conf`
-to `https://docker.mender.io:8080`. This can be achieved by manually editing or running
-the command below:
-
-```bash
-sudo sed -i -E "s/([ ]*\"ServerURL\"[ ]*:[ ]*)\".*\"/\1\"https:\/\/docker.mender.io:8080\"/" /mnt/rootfs[12]/etc/mender/mender.conf
-```
-
 
 ### Set a static device IP address and subnet
 
@@ -174,7 +166,7 @@ Black boot from the SD card instead of internal storage.
 
 ## See the BeagleBone Black(s) in the Mender UI
 
-If you refresh the Mender server UI (by default found at [https://localhost:8080/](https://localhost:8080/?target=_blank)),
+If you refresh the Mender server UI (by default found at [https://localhost/](https://localhost/?target=_blank)),
 you should see one or more devices waiting authorization.
 
 Once you **authorize** these devices, Mender will auto-discover
@@ -228,12 +220,6 @@ echo "$IP_OF_MENDER_SERVER_FROM_DEVICE docker.mender.io s3.docker.mender.io" | s
 You should see output similar to the following:
 
 > 192.168.10.1 docker.mender.io s3.docker.mender.io
-
-Next, ensure we have the right `ServerURL`:
-
-```bash
-sudo sed -i -E "s/([ ]*\"ServerURL\"[ ]*:[ ]*)\".*\"/\1\"https:\/\/docker.mender.io:8080\"/" /mnt/rootfs/etc/mender/mender.conf
-```
 
 Finally, **only if you are using static IP addressing**, you need to set the
 device IP address, as shown below (otherwise skip this step). Please note that the same


### PR DESCRIPTION
Since this is the default, some sections can be removed, since no
change is required anymore.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>