### PR TITLE
State scripts timeout

### DIFF
--- a/04.Artifacts/07.State-scripts/docs.md
+++ b/04.Artifacts/07.State-scripts/docs.md
@@ -63,7 +63,7 @@ For many devices with a display that interacts with an end user, it is desirable
 
 Mender state scripts enable this use case with a script written to create the dialog box on the UI framework used. The script will simply wait for user input, and Mender will wait with the update process while waiting for the script to finish. Depending on what the user selects, the script can return 0 (proceed) or 1 (stop). This script can be run in the `Download_Enter` state, for example.
 
-Make sure to increase the default timeout for state scripts to enable this use case.
+Make sure to [increase the default timeout for state scripts](../../client-configuration/configuration-file/configuration-options#statescripttimeoutseconds) to enable this use case.
 
 
 #### Custom sanity checks after the update is installed

--- a/05.Client-configuration/04.Configuration-file/01.Polling-intervals/docs.md
+++ b/05.Client-configuration/04.Configuration-file/01.Polling-intervals/docs.md
@@ -37,23 +37,15 @@ Both parameters are stored in the configuration file `/etc/mender/mender.conf`:
 
 ```
 {
-  "ClientProtocol": "http",
-  "HttpsClient": {
-    "Certificate": "",
-    "Key": ""
-  },
-  "RootfsPartA": "/dev/mmcblk0p2",
-  "RootfsPartB": "/dev/mmcblk0p3",
   "UpdatePollIntervalSeconds": 1800,
   "InventoryPollIntervalSeconds": 86400,
-  "ServerURL": "https://docker.mender.io",
-  "ServerCertificate": "/etc/mender/server.crt"
 ...
 ```
 
-Before building an image as described in [Building Mender Yocto image](../../artifacts/building-mender-yocto-image),
-you can adjust these configuration settings with the steps described in
-[Configuring polling intervals](../../artifacts/image-configuration#configuring-polling-intervals).
+Before building an image as described in [Building Mender Yocto
+image](../../artifacts/building-mender-yocto-image), you can adjust these configuration settings
+either [using a custom configuration file](..), or [using Yocto
+variables](../../../artifacts/image-configuration#configuring-polling-intervals).
 
 If you have already built an Artifact containing the rootfs, have a look at
 [Modifying a Mender Artifact](../../artifacts/modifying-a-mender-artifact) for steps on how

--- a/05.Client-configuration/04.Configuration-file/50.Configuration-options/docs.md
+++ b/05.Client-configuration/04.Configuration-file/50.Configuration-options/docs.md
@@ -1,0 +1,70 @@
+---
+title: Configuration options
+taxonomy:
+    category: docs
+---
+
+This sections lists all the configuration options in `mender.conf`. Some of
+these options can also be modified using Yocto variables.
+
+#### ArtifactVerifyKey
+
+Specifies the location of the public key used to verify signed updates, and also
+enables signed-updates-only mode when it is set. If set the client will reject
+incorrectly signed updates, or updates without a signature. See also the section
+about [signing and verification](../../../artifacts/signing-and-verification).
+
+#### RetryPollIntervalSeconds
+
+An integer that sets the number of seconds to wait between each attempt to
+download an update file. Note that the client may attempt more often initially
+to enable rapid upgrades, but will gradually fall back to this value if the
+server is busy. See also the section about [polling
+intervals](../polling-intervals).
+
+#### RootfsPartA
+
+The Linux device that contains root filesystem A. This is set by the build
+system based on Yocto configuration and rarely needs to be modified.
+
+#### RootfsPartB
+
+The Linux device that contains root filesystem B. This is set by the build
+system based on Yocto configuration and rarely needs to be modified.
+
+#### ServerURL
+
+The server URL which is used as the basis for API requests. This should be set
+to the server that runs the Mender server services. It should include the whole
+URL, including `https://` and a trailing slash.
+
+#### ServerCertificate
+
+The location of the public certificate of the server, if any. If this
+certificate is missing, or the one presented by the server doesn't match the one
+specified in this setting, the server certificate will be validated using
+standard certificate trust chains.
+
+#### StateScriptTimeoutSeconds
+
+The number of seconds to wait for any state script to terminate. If a script
+exceeds this running time, its process group will be killed and Mender will
+continue, treating the script as having failed. See also the section about
+[state scripts](../../../artifacts/state-scripts).
+
+#### TenantToken
+
+A token which identifies which tenant a device belongs to. This is only relevant
+if using Hosted Mender.
+
+#### UpdateLogPath
+
+The location where deployment logs will be written. This must be on a persistent
+partition to work correctly.
+
+#### UpdatePollIntervalSeconds
+
+An integer that sets the number of seconds to wait between each check for a new
+update. Note that the client may occasionally check more often if there has been
+recent activity on the device. See also the section about [polling
+intervals](../polling-intervals).

--- a/05.Client-configuration/04.Configuration-file/docs.md
+++ b/05.Client-configuration/04.Configuration-file/docs.md
@@ -1,0 +1,53 @@
+---
+title: Configuration file
+taxonomy:
+    category: docs
+---
+
+Much of the Mender client's configuration resides in `/etc/mender/mender.conf`
+on the root filesystem. This file is JSON structured and defines various
+parameters for Mender's operation. Some of the most common settings are tunable
+using [Yocto
+variables](../artifacts/image-configuration#configuring-polling-intervals). The
+remaining parameters can only be changed by providing your own `mender.conf`.
+
+
+# Providing mender.conf
+
+It is easy to provide your own `mender.conf` file. First you will need to have
+your own layer. If you don't already have one see [the Yocto
+Manual](http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#creating-your-own-layer)
+for how to create one.
+
+Inside the layer, you will need to create a `.bbappend` file for the mender
+recipe. It should be placed in a location like this:
+`meta-<mylayer>/recipes-mender/mender/mender_%.bbappend`. The content of the
+file should be the following:
+
+```
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:"
+SRC_URI_append = " file://mender.conf"
+```
+
+If your layer already contains a `mender_%.bbappend` file, then add the above
+contents into your file, taking care to not redefine any variables you are
+already using.
+
+Then, inside `meta-<mylayer>/recipes-mender/mender/files/mender.conf`, you can
+put whatever configuration options you need, as a JSON structure. The file you
+provide will be merged with other settings taken from various variables in the
+build, with variables taking precedence.
+
+Here is an example of a `mender.conf` file:
+
+```
+{
+  "ServerURL": "https://mymenderserver.net",
+  "ServerCertificate": "/etc/site-conf/server.crt"
+}
+```
+
+Note that many mandatory entries are missing, such as `RootfsPartA` and
+`RootfsPartB`. These are filled in by the Yocto buildsystem automatically, using
+the merge method described in the paragraph above. So you do not need to provide
+all values, those that are not provided will take on default values.


### PR DESCRIPTION
```
commit c5b3e066824a10b9998e8fbf4393b538a13648b3
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Sep 7 13:58:21 2017

    Link state scripts timeout paragraph to configuraion options list.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 8e85b267bfc18458f2228e54a0f2ee5864889310
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Sep 7 13:43:33 2017

    Document using a custom mender.conf file.
    
    This is preferred over Yocto variables for most non-critical settings,
    in order to avoid polluting the build with a lot of global variables
    for small details.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```