### PR TITLE
Fix typo in beablebone Artifact names

### DIFF
--- a/01.Getting-started/04.Deploy-to-physical-devices/docs.md
+++ b/01.Getting-started/04.Deploy-to-physical-devices/docs.md
@@ -286,10 +286,10 @@ of the `mender-artifact` tool, first making a copy of the original. To do this,
 run these two commands (adjust the Artifact file name accordingly):
 
 
-<!--AUTOVERSION: "release-2_%"/mender -->
+<!--AUTOVERSION: "release_1_%"/mender "release_2_%"/mender "release-2_%"/mender -->
 ```bash
-cp beaglebone_release_1.mender beaglebone_release_2.mender
-mender-artifact modify beaglebone_release_2.mender -n release-2_master
+cp beagleboneblack_release_1_master.mender beagleboneblack_release_2_master.mender
+mender-artifact modify beagleboneblack_release_2_master.mender -n release-2_master
 ```
 
 


### PR DESCRIPTION
The filename's prefix is 'beagleboneblack' and includes the Mender
version in it.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>