### PR TITLE
mention usage of 'jq' utility to decoded and pretty-print JSON

### DIFF
--- a/06.Server-integration/01.Using-the-apis/docs.md
+++ b/06.Server-integration/01.Using-the-apis/docs.md
@@ -47,7 +47,13 @@ For example, to upload an Artifact you can run the following command:
 
 ## Set up shell variables for cURL
 
-There are many ways to call http-based REST APIs, but the most generally available method is most likely the command line utility `curl`.
+There are many ways to call http-based REST APIs, but the most generally available method is the command line utility `curl`. The `jq` utility is commonly used to decode JSON messages and display them in human-readable format. REST API responses can contain raw data and must run through a JSON parser (`jq`).
+
+You can easily get both using:
+
+```bash
+sudo apt-get install curl jq
+```
 
 Open a terminal, which we will use in the following to call the Mender server's REST APIs. First set a shell variable with the URI of your server:
 ```bash
@@ -80,7 +86,7 @@ You should now have an API token you can use to call any of the [Mender server m
 To verify you can call the server APIs, list the users of your Mender server instance:
 
 ```bash
-curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/useradm/users
+curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/useradm/users | jq
 ```
 
 If it succeeds it will return something like the following:

--- a/06.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/06.Server-integration/02.Preauthorizing-devices/docs.md
@@ -89,11 +89,11 @@ Secondly, To make sure that the device is not in an existing authentication set,
 In the same terminal, run the following commands:
 
 ```bash
-curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | python -m json.tool > /tmp/admission.json
-curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/devauth/devices | python -m json.tool > /tmp/devauth.json
+curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | jq > /tmp/admission.json
+curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/devauth/devices | jq > /tmp/devauth.json
 ```
 
-!!! To make the response more readable, we use the `json.tool` module of python to indent it. If it is not available on your system you can omit this pipe or replace it with a different indentation tool (remove or replace `| python -m json.tool`).
+!!! To make the response more readable, we use the `jq` utility to decode it. If it is not available on your system you can omit this pipe or replace it with a different indentation tool (e.g `python -m json.tool`).
 
 Now open the files `/tmp/admission.json` and `/tmp/devauth.json` and search for a value of your device identity (e.g. `02:12:61:13:6c:42` if you are using MAC addresses).
 
@@ -133,7 +133,7 @@ curl -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -X POST
 If there is no output from the command, this indicates it succeeded. To verify, list the currently registered authentication sets and make sure there is one for your device with the `preauthorized` status:
 
 ```bash
-curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | python -m json.tool
+curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | jq
 ```
 
 Your device should now be preauthorized and accepted to the Mender server once it connects with the exact same identity and key.

--- a/201.Troubleshooting/04.Mender-Server/docs.md
+++ b/201.Troubleshooting/04.Mender-Server/docs.md
@@ -37,7 +37,7 @@ If you see your device gets the `pending` status after [preauthorizing it](../..
 To diagnose this, look for the device identity in the `admission` service, for example:
 
 ```bash
-curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | python -m json.tool
+curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v1/admission/devices | jq
 ```
 
 ```json


### PR DESCRIPTION
It is commonly used together with 'curl' and JSON, but it is also
required to decode certain values in responses, e.g an artifact
URI will contain raw values that need to be decoded by a JSON
parses.

Some more background info can be found in MEN-2082.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>