### PR TITLE
add link to state-scripts example directory

### DIFF
--- a/04.Artifacts/07.State-scripts/docs.md
+++ b/04.Artifacts/07.State-scripts/docs.md
@@ -102,6 +102,8 @@ State scripts are allowed to return a specific error code, in order to rerun at 
 
 Mender users will probably come up with a lot of interesting use cases for state scripts, and we will cover some well-known ones below for inspiration.
 
+<!--AUTOVERSION: "mender/tree/%"/ignore-->
+You can find code examples in the [Mender client source repository](https://github.com/mendersoftware/mender/tree/master/examples/state-scripts) and if you have implemented an interesting use-case we encourage you to create a pull-request so all of the community can benefit.
 
 #### Application data migration
 In this case, application data like a user profile is stored in an SQLite database and a new column need to be added before starting the new version of the application. This can be achieved by adding a state script to `ArtifactInstall_Leave` (that would run after writing the new rootfs, but before rebooting). This script can then do the necessary migrations on the data partition before the new version of the application is brought up after the reboot.


### PR DESCRIPTION
We store a couple of state-script examples (code) in
the Mender client repository.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>