### PR TITLE
Mention fallback configuration file in documentation.

### DIFF
--- a/05.Client-configuration/04.Configuration-file/docs.md
+++ b/05.Client-configuration/04.Configuration-file/docs.md
@@ -11,6 +11,17 @@ using [Yocto
 variables](../../artifacts/image-configuration/yocto-image-configuration#configuring-polling-intervals). The
 remaining parameters can only be changed by providing your own `mender.conf`.
 
+On systems where it is desired for one or more of the configuration options
+to be customized and survive future updates, there is an optional "fallback"
+configuration file `/var/lib/mender/mender.conf`. Because the directory
+`/var/lib/mender` is backed by persistent storage, the fallback configuration
+file will not be overwritten by Mender updates.
+
+The fallback configuration file has the same JSON format as the main configuration file.
+Any setting value that appears in the main configuration file `/etc/mender/mender.conf`
+will be used, whether or not the setting appears in the fallback file `/var/lib/mender/mender.conf`.
+Therefore a setting in the fallback file will only be used if it does not appear
+in the main file.
 
 # Providing mender.conf
 


### PR DESCRIPTION
Changelog: None

The documentation now mentions the existence of the optional
fallback configuration file, along with a brief summary of
how it works. More documentation to come later: See MEN-2177.

Signed-off-by: Don Cross <cosinekitty@gmail.com>