### PR TITLE
Updated device integration checklist with 'pgrep' alternative.

### DIFF
--- a/03.Devices/04.Integrating-with-U-Boot/02.Integration-checklist/docs.md
+++ b/03.Devices/04.Integrating-with-U-Boot/02.Integration-checklist/docs.md
@@ -111,6 +111,13 @@ This checklist will verify some key functionality aspects of the Mender integrat
     pgrep mender
     ```
 
+    Or if `pgrep` is not installed
+
+    ```bash
+    pidof mender
+    ```
+
+
     If Mender has been enabled as a daemon, either through inheriting `mender-full` or enabling the `mender-systemd` feature in `MENDER_FEATURES_ENABLE`, it should return a PID. If not, it should return nothing. This verifies that Mender is started as a service if applicable.
 
 12. Now we verify that the booted kernel is from the rootfs. The easiest way to check this is to check the build date, which can be seen by running:


### PR DESCRIPTION
On some Yocto builds, depending on the image config, 'pgrep' is not
configured to be installed by default as part of busybox recipe.
However 'pidof' is available. Documentation has been updated to
give the user the option of either depending upon their setup.

Changelog: None

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>