### PR TITLE
Rename IMAGE_BOOTLOADER* variables to MENDER_IMAGE_BOOTLOADER*.

### DIFF
--- a/04.Artifacts/99.Variables/docs.md
+++ b/04.Artifacts/99.Variables/docs.md
@@ -14,16 +14,6 @@ The variables are either specific to- and defined by Mender, as shown by the `ME
 Defines which file system type Mender will build for the rootfs partitions in the `.sdimg`, `.uefiimg` and the `.mender` file.  See [File system types](../../devices/partition-layout#file-system-types) for more information.
 
 
-#### IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET
-
-Together with `IMAGE_BOOTLOADER_FILE`, this sets the offset where the bootloader should be placed, counting from the start of the storage medium. The offset is specified in units of 512-byte sectors. Obviously this needs to be non-zero, or the partition table itself would be overwritten.
-
-
-#### IMAGE_BOOTLOADER_FILE
-
-Together with `IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET`, this specifies a file that you would like to write directly into the boot sector, in the intervening space between the partition table and the first partition.
-
-
 #### IMAGE_ROOTFS_SIZE
 
 The size of the generated rootfs. This will be the size that is shipped in a `.mender` update. This variable is a standard Yocto Project variable and is influenced by several other factors. See [the Yocto Project documentation](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
@@ -128,6 +118,16 @@ section on features](../image-configuration/features) for more information.
 
 Features appended to this variable will be enabled in the build. See [the
 section on features](../image-configuration/features) for more information.
+
+
+#### MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET
+
+Together with `MENDER_IMAGE_BOOTLOADER_FILE`, this sets the offset where the bootloader should be placed, counting from the start of the storage medium. The offset is specified in units of 512-byte sectors. Obviously this needs to be non-zero, or the partition table itself would be overwritten.
+
+
+#### MENDER_IMAGE_BOOTLOADER_FILE
+
+Together with `MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET`, this specifies a file that you would like to write directly into the boot sector, in the intervening space between the partition table and the first partition.
 
 
 #### MENDER_KERNEL_IMAGETYPE_FORCE


### PR DESCRIPTION
These are mender-specific; rename them so it's more obvious.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>