### PR TITLE
Fix dead link for Update Modules spec by refering to the fork

### DIFF
--- a/04.Artifacts/08.Update-Modules/docs.md
+++ b/04.Artifacts/08.Update-Modules/docs.md
@@ -204,7 +204,4 @@ It saves a tarball with all current files in `/var/www` (only the single files, 
 
 ## Further reading
 
-<!--AUTOVERSION: "mender/blob/%"/mender-->
-* [Update modules v3 protocol](https://github.com/mendersoftware/mender/blob/master/Documentation/update-modules-v3-file-api.md)
-
-!! TO-DO: Check links
+* [Update modules v3 protocol](https://github.com/kacf/mender/blob/update_modules/Documentation/update-modules-v3-file-api.md)


### PR DESCRIPTION
We will restore it back to master once Update Modules feature is fully
merged in mender repo

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>