### PR TITLE
Redeploy to staging production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,8 @@ before_script:
 
 script:
   - ./test_docs.py 06.Administration/02.Production-installation/docs.md
+
+after_success:
+  # on merge, first deploy to staging, wait 5 minutes, and deploy to production:
+  # note that worse possible outcome here is incorrectly formatted markdown appearing
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./redeploy.sh master && sleep 300 && ./redeploy.sh production; fi

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e -x -u
+
+# This script triggers a build of the mender-doc in travis, which redeploys the webite.
+# The only argument you have to pass to this script is the branch of mender-docs-site you want to build.
+
+body=$(cat <<EOF
+    {
+      "request": {
+         "branch": "$1"
+    }}
+EOF
+)
+
+curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token $TRAVIS_COM_TOKEN" \
+   -d "$body" \
+   https://api.travis-ci.com/repo/mendersoftware%2Fmender-docs-site/requests


### PR DESCRIPTION
@drewmoseley @estenberg 

~~With this change, opening a PR will redeploy the staging website, and a merge will update the production server.~~

~~Note, that is you have multiple PRs open, the last PR to run will be visible in the production environment.~~

~~The alternative will be to just update both production AND testing on merge.~~

~~Any thoughts?~~

Since I need a token stored in an env. variable to redeploy the website, re-deployment can only happen on merge (Travis limitation).

My solution is update the staging env. and 5 minutes after, update the production env. 

The worse thing that can happen here is that the markdown is incorrectly formatted. If you notice within 5 minutes, you can cancel the job.
