### PR TITLE
Make sure terminal quotes are monospaced.

### DIFF
--- a/01.Getting-started/04.Deploy-a-system-update-demo/docs.md
+++ b/01.Getting-started/04.Deploy-a-system-update-demo/docs.md
@@ -100,7 +100,9 @@ mender-artifact cat $MENDER_IMGPATH:/etc/hosts
 
 You should see output similar to the following:
 
+> ```
 > 192.168.10.1 docker.mender.io s3.docker.mender.io
+> ```
 
 ### Set a static device IP address and subnet
 
@@ -211,7 +213,9 @@ mender-artifact cat $MENDER_FILE_IMGPATH:/etc/hosts
 
 You should see output similar to the following:
 
+> ```
 > 192.168.10.1 docker.mender.io s3.docker.mender.io
+> ```
 
 Finally, **only if you are using static IP addressing**, you need to set the
 device IP address, as shown below (otherwise skip this step). Please note that the same

--- a/04.Artifacts/04.Modifying-a-disk-image/docs.md
+++ b/04.Artifacts/04.Modifying-a-disk-image/docs.md
@@ -51,7 +51,7 @@ The second piece of information we need is the *start sector* of the partition w
 This is the second column in the output from `fdisk`. The start sector is shown in bold below for
 our two rootfs partitions:
 
-> mender-beaglebone.sdimg2       **81920** 294911  212992  104M 83 Linux
+> mender-beaglebone.sdimg2       **81920** 294911  212992  104M 83 Linux<br>
 > mender-beaglebone.sdimg3      **294912** 507903  212992  104M 83 Linux
 
 In order to mount a partition we simply multiply the sector size and the start sector

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -76,6 +76,7 @@ named `mender-server`:
 git clone -b master https://github.com/mendersoftware/integration mender-server
 ```
 
+> ```
 > Cloning into 'deployment'...
 > remote: Counting objects: 1117, done.
 > remote: Compressing objects: 100% (11/11), done.
@@ -83,6 +84,7 @@ git clone -b master https://github.com/mendersoftware/integration mender-server
 > Receiving objects: 100% (1117/1117), 233.85 KiB | 411.00 KiB/s, done.
 > Resolving deltas: 100% (678/678), done.
 > Checking connectivity... done.
+> ```
 
 Enter the directory:
 
@@ -111,9 +113,11 @@ cd production
 ```
 ls -l
 ```
+> ```
 > total 12
 > -rw-rw-r--. 1 user user 4101 01-26 14:06 prod.yml
 > -rwxrwxr-x. 1 user user  161 01-26 14:06 run
+> ```
 
 The template includes 2 files:
 
@@ -143,10 +147,12 @@ git add .
 ```bash
 git commit -m 'production: initial template'
 ```
+> ```
 > [my-production-setup 556cc2e] production: initial template
 >  2 files changed, 110 insertions(+)
 >  create mode 100644 production/prod.yml
 >  create mode 100755 production/run
+> ```
 
 Assuming that current working directory is still `production`, download
 necessary Docker images:
@@ -155,6 +161,7 @@ necessary Docker images:
 ./run pull
 ```
 
+> ```
 > Pulling mender-mongo (mongo:3.4)...
 > 3.4: Pulling from library/mongo
 > Digest: sha256:aff0c497cff4f116583b99b21775a8844a17bcf5c69f7f3f6028013bf0d6c00c
@@ -180,6 +187,7 @@ necessary Docker images:
 > latest: Pulling from mendersoftware/api-gateway
 > Digest: sha256:97243de3da950e754ada73abf8c123001c0a0c8b20344256dc7db4c89c0ecd82
 > Status: Image is up to date for mendersoftware/api-gateway:latest
+> ```
 
 ! Using the `run` helper script may fail when local user has insufficient permissions to reach a local docker daemon. Make sure that the Docker installation was completed successfully and the user has sufficient permissions (typically the user must be a member of the `docker` group).
 
@@ -194,12 +202,14 @@ CERT_API_CN=mender.example.com CERT_STORAGE_CN=s3.example.com ../keygen
 ```
 <!--AUTOMATION: execute=CERT_API_CN=s3.docker.mender.io CERT_STORAGE_CN=s3.docker.mender.io ../keygen -->
 
+> ```
 > Generating a 256 bit EC private key
 > writing new private key to 'private.key'
 > ...
 > All keys and certificates have been generated in directory keys-generated.
 > Please include them in your docker compose and device builds.
 > For more information please see https://docs.mender.io/Administration/Certificates-and-keys.
+> ```
 
 Your local directory tree should now look like this:
 <!--AUTOMATION: ignore -->
@@ -239,6 +249,7 @@ git add keys-generated
 git commit -m 'production: adding generated keys and certificates'
 ```
 
+> ```
 > [my-production-setup fd8a397] production: adding generated keys and certificates
 >  6 files changed, 108 insertions(+)
 >  create mode 100644 production/keys-generated/certs/api-gateway/cert.crt
@@ -248,6 +259,7 @@ git commit -m 'production: adding generated keys and certificates'
 >  create mode 100644 production/keys-generated/certs/storage-proxy/private.key
 >  create mode 100644 production/keys-generated/keys/deviceauth/private.key
 >  create mode 100644 production/keys-generated/keys/useradm/private.key
+> ```
 
 The API Gateway and Storage Proxy certificates generated here need to be made
 available to the Mender client.
@@ -282,10 +294,12 @@ rm -rf keys-generated
 ```
 ls -l
 ```
+> ```
 > total 20
 > -rw-rw-r--. 1 user group 5094 01-30 11:24 keys-generated.tar.gpg
 > -rw-rw-r--. 1 user group 5519 01-30 11:08 prod.yml
 > -rwxrwxr-x. 1 user group  173 01-27 14:16 run
+> ```
 
 Keys need to be decrypted before bringing the whole environment up:
 
@@ -309,9 +323,11 @@ git add keys-generated.tar.gpg
 git commit -m 'production: adding generated keys and certificates'
 ```
 
+> ```
 > [my-production-setup 237af44] production: adding generated keys and certificates
 >  1 file changed, 111 insertions(+)
 >  create mode 100644 production/keys-generated.tar.gpg
+> ```
 
 
 ### Persistent storage
@@ -351,7 +367,9 @@ command:
 ```bash
 docker volume inspect --format '{{.Mountpoint}}' mender-artifacts
 ```
+> ```
 > /var/lib/docker/volumes/mender-artifacts/_data
+> ```
 
 The path depends on local docker configuration and may vary between installations.
 
@@ -397,7 +415,9 @@ for generating the secret. Run the following command to generate a 16-character 
 ```bash
 pwgen 16 1
 ```
+> ```
 > ahshagheeD1ooPae
+> ```
 
 The updated entry should look similar to this:
 
@@ -534,9 +554,11 @@ At this point your commit history should look as follows:
 ```bash
 git log --oneline origin/master..HEAD
 ```
+> ```
 > 7a4de3c production: final configuration
 > 41273f7 production: adding generated keys and certificates
 > 5ad6528 production: initial template
+> ```
 
 
 ### Bring it all up
@@ -546,6 +568,7 @@ Bring up all services up in detached mode with the following command:
 ```bash
 ./run up -d
 ```
+> ```
 > Creating network "menderproduction_mender" with the default driver
 > Creating menderproduction_mender-mongo_1
 > Creating menderproduction_mender-gui_1
@@ -556,6 +579,7 @@ Bring up all services up in detached mode with the following command:
 > Creating menderproduction_mender-useradm_1
 > Creating menderproduction_mender-deployments_1
 > Creating menderproduction_mender-api-gateway_1
+> ```
 
 !!! Services, networks and volumes have a `menderproduction` prefix, see the note about [docker-compose naming scheme](#docker-compose-naming-scheme) for more details. When using `docker ..` commands, a complete container name must be provided (ex. `menderproduction_mender-deployments_1`).
 

--- a/07.Administration/06.Upgrading/docs.md
+++ b/07.Administration/06.Upgrading/docs.md
@@ -66,6 +66,7 @@ update origin`.
 git fetch origin --tags
 ```
 <!--AUTOVERSION: "%      -> origin/%"/ignore "%     -> origin/%"/ignore-->
+> ```
 > Fetching origin  
 > remote: Counting objects: 367, done.  
 > remote: Compressing objects: 100% (31/31), done.  
@@ -75,6 +76,7 @@ git fetch origin --tags
 > From https://github.com/mendersoftware/integration  
 >    02cd118..75b7831  1.0.x      -> origin/1.0.x  
 >    06f3212..e9e5df4  master     -> origin/master  
+> ```
 
 <!--AUTOVERSION: "branch named `%` provides"/ignore "e.g. `%`"/ignore-->
 For each release there will be a corresponding release branch. For example, the
@@ -111,12 +113,14 @@ Upgrading our local production branch is performed by issuing a `git merge` comm
 ```bash
 git merge 1.0.1
 ```
+> ```
 > Merge made by the 'recursive' strategy.
 >  .travis.yml            | 16 ++++++++++++++++
 >  tests/run.sh           |  4 ++--
 >  update                 |  1 -
 >  verify-docker-versions | 29 ++++++++++++++++++++---------
 >  4 files changed, 38 insertions(+), 12 deletions(-)
+> ```
 
 !!! Since your local changes are kept in git, it is possible to tag your production version or branch to create pre-merge branches that can be tested in a staging environment.
 
@@ -130,6 +134,7 @@ First, pull in new container images:
 ./run pull
 ```
 <!--AUTOVERSION: "%: Pulling from mendersoftware/deviceauth"/deviceauth "%: Pulling from mendersoftware/gui"/gui "%: Pulling from mendersoftware/api-gateway"/api-gateway "mendersoftware/deviceauth:%"/deviceauth "mendersoftware/gui:%"/gui "mendersoftware/api-gateway:%"/api-gateway-->
+> ```
 > Pulling mender-mongo (mongo:3.4)...  
 > 3.4: Pulling from library/mongo  
 > Digest: sha256:e5a4f6caf4fb6773e41292b56308ed427692add67ffd7c655fdf11a78a72df4e  
@@ -151,6 +156,7 @@ First, pull in new container images:
 > master: Pulling from mendersoftware/api-gateway  
 > Digest: sha256:0a2033a57f88afc38253a45301c83484e532047d75858df95d46c12b48f1f2f8  
 > Status: Image is up to date for mendersoftware/api-gateway:master````  
+> ```
 
 Then stop and remove existing containers:
 
@@ -159,6 +165,7 @@ Then stop and remove existing containers:
 ```bash
 ./run stop
 ```
+> ```
 > Stopping menderproduction_mender-api-gateway_1 ... done
 > Stopping menderproduction_mender-inventory_1 ... done
 > Stopping menderproduction_mender-deployments_1 ... done
@@ -168,12 +175,14 @@ Then stop and remove existing containers:
 > Stopping menderproduction_mender-mongo_1 ... done
 > Stopping menderproduction_mender-gui_1 ... done
 > Stopping menderproduction_minio_1 ... done
+> ```
 
 !!! All system data is kept in named Docker volumes. Removing containers does not affect volumes.
 
 ```bash
 ./run rm
 ```
+> ```
 > Going to remove menderproduction_mender-api-gateway_1, ...
 > Are you sure? [yN] y
 > Removing menderproduction_mender-api-gateway_1 ... done
@@ -185,12 +194,14 @@ Then stop and remove existing containers:
 > Removing menderproduction_mender-mongo_1 ... done
 > Removing menderproduction_mender-gui_1 ... done
 > Removing menderproduction_minio_1 ... done
+> ```
 
 Start the new environment:
 
 ```bash
 ./run up -d
 ```
+> ```
 > Creating menderproduction_mender-mongo_1
 > Creating menderproduction_minio_1
 > Creating menderproduction_mender-gui_1
@@ -200,6 +211,7 @@ Start the new environment:
 > Creating menderproduction_mender-device-auth_1
 > Creating menderproduction_mender-inventory_1
 > Creating menderproduction_mender-api-gateway_1
+> ```
 
 ## Removing deviceadm service database
 

--- a/07.Administration/07.Backup-and-restore/docs.md
+++ b/07.Administration/07.Backup-and-restore/docs.md
@@ -44,6 +44,7 @@ the contents of each DB into `$PWD/db-dump/<service-name>` directory.
 ```bash
 ../migration/dump-db
 ```
+> ```
 > Stopping menderproduction_mender-deployments_1 ... done
 > Stopping menderproduction_mender-inventory_1 ... done
 > Stopping menderproduction_mender-useradm_1 ... done
@@ -56,6 +57,7 @@ the contents of each DB into `$PWD/db-dump/<service-name>` directory.
 > 2017-06-06T11:20:05.025+0000    done dumping useradm.migration_info (1 document)
 > (output continues...)
 > 2017-06-06T11:20:05.315+0000    done dumping deployment_service.migration_info (1 document)
+> ```
 
 The tool `restore-db` will run a mongo container inside the mender network to restore
 DB dumps previously created with `dump-db`.
@@ -63,6 +65,7 @@ DB dumps previously created with `dump-db`.
 ```bash
 ../migration/restore-db
 ```
+> ```
 > Stopping menderproduction_mender-deployments_1 ... done
 > Stopping menderproduction_mender-inventory_1 ... done
 > Stopping menderproduction_mender-useradm_1 ... done
@@ -74,6 +77,7 @@ DB dumps previously created with `dump-db`.
 > 2017-06-06T11:35:14.563+0000    no indexes to restore
 > 2017-06-06T11:35:14.563+0000    finished restoring deployment_service.migration_info (1 document)
 > 2017-06-06T11:35:14.563+0000    done
+> ```
 
 ! Note `restore-db` and `dump-db` will automatically stop all Mender services that may access respective DBs.
 
@@ -82,6 +86,7 @@ Once the data has been dumped or restored, the services can be started using
 ```bash
 ./run up -d
 ```
+> ```
 > menderproduction_mender-mongo_1 is up-to-date
 > menderproduction_mender-elasticsearch_1 is up-to-date
 > menderproduction_mender-gui_1 is up-to-date
@@ -94,6 +99,7 @@ Once the data has been dumped or restored, the services can be started using
 > menderproduction_mender-conductor_1 is up-to-date
 > Starting menderproduction_mender-deployments_1
 > menderproduction_mender-api-gateway_1 is up-to-date
+> ```
 
 Occasionally services may get new IP addresses and the API gateway DNS cache may no
 longer be correct. To refresh the API gateway's cache, run the following command:

--- a/201.Troubleshooting/03.Mender-Client/docs.md
+++ b/201.Troubleshooting/03.Mender-Client/docs.md
@@ -64,8 +64,10 @@ Replace the hostname with the one for your Mender API Gateway below and run the 
 ```bash
 echo | openssl s_client -connect mender.example.com:443 2>/dev/null | openssl x509 -noout -dates
 ```
+> ```
 > notBefore=Dec 14 19:52:46 2016 GMT
 > notAfter=Dec 12 19:52:46 2026 GMT
+> ```
 
 Also note that the storage proxy has its own certificate, and it runs on the same host as the API Gateway
 on port 9000 by default. Adjust the hostname and verify the validity of its certificate with the following command:
@@ -73,8 +75,10 @@ on port 9000 by default. Adjust the hostname and verify the validity of its cert
 ```bash
 echo | openssl s_client -connect s3.example.com:9000 2>/dev/null | openssl x509 -noout -dates
 ```
+> ```
 > notBefore=Dec 14 19:52:46 2016 GMT
 > notAfter=Dec 12 19:52:46 2026 GMT
+> ```
 
 We can see that both these certificates are currently valid.
 Also see the [documentation on certificates](../../administration/certificates-and-keys) for an


### PR DESCRIPTION
One block uses <br> instead, since it doesn't need to be monospaced,
and relies on being able to turn one piece of text bold, which doesn't
work inside a monospaced code block.

The advantage is clear. It goes from this:

![Before](https://eu.hostiso.cloud/index.php/s/2yTziPyJ6G3XfYM/preview)

To this:

![After](https://eu.hostiso.cloud/index.php/s/58aJLjSiaaT4ZHw/preview)