### PR TITLE
reference Mender Hub alongside commercial board integration

### DIFF
--- a/03.Devices/02.Yocto-project/docs.md
+++ b/03.Devices/02.Yocto-project/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-!!! Mender has four reference devices already integrated with the Yocto Project: [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank), [BeagleBone Black](https://beagleboard.org/black?target=_blank) and two virtual devices (`qemux86-64` and `vexpress-qemu`). If you would like assistance supporting your device and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
+!!! Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is already integrated. If you would like professional assistance supporting your board and OS, please refer to the [commercial device support offering](https://mender.io/product/board-support?target=_blank).
 
 ##Yocto Project
 Although it is possible to compile and install Mender independently, we have optimized the installation experience for those who build their Linux images using [Yocto Project](https://www.yoctoproject.org?target=_blank).

--- a/03.Devices/chapter.md
+++ b/03.Devices/chapter.md
@@ -9,4 +9,6 @@ taxonomy:
 # Board integration
 
 A description of how to integrate Mender with your board.
+
+Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is already integrated.
 For commercial support, please see the [Board support offering](https://mender.io/product/board-support?target=_blank).

--- a/04.Artifacts/01.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/01.Yocto-project/01.Building/docs.md
@@ -33,19 +33,12 @@ The other layers in *meta-mender* provide support for specific boards.
 ### Board integrated with Mender
 
 Mender needs to integrate with your board, most notably with the boot process.
-This integration enables robust and atomic rollbacks with Mender.
-Please see [Board integration](../../../devices) for general requirements and
+Although the integration is automated for most boards, please see
+[Board integration](../../../devices) for general requirements and
 adjustment you might need to make before building.
 
-The following reference boards are already integrated with Mender
-and covered by automated tests to ensure they work well:
-
-<!--AUTOVERSION: "meta-mender/tree/%"/ignore-->
-* [Raspberry Pi 3](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-raspberrypi?target=_blank) (other revisions are also likely to work)
-* BeagleBone Black (no board specific layer needed)
-* [Virtual board (qemux86-64)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
-* [Virtual board (vexpress-qemu)](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-qemu?target=_blank)
-
+Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is
+already integrated.
 If you encounter any issues and want to save time, you can use
 the [Mender professional services to integrate your board](https://mender.io/product/board-support?target=_blank).
 
@@ -124,8 +117,8 @@ For the three Mender reference boards use these layers (only add one of these):
 * BeagleBone Black: No board specific layer needed
 * Virtual boards: `bitbake-layers add-layer ../meta-mender/meta-mender-qemu`
 
-If you are building for a different board and encounter any issues, please see [Board integration](../../../devices)
-for general requirements and adjustments you might need to enable your board to support Mender.
+If you encounter any issues, please see [Board integration](../../../devices)
+and [Mender Hub](https://hub.mender.io?target=_blank) for general requirements and adjustments you might need to enable your board to support Mender.
 
 At this point, all the layers required for Mender should be
 part of your Yocto Project build environment.


### PR DESCRIPTION
Removed reference devices I saw in these areas, this status should probably be moved to Mender Hub.
Though I wonder about the virtual ones - they are not (yet) present in Mender Hub..