### PR TITLE
Updated device integration list to include mender_boot_part_hex variable

### DIFF
--- a/03.Devices/03.Integrating-with-U-Boot/02.Integration-checklist/docs.md
+++ b/03.Devices/03.Integrating-with-U-Boot/02.Integration-checklist/docs.md
@@ -142,11 +142,13 @@ This checklist will verify some key functionality aspects of the Mender integrat
     - When using SD card or eMMC storage:
     ```bash
     fw_setenv mender_boot_part 3
+    fw_setenv mender_boot_part_hex 3
     ```
 
     - When using raw flash storage:
     ```bash
     fw_setenv mender_boot_part 1
+    fw_setenv mender_boot_part_hex 1
     ```
 
     ! The number is the number of the second rootfs partition, and corresponds to the last component of the `MENDER_ROOTFS_PART_B` variable. If you've changed this variable in the Yocto configuration, you may need to use a different number.
@@ -166,11 +168,13 @@ This checklist will verify some key functionality aspects of the Mender integrat
     - When using SD card or eMMC storage:
     ```bash
     fw_setenv mender_boot_part 2
+    fw_setenv mender_boot_part_hex 2
     ```
 
     - When using raw flash storage:
     ```bash
     fw_setenv mender_boot_part 0
+    fw_setenv mender_boot_part_hex 0
     ```
 
     Once the commands above have been run, we need to tell Mender that there is an upgrade available:


### PR DESCRIPTION
At some point a new 'mender_boot_part_hex' variable was introduced.
This variable needs to be changed along with 'mender_boot_part' from linux
to perform a successful kernel swapping test, otherwise you end up with
a swapped rootfs, but the kernel from the previous rootfs.

It should be noted that if testing from uboot shell then you can
run the 'mender_altbootcmd' which will swap both variables for you.

Changelog: None

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>