### PR TITLE
Remove description of MENDER_STORAGE_DEVICE_BASE.

### DIFF
--- a/03.Devices/02.Partition-layout/docs.md
+++ b/03.Devices/02.Partition-layout/docs.md
@@ -74,12 +74,10 @@ In order to select the storage device where the partitions are expected to be lo
 MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
 ```
 
-! For memory card storage and some other types of storage, the default way to refer to partitions is to add a "p" and then the number of the partition (for example `/dev/mmcblk0p1`). If you're using a storage type which doesn't follow this scheme (for example `/dev/sda1`), then you also need to set `MENDER_STORAGE_DEVICE_BASE` to the correct value, such as `MENDER_STORAGE_DEVICE_BASE = "${MENDER_STORAGE_DEVICE}"`. The default is the value of `MENDER_STORAGE_DEVICE` plus a "p".
-
 
 ###More detailed storage configuration
 
-If you need more fine grained control over which partitions Mender will use, you can set one or more the following variables to specific partition strings:
+If you need more fine grained control over which partitions Mender will use, you can set one or more the following variables to specific partition strings, using `MENDER_STORAGE_DEVICE_BASE`:
 
 * `MENDER_BOOT_PART`
 * `MENDER_DATA_PART`

--- a/03.Devices/03.Integrating-with-U-Boot/02.Integration-checklist/docs.md
+++ b/03.Devices/03.Integrating-with-U-Boot/02.Integration-checklist/docs.md
@@ -135,7 +135,7 @@ This checklist will verify some key functionality aspects of the Mender integrat
 
     The output of the two commands should be identical. This verifies that the correct rootfs is mounted when partition A is active.
 
-    ! If you have selected a different device using either `MENDER_ROOTFS_PART_A` or `MENDER_STORAGE_DEVICE_BASE` in the Yocto configuration, the `/dev/mmcblk0p2` (or `ubi0_0`) entry may be different, but it should always correspond to the value in `MENDER_ROOTFS_PART_A`.
+    ! If you have selected a different device using either `MENDER_ROOTFS_PART_A` or `MENDER_STORAGE_DEVICE` in the Yocto configuration, the `/dev/mmcblk0p2` (or `ubi0_0`) entry may be different, but it should always correspond to the value in `MENDER_ROOTFS_PART_A`.
 
 14. Everything we have tested so far has been for partition A; we will now verify both kernel and rootfs for partition B. Run the following:
 
@@ -159,7 +159,7 @@ This checklist will verify some key functionality aspects of the Mender integrat
 
 17. Repeat step 13, but this time using `/dev/mmcblk0p3` (or `ubi0_1`). This verifies that the correct rootfs is mounted when partition B is active.
 
-    ! As in the previous step, `/dev/mmcblk0p3` (or `ubi0_1`) may be different if `MENDER_ROOTFS_PART_B` or `MENDER_STORAGE_DEVICE_BASE` has been changed.
+    ! As in the previous step, `/dev/mmcblk0p3` (or `ubi0_1`) may be different if `MENDER_ROOTFS_PART_B` or `MENDER_STORAGE_DEVICE` has been changed.
 
 18. Run the following commands:
 


### PR DESCRIPTION
It is now fully automatic, and should not need to be set by anyone
anymore.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>