### PR TITLE
spell-check: Force ispell to use the local dictionary

### DIFF
--- a/spell-check.sh
+++ b/spell-check.sh
@@ -5,4 +5,4 @@
 # File checksum, crypto hases and Bitbake variables are difficult to account
 # for so this dictionary is rather large and will need to be added to over time.
 
-ispell $(find . -name '*.md')
+ispell -p ./.ispell_english $(find . -name '*.md')


### PR DESCRIPTION
Evidently some versions don't load it automatically

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>