### PR TITLE
Board integration is a new taxonomy concept.

### DIFF
--- a/01.Getting-started/04.Deploy-to-physical-devices/docs.md
+++ b/01.Getting-started/04.Deploy-to-physical-devices/docs.md
@@ -27,9 +27,9 @@ a SD card to store the OS, so you will need one SD card
 
 ### Disk image and Artifacts
 
-Get the disk image and Artifacts for your device(s) from [Download demo images](../download-test-images).
+Get the disk image and Artifacts for your board(s) from [Download demo images](../download-test-images).
 
-!!! It is possible to use this tutorial with *any* physical device, as long as you have integrated Mender with it. In this case you cannot use the demo Artifacts we provide in this tutorial, but you need to build your own artifacts as described in [Building a Mender Yocto Project image](../../artifacts/building-mender-image/building-yocto-image).
+!!! It is possible to use this tutorial with *any* physical board, as long as you have integrated Mender with it. In this case you cannot use the demo Artifacts we provide in this tutorial, but you need to build your own artifacts as described in [Building a Mender Yocto Project image](../../artifacts/building-mender-image/building-yocto-image).
 
 ### Mender-Artifact tool
 Download [the prebuilt mender-artifact tool][x.x.x_mender-artifact] available
@@ -293,18 +293,18 @@ Now that you have two Mender Artifact files that are configured for your
 network with different names, you can deploy updates back and forth between them.
 
 
-## Integrate Mender with your device
+## Integrate Mender with your board
 
 If you want to build your own artifact for the Raspberry Pi 3 or BeagleBone Black,
 head over to the tutorial [Building a Mender Yocto Project image](../../artifacts/building-mender-yocto-image).
 
-Development devices like the Raspberry Pi 3 and BeagleBone Black
+Development boards like the Raspberry Pi 3 and BeagleBone Black
 are rarely used in production due to the cost of scaling and specific
 needs of custom applications.
 
-Now that you have seen how Mender works with a reference device, you might be wondering what
+Now that you have seen how Mender works with a reference board, you might be wondering what
 it would take to port it to your own platform. The first place to go is
-[Device integration](../../devices), where you will find out how to integrate
+[Board integration](../../devices), where you will find out how to integrate
 the Mender client with your device software, and then look at
 [Creating Artifacts](../../artifacts) to see how to build images ready to be
 deployed over the network to your devices.

--- a/01.Getting-started/05.Download-test-images/docs.md
+++ b/01.Getting-started/05.Download-test-images/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-Pre-built demo images for a set of reference devices are provided below, so you do not have to integrate devices nor build images in order to test Mender.
+Pre-built demo images for a set of reference boards are provided below, so you do not have to integrate devices nor build images in order to test Mender.
 
 !!! Steps to build Artifacts for other device types and with custom software are provided at [Building a Mender Yocto Project image](../../artifacts/building-mender-yocto-image), however we recommend using the demo images first.
 

--- a/03.Devices/01.System-requirements/01.Yocto/docs.md
+++ b/03.Devices/01.System-requirements/01.Yocto/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-!!! Mender has four reference devices already integrated: [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank), [BeagleBone Black](https://beagleboard.org/black?target=_blank) and two virtual devices (`qemux86-64` and `vexpress-qemu`). If you would like assistance supporting your device and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
+!!! Mender has four reference boards already integrated: [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank), [BeagleBone Black](https://beagleboard.org/black?target=_blank) and two virtual devices (`qemux86-64` and `vexpress-qemu`). If you would like assistance supporting your device and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
 
 ##Yocto Project
 Although it is possible to compile and install Mender independently, we have optimized the installation experience for those who build their Linux images using [Yocto Project](https://www.yoctoproject.org?target=_blank).

--- a/03.Devices/01.System-requirements/docs.md
+++ b/03.Devices/01.System-requirements/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-!!! Mender has four reference devices already integrated: [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank), [BeagleBone Black](https://beagleboard.org/black?target=_blank) and two virtual devices (`qemux86-64` and `vexpress-qemu`). If you would like assistance supporting your device and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
+!!! Mender has four reference boards already integrated: [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank), [BeagleBone Black](https://beagleboard.org/black?target=_blank) and two virtual devices (`qemux86-64` and `vexpress-qemu`). If you would like assistance supporting your device and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
 
 ##Device capacity
 The client binaries are about 7 MB in size, or about 4 MB when debug symbols are stripped (using the `strip` tool). This includes all dependencies for the client, such as the http, TLS, and JSON libraries.

--- a/03.Devices/chapter.md
+++ b/03.Devices/chapter.md
@@ -1,12 +1,12 @@
 ---
-title: Device integration
+title: Board integration
 taxonomy:
     category: docs
 ---
 
 ### Chapter 3
 
-# Device integration
+# Board integration
 
-A description of how to integrate Mender with your device.
-For commercial support, please see the [Device support offering](https://mender.io/product/board-support?target=_blank).
+A description of how to integrate Mender with your board.
+For commercial support, please see the [Board support offering](https://mender.io/product/board-support?target=_blank).

--- a/04.Artifacts/01.Building-Mender-image/01.Building-Yocto-image/docs.md
+++ b/04.Artifacts/01.Building-Mender-image/01.Building-Yocto-image/docs.md
@@ -30,24 +30,24 @@ The other layers in *meta-mender* provide support for specific boards.
 
 ## Prerequisites
 
-### Device integrated with Mender
+### Board integrated with Mender
 
-Mender needs to integrate with your device, most notably with the boot process.
+Mender needs to integrate with your board, most notably with the boot process.
 This integration enables robust and atomic rollbacks with Mender.
-Please see [Device integration](../../../devices) for general requirements and
+Please see [Board integration](../../../devices) for general requirements and
 adjustment you might need to make before building.
 
-The following reference devices are already integrated with Mender
+The following reference boards are already integrated with Mender
 and covered by automated tests to ensure they work well:
 
 <!--AUTOVERSION: "meta-mender/tree/%"/ignore-->
 * [Raspberry Pi 3](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-raspberrypi?target=_blank) (other revisions are also likely to work)
 * BeagleBone Black (no board specific layer needed)
-* [Virtual device (qemux86-64)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
-* [Virtual device (vexpress-qemu)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
+* [Virtual board (qemux86-64)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
+* [Virtual board (vexpress-qemu)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
 
 If you encounter any issues and want to save time, you can use
-the [Mender professional services to integrate your device](https://mender.io/product/board-support?target=_blank).
+the [Mender professional services to integrate your board](https://mender.io/product/board-support?target=_blank).
 
 
 ### Correct clock on device
@@ -118,14 +118,14 @@ bitbake-layers add-layer ../meta-mender/meta-mender-demo
 !!! Mender board integration is mostly automated. Consequently, a board-specific Mender integration layer as described below is typically only necessary for improving performance or resolving any board-specific issues. If you are unsure if you need one, try to build without adding any board integration layer.
 
 If needed, add any Mender integration layer specific to your board.
-For the three Mender reference devices use these layers (only add one of these):
+For the three Mender reference boards use these layers (only add one of these):
 
 * Raspberry Pi 3 (other revisions might also work): `bitbake-layers add-layer ../meta-mender/meta-mender-raspberrypi` (depends on `meta-raspberrypi`)
 * BeagleBone Black: No board specific layer needed
-* Virtual devices: `bitbake-layers add-layer ../meta-mender/meta-mender-qemu`
+* Virtual boards: `bitbake-layers add-layer ../meta-mender/meta-mender-qemu`
 
-If you are building for a different device and encounter any issues, please see [Device integration](../../../devices)
-for general requirements and adjustments you might need to enable your device to support Mender.
+If you are building for a different board and encounter any issues, please see [Board integration](../../../devices)
+for general requirements and adjustments you might need to enable your board to support Mender.
 
 At this point, all the layers required for Mender should be
 part of your Yocto Project build environment.
@@ -147,7 +147,7 @@ MENDER_ARTIFACT_NAME = "release-1"
 INHERIT += "mender-full"
 
 # A MACHINE integrated with Mender.
-# raspberrypi3, beaglebone-yocto, vexpress-qemu and qemux86-64 are reference devices
+# raspberrypi3, beaglebone-yocto, vexpress-qemu and qemux86-64 are reference boards
 MACHINE = "<YOUR-MACHINE>"
 
 # For Raspberry Pi, uncomment the following block:
@@ -240,4 +240,4 @@ which have `.mender` suffix. You can either deploy this Artifact in managed mode
 the Mender server as described in [Deploy to physical devices](../../../getting-started/deploy-to-physical-devices)
 or by using the Mender client only in [Standalone deployments](../../../architecture/standalone-deployments).
 
-!!! If you built for one of the virtual Mender reference devices (`qemux86-64` or `vexpress-qemu`), you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.
+!!! If you built for one of the virtual Mender reference boards (`qemux86-64` or `vexpress-qemu`), you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.

--- a/06.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/06.Server-integration/02.Preauthorizing-devices/docs.md
@@ -14,14 +14,14 @@ See [Device authentication](../../architecture/device-authentication) for a gene
 ## Prerequisites
 
 
-### A device integrated with Mender
+### A board integrated with Mender
 
-You need a physical device that has already been [integrated with Mender](../). For example, you may use one of the reference devices BeagleBone Black or Raspberry Pi 3.
+You need a physical board that has already been [integrated with Mender](../). For example, you may use one of the reference boards BeagleBone Black or Raspberry Pi 3.
 
 
-### A block-based disk image for your device
+### A block-based disk image for your board
 
-We assume you have either [built a disk image for your device](../../artifacts/building-mender-yocto-image) or base it off one of the [pre-built demo images](../../getting-started/download-test-images). Note that a disk image is used to provision the entire storage of the device (it contains *all* the partitions) and typically has the `.sdimg` suffix.
+We assume you have either [built a disk image for your board](../../artifacts/building-mender-yocto-image) or base it off one of the [pre-built demo images](../../getting-started/download-test-images). Note that a disk image is used to provision the entire storage of the board (it contains *all* the partitions) and typically has the `.sdimg` suffix.
 
 !!! Raw flash or raw filesystem images are not covered by this tutorial; however the steps are conceptually the same in these cases.
 
@@ -36,7 +36,7 @@ By default the Mender client uses the [MAC address of the first interface](https
 
 ### Mender client and server connectivity
 
-Once your device boots with a newly provisioned disk image, it should already be correctly connecting to the Mender server. After booting the device you see your device pending authorization in the Mender server UI, similar to the following.
+Once your device boots with a newly provisioned disk image, it should already be correctly connecting to the Mender server. After booting the device you see it pending authorization in the Mender server UI, similar to the following.
 
 ![Mender UI - device pending authorization](device-pending-authorization.png)
 


### PR DESCRIPTION
It only applies to the actual Mender integration of the board
and any related low-level sections like the reference boards, output images.

Devices will still be the common term to describe a product,
identity and the over-arching concept.

Signed-off-by: Eystein Måløy Stenberg <eystein@mender.io>