### PR TITLE
Mender artifact cleanup 1.6.x

### DIFF
--- a/01.Getting-started/04.Deploy-to-physical-devices/docs.md
+++ b/01.Getting-started/04.Deploy-to-physical-devices/docs.md
@@ -33,7 +33,7 @@ Get the disk image and Artifacts for your device(s) from [Download demo images](
 
 ### Mender-Artifact tool
 Download [the prebuilt mender-artifact tool][autoupdate_x.x.x_mender-artifact] available
-for Linux, or install from source [mender-artifact]("https://github.com/mendersoftware/mender-artifact"). In both cases remember to add execute permission (e.g. with `chmod +x mender-artifact`).
+for Linux, or [compile it from source](../../artifacts/modifying-a-mender-artifact#compiling-mender-artifact). In both cases remember to add execute permission (e.g. with `chmod +x mender-artifact`).
 
 [autoupdate_x.x.x_mender-artifact]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/2.3.0b1/mender-artifact
 
@@ -182,25 +182,6 @@ Which information is collected about devices is fully configurable; see the docu
 
 !!! If your device does not show up for authorization in the UI, you need to diagnose what went wrong. Most commonly this is due to problems with the network. You can test if your workstation can reach the device by trying to ping it, e.g. with `ping 192.168.10.2` (replace with the IP address of your device). If you can reach the device, you can ssh into it, e.g. `ssh root@192.168.10.2`. Otherwise, if you have a serial cable, you can log in to the device to diagnose. The `root` user is present and has an empty password in this test image. Check the log output from Mender with `journalctl -u mender`. If you get stuck, please feel free to reach out on the [Mender community mailing list](https://groups.google.com/a/lists.mender.io/forum?target=_blank/#!forum/mender)!
 
-#### Create a new Mender Artifact with the rootfs
-
-Using the BeagleBone Black as an example below (adjust the file names and use `-t raspberrypi3` if you are using the Raspberry Pi 3),
-run the following command to create a new Mender Artifact:
-
-[start_autoupdate_release_1_x.x.x]: #
-
-```bash
-mender-artifact write rootfs-image -u core-image-base-beaglebone.ext4 -t beaglebone -n release-1_1.6.0b1 -o beaglebone_release_1_configured.mender
-```
-
-where `-u core-image-base-beaglebone.ext4` is the rootfs,
-`-t beaglebone` is the device type compatible with the given Artifact,
-`-n release-1_1.6.0b1` is the Artifact name (do not change this as it needs to be in
-sync with `/etc/mender/artifact_info` *inside* the rootfs), and
-`-o beaglebone_release_1_configured.mender` is
-the filename of the created Artifact.
-
-[end_autoupdate_release_1_x.x.x]: #
 
 ## Prepare the Mender Artifact to update to
 
@@ -215,39 +196,15 @@ a complete description of this format.
 Locate the `release_1` demo Artifact file (`.mender`) for your device that you [downloaded earlier](../download-test-images).
 
 Using the BeagleBone Black as an example below (adjust the directory and file names if you are using the Raspberry Pi 3),
-the steps needed to edit the root file system contained in this Artifact are:
-
-[start_autoupdate_beaglebone_release_1_x.x.x.mender]: #
+we carry out exactly the same configuration steps for the Mender Artifact as we did for the disk image above:
 
 ```bash
-mkdir beaglebone_release_1 && tar -C beaglebone_release_1 -xvf beaglebone_release_1_1.6.0b1.mender
-```
-
-[end_autoupdate_beaglebone_release_1_x.x.x.mender]: #
-
-```bash
-cd beaglebone_release_1 && tar zxvf data/0000.tar.gz
-```
-
-Create a mender-artifact image
-
-```bash
-mender-artifact write rootfs-image -u core-image-base-beaglebone.ext4 -t beaglebone -n release-1_1.3.0 -o beaglebone_release_1_configured.mender
-```
-
-Please see [Modifying a Mender Artifact](../../artifacts/modifying-a-mender-artifact)
-for a more detailed overview.
-
-We carry out exactly the same configuration steps for the rootfs image
-as we did for the rootfs partitions in the disk image above:
-
-```bash
-echo "$IP_OF_MENDER_SERVER_FROM_DEVICE docker.mender.io s3.docker.mender.io" | mender-artifact cp beaglebone_release_1_configured.mender:/etc/hosts
+echo "$IP_OF_MENDER_SERVER_FROM_DEVICE docker.mender.io s3.docker.mender.io" | mender-artifact cp beaglebone_release_1.mender:/etc/hosts
 ```
 
 Then check the contents of the file
 ```bash
-mender-artifact cat beaglebone_release_1_configured.mender:/etc/hosts
+mender-artifact cat beaglebone_release_1.mender:/etc/hosts
 ```
 
 You should see output similar to the following:
@@ -267,7 +224,7 @@ Name=eth0
 [Network]
 Address=$IP_OF_MENDER_CLIENT
 Gateway=$IP_OF_MENDER_SERVER_FROM_DEVICE
-" | mender-artifact cp beaglebone_release_1_configured.mender:/etc/systemd/network/eth.network
+" | mender-artifact cp beaglebone_release_1.mender:/etc/systemd/network/eth.network
 ```
 
 !!! The Mender client will roll back the deployment if it is not able to report the final update status to the server when it boots from the updated partition. This helps ensure that you can always deploy a new update to your device, even when fatal conditions like network misconfiguration occur.
@@ -323,8 +280,8 @@ run these two commands (adjust the Artifact file name accordingly):
 [start_autoupdate_beaglebone_release_2_x.x.x.mender]: #
 
 ```bash
-cp beaglebone_release_1_configured.mender beaglebone_release_2_configured.mender
-mender-artifact modify beaglebone_release_2_configured.mender -n release-2_1.6.0b1
+cp beaglebone_release_1.mender beaglebone_release_2.mender
+mender-artifact modify beaglebone_release_2.mender -n release-2_1.6.0b1
 ```
 
 [end_autoupdate_beaglebone_release_2_x.x.x.mender]: #

--- a/02.Architecture/03.Compatibility/docs.md
+++ b/02.Architecture/03.Compatibility/docs.md
@@ -47,7 +47,7 @@ The [Mender Artifact format](../mender-artifacts) is managed by the [Mender Arti
 | Mender 1.5.x / mender-artifact 2.2.x | yes         | yes         |
 | Mender 1.6.x / mender-artifact 2.3.x | yes         | yes         |
 
-!! Older Mender clients do not support newer versions of the Artifact format; they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#write-a-new-artifact) for an introduction how to do this.
+!! Older Mender clients do not support newer versions of the Artifact format; they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
 
 
 ## Mender server and client API

--- a/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
@@ -13,19 +13,10 @@ is different from the one that you have installed so you can see that the update
 You might also want to configure certain aspects of the update after you build it,
 but before deploying it.
 
-In this tutorial we will unpack a Mender Artifact, 
-recognized by its `.mender` suffix, mount the rootfs (e.g. `.ext4`) inside it,
-modify it, and then create a new Mender Artifact that has these modifications
-by using the `mender-artifact` utility.
+In this tutorial we will highlight some key use cases covered by the `mender-artifact` utility.
 
 
 ## Prerequisites
-
-#### tar
-
-You need a standard `tar` utility, like the ones that are bundled with popular
-Linux distributions.
-
 
 #### mender-artifact
 
@@ -36,139 +27,81 @@ You can download a [prebuilt mender-artifact Linux binary here][autoupdate_x.x.x
 !!! If you need to build `mender-artifact` from source, please see [Compiling mender-artifact](#compiling-mender-artifact).
 
 
-## Unpack the root file system
+## Changing the Mender server
 
-The Mender Artifact can be unpacked using a standard tar utility,
-we simply create a directory for it and unpack it.
-Depending on the version of the artifact used, for a BeagleBone Black Artifact, the commands and output
-will look like the following:
+If you would like to change the Mender server the devices will be using,
+you can use the `mender-artifact modify` parameter:
 
 ```bash
-mkdir core-image-base-beaglebone && tar -C core-image-base-beaglebone -xvf core-image-base-beaglebone.mender
+MENDER_SERVER_URL='https://hosted.mender.io'
+MENDER_TENANT_TOKEN='<YOUR-MENDER-TENANT-TOKEN>'
+mender-artifact modify artifact.mender --server-uri "$MENDER_SERVER_URL" --tenant-token "$MENDER_TENANT_TOKEN"
 ```
 
-> version  
-> header.tar.gz  
-> data/0000.tar.gz  
+!!! The `--tenant-token` parameter is only needed for multi-tenant Mender servers like Hosted Mender. In Hosted Mender you can find it under [My organization](https://hosted.mender.io/ui/?target=_blank#/settings/my-organization).
 
-The output for the version 2 should look similar to the following:
-
-> version  
-> manifest  
-> manifest.sig  
-> header.tar.gz  
-> data/0000.tar.gz  
-
-You can inspect the metadata files to learn about how they work,
-but it is not recommended to modify them directly as this can
-be quite error-prone. We will rather use the `mender-artifact` utility to make
-modifications below.
-
-The updates to be deployed are stored in the `data` subdirectory. We
-can extract the first (and currently only) file there, which is the root file system,
-like the following:
+If you are using a self-signed certificate for the Mender server (not needed for Hosted Mender), you can
+include it in the Artifact using the `--server-cert` parameter:
 
 ```bash
-cd core-image-base-beaglebone && tar zxvf data/0000.tar.gz
+mender-artifact modify artifact.mender --server-cert server.crt
 ```
 
-> core-image-base-beaglebone.ext4  
+## Reading a configuration file
 
-
-## Modify the root file system
-
-Once we have the file system image, a simple way to modify its contents
-is to loopback-mount the rootfs on your workstation
-and modify the configuration files you need in the mounted directory.
-
-In this example we will modify  `/etc/issue` on an `ext4` file system
-so you can see which rootfs image you are running just before the login prompt,
-but these steps can be used for modifying any configuration file and for
-several file system types.
-
-First we make the mount directory and copy the rootfs image:
+The `cat` parameter will output a file in the Artifact to standard output.
+For example, to see `/etc/hosts`, run the following command:
 
 ```bash
-sudo mkdir /mnt/rootfs
-```
-
-```bash
-cp core-image-base-beaglebone.ext4 core-image-base-beaglebone-modified.ext4
-```
-
-```bash
-sudo mount -t ext4 -o loop core-image-base-beaglebone-modified.ext4 /mnt/rootfs/
-```
-
-Now you can modify the file system found at `/mnt/rootfs`. For example,
-you can change `/mnt/rootfs/etc/issue` so you can detect that a deployment
-changed the system. After saving your modified files, simply unmount
-the rootfs again:
-
-```bash
-sudo umount /mnt/rootfs
-```
-
-You need to adjust the path to the rootfs image and its type depending on the machine and file system you are building for.
-
-
-## Create a new Mender Artifact
-
-#### Find required metadata from original Artifact
-
-We would probably like to reuse some of the original Artifact metadata
-for the new Artifact, as for example the device types it is compatible
-with is the same.
-
-To see which metadata the original Artifact contains, you can run the
-following command:
-
-```bash
-mender-artifact read core-image-base-beaglebone.mender
+mender-artifact cat artifact.mender:/etc/hosts
 ```
 
 
-> Mender artifact:  
->   Name: release-1  
->   Format: mender  
->   Version: 2  
->   Compatible devices: '[beaglebone]'  
->   
-> Updates:  
->   0000  
->   Type: 'rootfs-image'  
->   Files:  
->     core-image-base-beaglebone.ext4  
->     size: 105638912  
->     modified: 2016-12-20 15:36:11 +0100 CET  
+## Modifying a configuration file
 
-
-The most important fields to note for writing a new Artifact are
-the *Compatible devices* and *Name*.
-
-!!! When working with a signed Artifact, you can verify the signature by providing the public verification key to the `-k` option, e.g. `mender-artifact read core-image-base-beaglebone.mender -k public.key`.
-
-
-#### Write a new Artifact
-
-We now have the information we need to generate a new Artifact,
-including the metadata to use and modified rootfs.
-
-In this example, we will keep the original *Compatible devices*
-and *Name* of the original Artifact, so only the rootfs modifications
-will be different:
+Files can be copied into and out from the Artifact using the `cp` parameter.
+For example, to modify any Mender client configuration, such as the polling interval,
+first copy it out:
 
 ```bash
-mender-artifact write rootfs-image -t beaglebone -n release-1 -u core-image-base-beaglebone-modified.ext4 -o core-image-base-beaglebone-modified.mender
+mender-artifact cp artifact.mender:/etc/mender/mender.conf /tmp/mender.conf
 ```
 
-! The Artifact name (`-n`) must correspond to the name stated *inside* the root file system at `/etc/mender/artifact_info`, so make sure to change both places if you are modifying it.
+Open `/tmp/mender.conf` and make the desired modifications.
+Afterwards, write it back into the Artifact:
 
-! If you are building for *older Mender Clients* that do not support the latest version of the Artifact format, you can build an older Artifact version with the `-v` option. For example, to build a version 1 Artifact, you can run `mender-artifact write rootfs-image -v 1 -t beaglebone -n release-1 -u core-image-base-beaglebone-modified.ext4 -o core-image-base-beaglebone-modified.mender`. The default Artifact version is the latest one. Also see the build variable [MENDER_ARTIFACT_EXTRA_ARGS](../variables#mender_artifact_extra_args).
+```bash
+mender-artifact cp /tmp/mender.conf artifact.mender:/etc/mender/mender.conf
+```
 
-!!! If you would like to generate a *signed Artifact*, simply add the `-k` option with the path to your *private key*. In our example above, the full command would be `mender-artifact write rootfs-image -t beaglebone -n release-1 -u core-image-base-beaglebone-modified.ext4 -o core-image-base-beaglebone-signed.mender -k private.key`.
+!!! To control the permissions on the file written to the Mender Artifact, use the `install -m<permissions>` parameter instead of `cp`.
 
-After deploying this Artifact with Mender and rebooting, your configuration changes will be in effect!
+
+## Create an Artifact from a raw root file system
+
+If you have a raw root file system (e.g. `ext4`), you can create a Mender Artifact
+file from it.
+
+! The Mender client and relevant configuration must already be contained in the root file system in order for the created Mender Artifact to be usable.
+
+To create an Artifact, use the `write` parameter:
+
+```bash
+mender-artifact write rootfs-image -t beaglebone -n release-1 -u rootfs.ext4 -o artifact.mender
+```
+
+! The Artifact name (`-n`) must correspond to the name stated *inside* the root file system at `/etc/mender/artifact_info`.
+
+! If you are building for *older Mender Clients* that do not support the latest version of the Artifact format, you can build an older Artifact version with the `-v` option. For example, to build a version 1 Artifact, you can run `mender-artifact write rootfs-image -v 1 -t beaglebone -n release-1 -u rootfs.ext4 -o artifact.mender`. The default Artifact version is the latest one. Also see the build variable [MENDER_ARTIFACT_EXTRA_ARGS](../variables#mender_artifact_extra_args).
+
+!!! If you would like to generate a *signed Artifact*, simply add the `-k` option with the path to your *private key*. In our example above, the full command would be `mender-artifact write rootfs-image -t beaglebone -n release-1 -u rootfs.ext4 -o artifact-signed.mender -k private.key`.
+
+
+## Signing after modification
+
+If you are signing Artifacts, the signature will become invalid whenever
+you make modifications to them. See the section on [signing and verification](../signing-and-verification)
+for more information.
 
 
 ## Compiling mender-artifact

--- a/04.Artifacts/06.Signing-and-verification/docs.md
+++ b/04.Artifacts/06.Signing-and-verification/docs.md
@@ -79,20 +79,31 @@ The resulting `private.key` and `public.key` files are the private and public ke
 
 ## Signing
 
-Once a root file system for a device is built, use the `mender-artifact` tool to create a signed Artifact.
+We can use the `mender-artifact` tool to create a signed Artifact.
 If you use Linux, [download the prebuilt mender-artifact binary][autoupdate_x.x.x_mender-artifact],
 otherwise [compile it for your platform](../modifying-a-mender-artifact#compiling-mender-artifact).
 
 [autoupdate_x.x.x_mender-artifact]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/2.3.0b1/mender-artifact
 
 To sign we use the `-k` parameter to specify the private key, which will be used for creating the signature.
-The full command will look like the following:
+This parameter works both if you have a root file system (e.g. `.ext4` file) and are writing a new Mender Artifact
+and if you are signing an existing Mender Artifact (`.mender`).
+
+#### A raw root file system
 
 ```bash
 mender-artifact write rootfs-image -t beaglebone -n mender-1.0.1 -u core-image-base-beaglebone.ext4 -k private.key -o artifact-signed.mender
 ```
 
-This is the command the Signing system uses to create a signed Artifact.
+#### An existing Mender Artifact
+
+```bash
+cp artifact.mender artifact-signed.mender
+mender-artifact modify artifact-signed.mender -k private.key
+```
+
+The latter is typically the command the Signing system uses to create a signed Artifact,
+as a Mender Artifact is built by the build system already.
 
 
 ## Verifying the signature

--- a/04.Artifacts/99.Variables/docs.md
+++ b/04.Artifacts/99.Variables/docs.md
@@ -41,7 +41,7 @@ The name of the image or update that will be built. This is what the device will
 
 Can be set to a private key which will be used to sign the update artifact. The default is empty, which means the artifact won't be signed.
 
-The signature can also be added or changed outside the build process, by using the `mender-artifact` tool's `-k` option. For more information, see the section on [modifying Mender artifacts](../modifying-a-mender-artifact).
+The signature can also be added or changed outside the build process, by using the `mender-artifact` tool's `-k` option. For more information, see [signing Mender Artifacts](../signing-and-verification#signing).
 
 
 #### MENDER_ARTIFACT_VERIFY_KEY

--- a/05.Client-configuration/04.Configuration-file/01.Polling-intervals/docs.md
+++ b/05.Client-configuration/04.Configuration-file/01.Polling-intervals/docs.md
@@ -50,5 +50,4 @@ either [using a custom configuration file](..), or [using Yocto
 variables](../../../artifacts/image-configuration#configuring-polling-intervals).
 
 If you have already built an Artifact containing the rootfs, have a look at
-[Modifying a Mender Artifact](../../../artifacts/modifying-a-mender-artifact) for steps on how
-to change these configurations in an existing Artifact.
+[modifying a configuration in a Mender Artifact](../../../artifacts/modifying-a-mender-artifact#modifying-a-configuration-file).

--- a/07.Administration/06.Upgrading/docs.md
+++ b/07.Administration/06.Upgrading/docs.md
@@ -204,7 +204,7 @@ Start the new environment:
 The Mender Client binary is built into the root file system, so it can be upgraded by
 fetching the sources when [building a Yocto Project image](../../artifacts/building-mender-yocto-image).
 
-!! Older Mender clients do not support newer [versions of the Mender Artifact format](../../architecture/mender-artifacts#versions); they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#write-a-new-artifact) for an introduction how to do this.
+!! Older Mender clients do not support newer [versions of the Mender Artifact format](../../architecture/mender-artifacts#versions); they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
 
 
 

--- a/201.Troubleshooting/03.Mender-Client/docs.md
+++ b/201.Troubleshooting/03.Mender-Client/docs.md
@@ -116,7 +116,7 @@ The problem here is most likely that you have built [a new version of the Artifa
 that your Mender Client does not support. It could also be that you are building a very old version of the
 Artifact format that your new version of the Mender Client does not support.
 
-In either case the solution is to [build a different version of the Artifact format](../../artifacts/modifying-a-mender-artifact#write-a-new-artifact) that your Mender Client supports
+In either case the solution is to [build a different version of the Artifact format](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) that your Mender Client supports
 until you have upgraded all Mender Clients and can use the corresponding latest version of the Mender Artifact format.
 
 


### PR DESCRIPTION
Backport of https://github.com/mendersoftware/mender-docs/pull/462

Note that at time of writing there is a bug in mender-artifact that corrupts artifacts by removing the Artifact Name. So this PR should probably only be merged after fixing that bug.