### PR TITLE
artifacts: do not recommend to store the artifact verify key on the d…

### DIFF
--- a/04.Artifacts/01.Yocto-project/03.Building-for-production/docs.md
+++ b/04.Artifacts/01.Yocto-project/03.Building-for-production/docs.md
@@ -86,8 +86,6 @@ The private key used for signing the Mender Artifact should be protected and kep
 thus there are no extra steps needed to add it to any part of the build system, Mender Client nor Server.
 
 Only the public key, which is used by the Mender Client to verify the signed Artifact must be included in the Mender Client build.
-The public verification key should be stored on *persistent storage* on the device where the Mender client runs,
-as the key should not change across deployments (except when doing key rotation). By default it is stored on the data partition.
 
 The best way to include a public verification key in the client is to add it to your own layer. Set the name of the verification key to `artifact-verify-key.pem` and append it to `SRC_URI` of the `mender` application before building the Yocto client image. For example:
 


### PR DESCRIPTION
…ata part

The documentation also stated that we do this by default, which we do not and
the key is stored in '/etc/mender/' by default which is also the recommended
location to be able to rotate it as part of an rootfs update.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>