### PR TITLE
[1.5.x] MEN-2125: Allow trailing AUTOVERSION tags for page headers.

### DIFF
--- a/README-autoversion.markdown
+++ b/README-autoversion.markdown
@@ -23,7 +23,12 @@ false matches.
 come in three flavors, described in the next sections.
 
 Each `AUTOVERSION` tag is only active for the code block or paragraph
-immediately following it.
+immediately following it (*).
+
+(*) There is one exception: The tag may come after a page header, and affect
+that header. The reason this exception was made is because the page doesn't
+render correctly if the tag is above the page header. This only works if the tag
+comes *immediately* after the header.
 
 
 ### Version numbers for Mender components

--- a/chapter.md
+++ b/chapter.md
@@ -3,6 +3,11 @@ title: "1.5"
 taxonomy:
     category: docs
 ---
+<!--AUTOVERSION: "title: \"Development\""/complain-->
+<!--
+Exception to the rule about AUTOVERSION tags coming before their affected block:
+For page headers the tag may come after due to misrendering if it is above.
+-->
 
 ### 1.5
 


### PR DESCRIPTION
If the tag is above the header, the page doesn't render correctly.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit efbb37557a3cc862d379a95906c681cb207d7333)