### PR TITLE
Update links to Yocto docs

### DIFF
--- a/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-Yocto-image/docs.md
@@ -25,7 +25,7 @@ Each one of these steps can be configured further, see the linked sections for m
 
 The other layers in *meta-mender* provide support for specific boards.
 
-!!! For general information about getting started with Yocto Project, it is recommended to read the [Yocto Project Quick Start guide](http://www.yoctoproject.org/docs/2.3/yocto-project-qs/yocto-project-qs.html?target=_blank).
+!!! For general information about getting started with Yocto Project, it is recommended to read the [Yocto Project Quick Start guide](http://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html?target=_blank).
 
 
 ## Prerequisites
@@ -63,7 +63,7 @@ See [certificate troubleshooting](../../troubleshooting/mender-client#certificat
 
 ! We use the **rocko** branch of the Yocto Project and `meta-mender` below. *Building meta-mender on other releases of the Yocto Project will likely not work seamlessly.* `meta-mender` also has other branches like [daisy](https://github.com/mendersoftware/meta-mender/tree/daisy?target=_blank) that correspond to Yocto Project releases, but these branches are no longer maintained by Mender developers. We offer professional services to to implement and support other branches over time, please take a look at the [Mender professional services offering](https://mender.io/product/professional-services?target=_blank).
 
-A Yocto Project poky environment is required. If you already have 
+A Yocto Project poky environment is required. If you already have
 this in your build environment, please open a terminal, go to the `poky`
 directory and skip to [Adding the meta layers](#adding-the-meta-layers).
 
@@ -79,7 +79,7 @@ git clone -b rocko git://git.yoctoproject.org/poky
 cd poky
 ```
 
-!!! Note that the Yocto Project also depends on some [development tools to be in place](http://www.yoctoproject.org/docs/2.3/yocto-project-qs/yocto-project-qs.html?target=_blank#packages).
+!!! Note that the Yocto Project also depends on some [development tools to be in place](http://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html?target=_blank#packages).
 
 
 

--- a/04.Artifacts/99.Variables/docs.md
+++ b/04.Artifacts/99.Variables/docs.md
@@ -5,7 +5,7 @@ taxonomy:
 ---
 
 This section provides a reference of variables Mender use during the Yocto Project build process.
-The variables are either specific to- and defined by Mender, as shown by the `MENDER_` prefix, or [defined by the Yocto Project](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#ref-variables-glos) and used by Mender.
+The variables are either specific to- and defined by Mender, as shown by the `MENDER_` prefix, or [defined by the Yocto Project](http://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html?target=_blank#ref-variables-glos) and used by Mender.
 
 
 #### ARTIFACTIMG_FSTYPE
@@ -21,7 +21,7 @@ Influences which file system type Mender will build for the rootfs partitions in
 
 #### IMAGE_ROOTFS_SIZE
 
-The size of the generated rootfs, expressed in kiB. This will be the size that is shipped in a `.mender` update. This variable is a standard Yocto Project variable and is influenced by several other factors. See [the Yocto Project documentation](http://www.yoctoproject.org/docs/2.2/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
+The size of the generated rootfs, expressed in kiB. This will be the size that is shipped in a `.mender` update. This variable is a standard Yocto Project variable and is influenced by several other factors. See [the Yocto Project documentation](http://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html?target=_blank#var-IMAGE_ROOTFS_SIZE) for more information.
 
 Note that this variable has no effect when generating an SD card or UEFI image (`sdimg` or `uefiimg`), since in that case the size is determined automatically. See  [`MENDER_STORAGE_TOTAL_SIZE_MB`](#mender_storage_total_size_mb) for more information.
 


### PR DESCRIPTION
To future proof the links updated links to use the /latest/
link which should always point to the latest release of Yocto.

Note that the Yocto Project Quick Start manual does not seem
to support /latest/ link, so instead update to the latest
available which is 2.4.

Signed-off-by: Mirza Krak <mirza.krak@endian.se>