### PR TITLE
devices/raw-flash: add missing ubifsmount in u-boot-integration section

### DIFF
--- a/03.Devices/05.Raw-flash/docs.md
+++ b/03.Devices/05.Raw-flash/docs.md
@@ -281,6 +281,7 @@ addition of a call to `mender_setup` script (using `vexpress-a9` as an example):
 	"run mender_setup; "                                      \
 	"run set_ubiargs; "                                       \
 	"ubi part ${mender_mtd_ubi_dev_name} && "                 \
+	"ubifsmount ${mender_uboot_root_name} && "                \
 	"ubifsload ${kernel_addr_r} /boot/zImage && "             \
     ...
 ```


### PR DESCRIPTION
Fixes: [MEN #1515]
Changelog: none
Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

@drewmoseley @eysteins @kacf 