### PR TITLE
update requirements for on-prem installation

### DIFF
--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -16,11 +16,12 @@ repository.
 
 ## Prerequisites
 
-- A machine with Ubuntu 18.04 (e.g. an instance from AWS EC2 or DigitalOcean) with
-  the following tools installed:
+- A machine with Ubuntu 18.04 (e.g. an instance from AWS EC2 or DigitalOcean) with the following tools installed:
   - git
   - [Docker Engine](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/?target=_blank), version **17.03 or later**.
   - [Docker Compose](https://docs.docker.com/compose/install/?target=_blank), version **1.6 or later**.
+- Minimum of 10 GB free disk space and 4 GB RAM available for Mender and its services.
+    - This heavily depends on your scale and environment, the supported [Mender Enterprise](https://mender.io/product/mender-enterprise) edition is recommended for larger-scale environments.
 - A public IP address assigned and ports 443 and 9000 publicly accessible.
 - Allocated DNS names for the Mender API Gateway and the Mender Storage Proxy
   (for purpose of the guide, it is assumed that you


### PR DESCRIPTION
I do not actually know if the values in the requirements are appropriate but recently we have had a number of questions/issues on the forums reporting failure to setup the on-prem server, and most where related to RAM memory which we seem to have increased recently due to update of Elasticsearch. 