### PR TITLE
Update documentation to encourage usage of "sign" command instead of "modify"

### DIFF
--- a/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
@@ -100,7 +100,7 @@ mender-artifact write rootfs-image -t beaglebone -n release-1 -u rootfs.ext4 -o 
 ## Signing after modification
 
 If you are signing Artifacts, the signature will become invalid whenever
-you make modifications to them. See the section on [signing and verification](../signing-and-verification)
+you make modifications to them. See the section on [signing and verification](../signing-and-verification#an-existing-mender-artifact)
 for more information.
 
 

--- a/04.Artifacts/06.Signing-and-verification/docs.md
+++ b/04.Artifacts/06.Signing-and-verification/docs.md
@@ -86,9 +86,10 @@ otherwise [compile it for your platform](../modifying-a-mender-artifact#compilin
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 [x.x.x_mender-artifact]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/2.4.0/mender-artifact
 
-To sign we use the `-k` parameter to specify the private key, which will be used for creating the signature.
-This parameter works both if you have a root file system (e.g. `.ext4` file) and are writing a new Mender Artifact
-and if you are signing an existing Mender Artifact (`.mender`).
+There are two ways to sign an Artifact: while creating it with the `write`
+command or once already created using the `sign` command. We add the `-k`
+paramater in both cases to specify the private key, which will be used for
+creating the signature.
 
 #### A raw root file system
 
@@ -102,13 +103,12 @@ mender-artifact write rootfs-image -t beaglebone -n mender-1.7.0 -u core-image-b
 #### An existing Mender Artifact
 
 ```bash
-cp artifact.mender artifact-signed.mender
-mender-artifact modify artifact-signed.mender -k private.key
+mender-artifact sign artifact.mender -k private.key -o artifact-signed.mender
 ```
 
-The latter is typically the command the Signing system uses to create a signed Artifact,
-as a Mender Artifact is built by the build system already.
-
+This is typically the command that the Signing system uses to create a
+signed Artifact from an unsigned one produced by the build system, or after
+modifying an Artifact with `mender-artifact modify` command.
 
 ## Verifying the signature
 


### PR DESCRIPTION
Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 2adcf88a644a2d48d1c09f9f10265a5b4548adc2)

Conflicts:
        04.Artifacts/06.Signing-and-verification/docs.md

Made a small modification to text explaining the 'sign' command

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>