### PR TITLE
Update update modules instructions

### DIFF
--- a/03.Devices/10.Update-Modules/docs.md
+++ b/03.Devices/10.Update-Modules/docs.md
@@ -41,7 +41,7 @@ Refer to [further reading](#further-reading) for more details.
 
 ### Mender server
 
-You will need a Mender server.
+You will need a Mender server if you are using [managed mode](../../architecture/overview#modes-of-operation).
 
 For easy setup, use [Hosted Mender](https://hosted.mender.io?target=_blank) or the [on-premise demo server](../../getting-started/create-a-test-environment).
 
@@ -96,6 +96,11 @@ Then add execute permission to the script:
 chmod +x web-file
 ```
 
+Then create the directory where the update files will be installed:
+```bash
+mkdir -p /var/www
+```
+
 Your Mender client is now able to handle any Artifact containing a `web-file` Update Module Artifact.
 
 ### Create an Artifact with a payload for the new Update Module
@@ -130,11 +135,25 @@ The command line options are detailed below:
 
 For more details, see `mender-artifact write module-image --help`
 
-### Upload and deploy your Artifact
+### Upload and deploy your Artifact in Managed Mode
 
 Go to Artifacts in the Mender server UI and upload your newly generated Mender Artifact.
 
 Now go to Deployments and deploy the Artifact to All devices. It should finish within a minute or so.
+
+### Upload and deploy your Artifact in Standalone Mode
+
+Copy your newly generated Mender Artifact to the target device.  SSH can be used for this, i.e. scp.
+
+```bash
+scp ~/Downloads/web-file-1.mender <username>@<deviceip>:
+```
+
+Then install the Mender Artifact on the target device:
+
+```bash
+mender -install web-file-1.mender
+```
 
 ### Verify the deployment on the device
 


### PR DESCRIPTION
This is the same pull request as #711 but based on master branch instead of 2.0.X branch.

Added instruction to create directory /var/www prior to installing artifact.

Added description for deploying an update module in standalone mode.