### PR TITLE
Remove all stable branch references from master.

### DIFF
--- a/01.Getting-started/02.Create-a-test-environment/docs.md
+++ b/01.Getting-started/02.Create-a-test-environment/docs.md
@@ -53,7 +53,7 @@ In a working directory, clone the Mender integration
 environment:
 
 ```bash
-git clone -b stable git://github.com/mendersoftware/integration
+git clone -b master git://github.com/mendersoftware/integration
 ```
 
 ```bash

--- a/01.Getting-started/03.Deploy-to-virtual-devices/docs.md
+++ b/01.Getting-started/03.Deploy-to-virtual-devices/docs.md
@@ -68,7 +68,7 @@ can be used, and steps to build one are provided at
 
 To make testing easier, a Mender Artifact that can be used with
 the virtual device is provided for download at
-[https://d1b0l86ne08fsf.cloudfront.net/stable/vexpress-qemu/vexpress_release_2.mender](https://d1b0l86ne08fsf.cloudfront.net/stable/vexpress-qemu/vexpress_release_2.mender).
+[https://d1b0l86ne08fsf.cloudfront.net/master/vexpress-qemu/vexpress_release_2.mender](https://d1b0l86ne08fsf.cloudfront.net/master/vexpress-qemu/vexpress_release_2.mender).
 
 After the download finishes, go back to the Mender server UI,
 click the **Artifacts** tab and upload this Mender Artifact.
@@ -126,7 +126,7 @@ uploaded, Mender will see that it contains the same rootfs
 that is already installed and skip the deployment. It will
 immediately be marked as successful and moved to *Past deployments*.
 For this reason, we provide another Artifact that you can use
-to deploy with at [https://d1b0l86ne08fsf.cloudfront.net/stable/vexpress-qemu/vexpress_release_1.mender](https://d1b0l86ne08fsf.cloudfront.net/stable/vexpress-qemu/vexpress_release_1.mender).
+to deploy with at [https://d1b0l86ne08fsf.cloudfront.net/master/vexpress-qemu/vexpress_release_1.mender](https://d1b0l86ne08fsf.cloudfront.net/master/vexpress-qemu/vexpress_release_1.mender).
 
 Go to **Artifacts** again and upload this artifact. You can set
 the *Description* input field to `My original build`.

--- a/01.Getting-started/04.Deploy-to-physical-devices/docs.md
+++ b/01.Getting-started/04.Deploy-to-physical-devices/docs.md
@@ -56,7 +56,7 @@ that your device(s) can connect to the Mender server.
 ! Please make sure to set a shell variable that expands correctly with `$IP_OF_MENDER_SERVER_FROM_DEVICE` or edit the commands below accordingly.
 
 Download the test *disk* image with Mender support for the BeagleBone Black
-at [https://d1b0l86ne08fsf.cloudfront.net/stable/beaglebone/mender-beaglebone.sdimg.gz](https://d1b0l86ne08fsf.cloudfront.net/stable/beaglebone/mender-beaglebone.sdimg.gz).
+at [https://d1b0l86ne08fsf.cloudfront.net/master/beaglebone/mender-beaglebone.sdimg.gz](https://d1b0l86ne08fsf.cloudfront.net/master/beaglebone/mender-beaglebone.sdimg.gz).
 This image contains *all the partitions* of the storage device, as
 described in [Partition layout](../../Devices/Partition-layout).
 
@@ -193,7 +193,7 @@ deployed. See [Mender Artifacts](../../Architecture/Mender-Artifacts) for
 a complete description of this format.
 
 Download the test Artifact for the BeagleBone Black
-at [https://d1b0l86ne08fsf.cloudfront.net/stable/beaglebone/beaglebone_release_1.mender](https://d1b0l86ne08fsf.cloudfront.net/stable/beaglebone/beaglebone_release_1.mender).
+at [https://d1b0l86ne08fsf.cloudfront.net/master/beaglebone/beaglebone_release_1.mender](https://d1b0l86ne08fsf.cloudfront.net/master/beaglebone/beaglebone_release_1.mender).
 
 The steps needed to edit the root file system contained in this Artifact are:
 
@@ -268,7 +268,7 @@ sudo umount /mnt/rootfs
 
 To create a Mender Artifact from a root file system, it is easiest
 to download the prebuilt mender-artifact tool available for Linux
-at [https://d25phv8h0wbwru.cloudfront.net/stable/tip/mender-artifact](https://d25phv8h0wbwru.cloudfront.net/stable/tip/mender-artifact).
+at [https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact](https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact).
 
 After the tool is downloaded and you added execute permission,
 simply run it as follows:

--- a/01.Getting-started/05.Standalone-deployments/docs.md
+++ b/01.Getting-started/05.Standalone-deployments/docs.md
@@ -41,7 +41,7 @@ for a more detailed overview.
 You can build the required images by following the steps
 described in [Building a Mender Yocto Project image](../../Artifacts/Building-Mender-Yocto-image).
 
-!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/stable/latest.tar.gz)**. The `.sdimg` disk images, and `.mender` Artifacts are found in the `vexpress-qemu` and `beaglebone` directories.
+!!! If you are testing Mender on the reference devices BeagleBone Black or QEMU, you can save the build time by **[downloading the prebuilt demo images](https://doyabzhx7xw8o.cloudfront.net/master/latest.tar.gz)**. The `.sdimg` disk images, and `.mender` Artifacts are found in the `vexpress-qemu` and `beaglebone` directories.
 
 
 ### Network connectivity

--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -35,7 +35,7 @@ The other layers in *meta-mender* provide support for specific boards.
 
 ## Prerequisites
 
-! We use the Yocto Project's **morty** branch below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* We use the `stable` branch in `meta-mender`, which builds a stable version of Mender for the latest Yocto Project release. `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases , but these branches are no longer maintained by Mender developers. Please reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank#!forum/mender) if you would like help with getting Mender to work on other versions of the Yocto Project.
+! We use the Yocto Project's **master** branch below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* We use the `master` branch in `meta-mender`, which builds a latest release of Mender for the bleeding edge Yocto Project revision. `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases , but these branches are no longer maintained by Mender developers. Please reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank#!forum/mender) if you would like help with getting Mender to work on other versions of the Yocto Project.
 
 !!! The meta-mender-demo layer, which is used below, and the web-server, are bundled with a default demo certificate and key. If you are intending on using Mender in production, you must generate your own certificate using OpenSSL. Please see the certificate section [for the server](../../Administration/Certificates-and-keys) and [for the client](../Building-for-production/#certificates) for more information.
 
@@ -43,13 +43,13 @@ The required meta layers are found in the following repositories:
 
 ```
 URI: git://git.yoctoproject.org/poky
-branch: morty
+branch: master
 
 URI: git://github.com/mem/oe-meta-go
 branch: master
 
 URI: git://github.com/mendersoftware/meta-mender
-branch: stable
+branch: master
 ```
 
 A Yocto Project poky environment is required. If you already have 
@@ -61,7 +61,7 @@ On the other hand, if you want to start from a *clean Yocto Project environment*
 you need to clone the latest poky and go into the directory:
 
 ```bash
-git clone -b morty git://git.yoctoproject.org/poky
+git clone -b master git://git.yoctoproject.org/poky
 ```
 
 ```bash
@@ -81,7 +81,7 @@ git clone git://github.com/mem/oe-meta-go
 ```
 
 ```bash
-git clone -b stable git://github.com/mendersoftware/meta-mender
+git clone -b master git://github.com/mendersoftware/meta-mender
 ```
 
 Next, we initialize the build environment:

--- a/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
@@ -31,7 +31,7 @@ Linux distributions.
 
 The `mender-artifact` utility is used to create and inspect Mender Artifacts.
 
-You can download a [prebuilt mender-artifact Linux binary here](https://d25phv8h0wbwru.cloudfront.net/stable/tip/mender-artifact).
+You can download a [prebuilt mender-artifact Linux binary here](https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact).
 
 !!! If you need to build `mender-artifact` from source, please see [Compiling mender-artifact](#compiling-mender-artifact).
 
@@ -160,7 +160,7 @@ After deploying this Artifact with Mender and rebooting, your configuration chan
 ## Compiling mender-artifact
 
 Compiling `mender-artifact` is only necessary if you can not use the prebuilt
-[mender-artifact binary for Linux](https://d25phv8h0wbwru.cloudfront.net/stable/tip/mender-artifact).
+[mender-artifact binary for Linux](https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact).
 
 
 #### Install git


### PR DESCRIPTION
We are not going to use stable any more and all master branch
artifacts links should point to master.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>