### PR TITLE
Fixes for Downloads page: newlines break the links

### DIFF
--- a/08.Downloads/docs.md
+++ b/08.Downloads/docs.md
@@ -17,14 +17,12 @@ according to your host platform:
 
 Remember to add execute permission (e.g. with `chmod +x mender-artifact`).
 
-!!! If you need to build `mender-artifact` from source, please see [Compiling
-mender-artifact](#compiling-mender-artifact).
+!!! If you need to build `mender-artifact` from source, please see [Compiling mender-artifact](../artifacts/modifying-a-mender-artifact#compiling-mender-artifact).
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-linux]:
-https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/linux/mender-artifact
-[x.x.x_mender-artifact-darwin]:
-https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/darwin/mender-artifact
+[x.x.x_mender-artifact-linux]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/linux/mender-artifact
+<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
+[x.x.x_mender-artifact-darwin]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/darwin/mender-artifact
 
 
 ## Mender client
@@ -37,5 +35,4 @@ A Debian package (`.deb`) is provided for convenience to install on e.g Debian, 
 | armhf (ARM-v6) | Raspberry Pi, BeagleBone, other ARM based | [mender-client_master-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
-[mender-client_x.x.x-1_armhf.deb]:
-https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
+[mender-client_x.x.x-1_armhf.deb]: https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb


### PR DESCRIPTION
See @eysteins comments in [this already merged PR](https://github.com/mendersoftware/mender-docs/pull/705).