### PR TITLE
Minor use case examples improvements

### DIFF
--- a/04.Artifacts/07.State-scripts/docs.md
+++ b/04.Artifacts/07.State-scripts/docs.md
@@ -100,7 +100,7 @@ In this case, application data like a user profile is stored in an SQLite databa
 #### Update confirmation by end user
 For many devices with a display that interacts with an end user, it is desirable to ask the user before applying the update. You have probably seen this on a smartphone, where it will ask you if you want to update to the latest release of Android or iOS and it only starts after you hit "Apply".
 
-Mender state scripts enable this use case with a script written to create the dialog box on the UI framework used. The script will simply wait for user input, and Mender will wait with the update process while waiting for the script to finish. Depending on what the user selects, the script can return `0` (proceed) or `21` ([retry later](#retry-later)). This script can be run in the `Download_Enter` state, for example.
+Mender state scripts enable this use case with a script written to create the dialog box on the UI framework used. The script will simply wait for user input, and Mender will wait with the update process while waiting for the script to finish. Depending on what the user selects, the script can return `0` (proceed) or `21` ([retry later](#retry-later)). For example, this script can be run in the `Download_Enter` state, and the user will be asked before the download begins. Alternatively, the script can also be run in the `Download_Leave` state, if you want the download to finish first, and the user only to accept installing the update and rebooting.
 
 Make sure to adjust `StateScriptRetryIntervalSeconds` as described in [retry later](#retry-later) to enable this use case.
 

--- a/04.Artifacts/07.State-scripts/docs.md
+++ b/04.Artifacts/07.State-scripts/docs.md
@@ -92,7 +92,7 @@ Mender users will probably come up with a lot of interesting use cases for state
 
 
 #### Application data migration
-In this case, application data like a user profile is stored in an SQLite database and a new column need to be added before starting the new version of the application. This can be achieved by adding a state script to `ArtifactReboot_Enter` (that would run after writing the new rootfs, but before rebooting). This script can then do the necessary migrations on the data partition before the new version of the application is brought up after the reboot.
+In this case, application data like a user profile is stored in an SQLite database and a new column need to be added before starting the new version of the application. This can be achieved by adding a state script to `ArtifactInstall_Leave` (that would run after writing the new rootfs, but before rebooting). This script can then do the necessary migrations on the data partition before the new version of the application is brought up after the reboot.
 
 ![Application data migration state scripts](mender-state-machine-data-migration.png)
 


### PR DESCRIPTION
```
commit 8187d799facea6d8b985a0ece0ddf621ce127d20
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Sep 27 16:11:26 2018

    Expand the use case example slightly for Update Confirmations.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 49bf95e03418a1eab2e14bfa9e3c1e4e2ba0fc24
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Sep 27 16:07:29 2018

    Avoid suggesting state script that can break migration.
    
    Clarify that it is ArtifactInstall_Leave that should be used for
    migrations, not ArtifactReboot_Enter. This is important because if a
    spontaneous reboot happens while inside ArtifactReboot_Enter, it will
    be ignored, and hence the new partition will be entered with an
    incomplete migration in place. With ArtifactInstall_Leave it will
    instead cause a rollback, triggering a potential ArtifactFailure
    script which can undo the half done migration.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```