### PR TITLE
Add sizelimit to mount for image modifying

### DIFF
--- a/04.Artifacts/04.Modifying-a-disk-image/docs.md
+++ b/04.Artifacts/04.Modifying-a-disk-image/docs.md
@@ -63,11 +63,11 @@ sudo mkdir /mnt/rootfs1 && sudo mkdir /mnt/rootfs2
 ```
 
 ```bash
-sudo mount -o loop,offset=$((512*81920)) mender-beaglebone.sdimg /mnt/rootfs1
+sudo mount -o loop,offset=$((512*81920)),sizelimit=$((512*212992)) mender-beaglebone.sdimg /mnt/rootfs1
 ```
 
 ```bash
-sudo mount -o loop,offset=$((512*294912)) mender-beaglebone.sdimg /mnt/rootfs2
+sudo mount -o loop,offset=$((512*294912)),sizelimit=$((512*212992)) mender-beaglebone.sdimg /mnt/rootfs2
 ```
 
 Now you can modify the rootfs file systems in the paths `/mnt/rootfs1` and `/mnt/rootfs2`.


### PR DESCRIPTION
`mount` didn't work for me on Ubuntu 18.04 LTS and was complaining about overlapping loop device. Added `sizelimit` to mitigate the issue.