### PR TITLE
client: install: remove mention of demo server

### DIFF
--- a/05.Client-configuration/06.Installing/docs.md
+++ b/05.Client-configuration/06.Installing/docs.md
@@ -39,8 +39,7 @@ sudo sed -i "s/Paste your Hosted Mender token here/$TENANT_TOKEN/" /etc/mender/m
 #### Use demo settings (optional)
 
 By default Mender uses production-grade configuration settings. However, if this is a test or development device,
-it is recommended to use the demo settings to get shorter polling intervals and allow an insecure certificate used
-by the [Mender demo server](../../getting-started/create-a-test-environment). Run the following commands:
+it is recommended to use the demo settings to get shorter polling intervals. Run the following commands:
 
 ```bash
 TENANT_TOKEN="<INSERT YOURS FROM https://hosted.mender.io/ui/#/settings/my-organization>"


### PR DESCRIPTION
All the provided configuration files point to Hosted Mender, and the
section "Use demo settings" only updates polling intervals and not
server url, meaning it is still using Hosted Mender.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>