### PR TITLE
MEN-2214: Set inventory poll interval default to 8h

### DIFF
--- a/04.Artifacts/01.Yocto-project/02.Image-configuration/docs.md
+++ b/04.Artifacts/01.Yocto-project/02.Image-configuration/docs.md
@@ -131,7 +131,7 @@ In order to do this, change the following in the file
 
 ```bash
 MENDER_UPDATE_POLL_INTERVAL_SECONDS ?= "1800"
-MENDER_INVENTORY_POLL_INTERVAL_SECONDS ?= "1800"
+MENDER_INVENTORY_POLL_INTERVAL_SECONDS ?= "28800"
 ```
 
 

--- a/05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md
+++ b/05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md
@@ -18,7 +18,7 @@ Default value: 1800 seconds (30 minutes).
 * `InventoryPollIntervalSeconds` sets the frequency for periodically sending [inventory data](../../inventory).
 Inventory data is always sent after each boot of the device, and after a new update has been
 correctly applied and committed by the device in addition to this periodic interval.
-Default value: 86400 seconds (one day). 
+Default value: 28800 seconds (8 hours).
 
 ## How to choose right intervals
 
@@ -40,7 +40,7 @@ Both parameters are stored in the configuration file `/etc/mender/mender.conf`:
 ```
 {
   "UpdatePollIntervalSeconds": 1800,
-  "InventoryPollIntervalSeconds": 86400,
+  "InventoryPollIntervalSeconds": 28800,
 ...
 ```
 


### PR DESCRIPTION
Update documentation so that it is consistent with the code

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>