### PR TITLE
administration: production: update URL for checking if mender backend is up [1.x]

### DIFF
--- a/06.Administration/02.Production-installation/docs.md
+++ b/06.Administration/02.Production-installation/docs.md
@@ -516,7 +516,7 @@ Furthermore, since this is a brand new installation it should be possible to req
 user login token through the API:
 
 ```bash
-curl -X POST  -D - --cacert keys-generated/certs/api-gateway/cert.crt https://mender.acme.org:443/api/management/0.1/useradm/auth/login
+curl -X POST  -D - --cacert keys-generated/certs/api-gateway/cert.crt https://mender.acme.org:443/api/management/v1/useradm/auth/login
 ```
 
 > HTTP/2.0 200  


### PR DESCRIPTION
URL API versioning scheme was updated at the gateway, but the docs were left
behind using the older scheme.

Fixes: [Mender #1009]

@maciejmrowiec @pasinskim @mendersoftware/rndity 