### PR TITLE
MEN-932: Rename section to "Image configuration" to be more generic.

### DIFF
--- a/02.Architecture/01.Overview/docs.md
+++ b/02.Architecture/01.Overview/docs.md
@@ -27,7 +27,7 @@ Other operating systems will be added later on.
 
 It is possible to run the Mender update client in standalone or managed mode.
 
-When run in standalone mode, the deployments are triggered (`mender -rootfs`), rebooted into (`reboot`) and made persistent (`mender -commit`) from the command line at the device or through some custom integration like a script. Any http(s) server or file path (e.g. USB stick or NFS share) can be used to serve the Artifacts; the URI is given to the `mender -rootfs` option. If you wish to run Mender in standalone mode, you can [disable Mender as a system service](../../Artifacts/Build-customizations#disabling-mender-as-a-system-service).
+When run in standalone mode, the deployments are triggered (`mender -rootfs`), rebooted into (`reboot`) and made persistent (`mender -commit`) from the command line at the device or through some custom integration like a script. Any http(s) server or file path (e.g. USB stick or NFS share) can be used to serve the Artifacts; the URI is given to the `mender -rootfs` option. If you wish to run Mender in standalone mode, you can [disable Mender as a system service](../../Artifacts/Image-configuration#disabling-mender-as-a-system-service).
 
 When running Mender in managed mode, the Mender client runs as a daemon and will regularly poll the server, automatically apply updates, reboot, report and commit the update. This is the best way to run Mender for most large-scale deployments, as the deployments are centrally managed across many devices, but it requires to set up and connect clients to the Mender server.
 

--- a/03.Devices/01.System-requirements/docs.md
+++ b/03.Devices/01.System-requirements/docs.md
@@ -36,7 +36,7 @@ Please see [Integrating with U-Boot](../Integrating-with-U-Boot) for more inform
 ##Kernel support
 While Mender itself does not have any specific kernel requirements beyond what a normal Linux kernel provides, it relies on systemd, which does have one such requirement: The `CONFIG_FHANDLE` feature must be enabled in the kernel. The symptom if this feature is unavailable is that systemd hangs during boot looking for device files.
 
-If you [run the Mender client in standalone mode](../../Architecture/Overview#modes-of-operation), you can avoid this dependency by [disabling Mender as a system service](../../Artifacts/Build-customizations#disabling-mender-as-a-system-service) .
+If you [run the Mender client in standalone mode](../../Architecture/Overview#modes-of-operation), you can avoid this dependency by [disabling Mender as a system service](../../Artifacts/Image-configuration#disabling-mender-as-a-system-service) .
 
 ##Partition layout
 Please see [Partition layout](../Partition-layout/).

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -118,7 +118,7 @@ part of your Yocto Project build environment.
 
 ## Configuring the build
 
-!!! The configuration in `conf/local.conf` below will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../Architecture/Overview#modes-of-operation). See the [section on customizations](../Build-customizations#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
+!!! The configuration in `conf/local.conf` below will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../Architecture/Overview#modes-of-operation). See the [section on customizations](../Image-configuration#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
 
 Add these lines to the start of your `conf/local.conf`:
 

--- a/04.Artifacts/02.Image-configuration/docs.md
+++ b/04.Artifacts/02.Image-configuration/docs.md
@@ -1,10 +1,10 @@
 ---
-title: Build customizations
+title: Image configuration
 taxonomy:
     category: docs
 ---
 
-In this section we look at some customizations that can be made due to requirements from a certain build or device configuration.
+In this section we look at the configuration that can be modified due to requirements from a certain build or device.
 
 ## Disabling Mender as a system service
 

--- a/04.Artifacts/07.Variables/docs.md
+++ b/04.Artifacts/07.Variables/docs.md
@@ -124,4 +124,4 @@ The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can 
 
 #### SYSTEMD_AUTO_ENABLE_pn-mender
 
-Controls whether to run Mender as a systemd service. See [Modes of operations](../../Architecture/Overview#modes-of-operation) and [Build customizations](../../Artifacts/Build-customizations) for more information.
+Controls whether to run Mender as a systemd service. See [Modes of operations](../../Architecture/Overview#modes-of-operation) and [Image configuration](../../Artifacts/Image-configuration) for more information.

--- a/05.Client-configuration/04.Polling-intervals/docs.md
+++ b/05.Client-configuration/04.Polling-intervals/docs.md
@@ -53,7 +53,7 @@ Both parameters are stored in the configuration file `/etc/mender/mender.conf`:
 
 Before building an image as described in [Building Mender Yocto image](../../Artifacts/Building-Mender-Yocto-image),
 you can adjust these configuration settings with the steps described in
-[Configuring polling intervals](../../Artifacts/Build-customizations#configuring-polling-intervals).
+[Configuring polling intervals](../../Artifacts/Image-configuration#configuring-polling-intervals).
 
 If you have already built an Artifact containing the rootfs, have a look at
 [Modifying a Mender Artifact](../../Artifacts/Modifying-a-Mender-Artifact) for steps on how


### PR DESCRIPTION
A subtle wording change, but the clue is that the section should cover
any and all client configuration meant to be done during the build,
even if some changes are not really a build system feature.

The only exception for this section is configuration for production
devices, which is still covered in its own section.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>