### PR TITLE
Switch pgrep to pidof, which is Busybox friendly.

### DIFF
--- a/.ispell_english
+++ b/.ispell_english
@@ -1152,6 +1152,7 @@ Philipp
 php
 picocom
 PID
+pidof
 pify
 pipermail
 pjQswswQsh

--- a/03.Devices/04.Integrating-with-U-Boot/02.Integration-checklist/docs.md
+++ b/03.Devices/04.Integrating-with-U-Boot/02.Integration-checklist/docs.md
@@ -108,7 +108,7 @@ This checklist will verify some key functionality aspects of the Mender integrat
 11. Now we will verify that Mender is running. Run the following:
 
     ```bash
-    pgrep mender
+    pidof mender
     ```
 
     If Mender has been enabled as a daemon, either through inheriting `mender-full` or enabling the `mender-systemd` feature in `MENDER_FEATURES_ENABLE`, it should return a PID. If not, it should return nothing. This verifies that Mender is started as a service if applicable.


### PR DESCRIPTION
Thanks to Dell Green <dell.green@ideaworks.co.uk> for spotting this.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>