### PR TITLE
state-script documentation cleanup

### DIFF
--- a/04.Artifacts/07.State-scripts/docs.md
+++ b/04.Artifacts/07.State-scripts/docs.md
@@ -67,10 +67,15 @@ If a script returns `0` Mender proceeds, but if it returns `1` the update is abo
 In addition, return code `21` is used for the [retry-later](#retry-later) feature.
 All other return codes are reserved for future use by Mender and should not be used.
 
+### Retry-later
+
+State scripts are allowed to return a specific error code (`21`), in which case the client will sleep for a time configured by [StateScriptRetryIntervalSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretryintervalseconds) before the state script is called again. Note that scripts are not allowed to retry for infinitely long. Please see description of [StateScriptRetryTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretrytimeoutseconds) for more information.
+
+This feature is useful e.g when you want user confirmation before proceeding with the update as is described in the [Update confirmation by end user](./#update-confirmation-by-end-user) section on this page.
+
 ## Script timeout
 
-Each script has a maximum execution default time of 1 hour, or of user-specified time `StateScriptTimeoutSeconds`. If
-a script exceeds this running time, its process group will be killed and Mender will treat the script as failed.
+Each script has a maximum execution time defined by [StateScriptTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescripttimeoutseconds). If a script exceeds this running time, its process group will be killed and the Mender client will treat the script and the update as failed.
 
 ## Power loss
 
@@ -93,11 +98,6 @@ information to standard error, especially in case of failure
 (returning 1). The maximum size of the log is 10KiB per state script,
 anything above this volume will be truncated.
 
-## Retry-later
-
-State scripts are allowed to return a specific error code, in order to rerun at a later time. Thus if a script returns the error code `21`, the client will sleep for a default time of one minute, or for a user-specified interval `StateScriptRetryIntervalSeconds`, which can be [set in the mender config](../../client-configuration/configuration-file). Also note that scripts are not allowed to retry for infinitely long. Either a standard max window of thirty minutes is allocated to each script, or this can be configured manually by using the mender config variable `StateScriptRetryTimeoutSeconds`.
-
-
 ## Example use cases
 
 Mender users will probably come up with a lot of interesting use cases for state scripts, and we will cover some well-known ones below for inspiration.
@@ -114,7 +114,7 @@ For many devices with a display that interacts with an end user, it is desirable
 
 Mender state scripts enable this use case with a script written to create the dialog box on the UI framework used. The script will simply wait for user input, and Mender will wait with the update process while waiting for the script to finish. Depending on what the user selects, the script can return `0` (proceed) or `21` ([retry later](#retry-later)). For example, this script can be run in the `Download_Enter` state, and the user will be asked before the download begins. Alternatively, the script can also be run in the `Download_Leave` state, if you want the download to finish first, and the user only to accept installing the update and rebooting.
 
-Make sure to adjust `StateScriptRetryIntervalSeconds` as described in [retry later](#retry-later) to enable this use case.
+Make sure to adjust [StateScriptRetryTimeoutSeconds]([StateScriptRetryTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretrytimeoutseconds)), to enable this use case.
 
 ![End user update confirmation state scripts](mender-state-machine-user-confirmation.png)
 

--- a/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
+++ b/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
@@ -74,27 +74,70 @@ standard certificate trust chains.
 
 #### StateScriptRetryIntervalSeconds
 
-The timeout before a state script that previously returned the special retry
-return code (21), will be run again.
+This variable relates to state scripts returning `21` meaning `retry-later`.
+This variable specifies how long time should elapse from the `retry-later`
+until the script is called again.
+
+Example:
+
+```
+"StateScriptRetryIntervalSeconds": 30
+```
+
+Above will ensure that the state-script is called every 30 seconds as long as
+it is returning `retry-later`.
+
+Default value is: `60`
+
+See also the section about [state scripts](../../../artifacts/state-scripts).
 
 <!--AUTOVERSION: "mender v%"/ignore-->
-*Note*: Before mender v2.0.0 release, this option used to be called `StateScriptRetryTimeoutSeconds`.
+*Note*: Before mender v2.0.0 release, this option used to be called
+`StateScriptRetryTimeoutSeconds`.
 
 #### StateScriptRetryTimeoutSeconds
 
-The interval for which the script is allowed to keep retrying. After this
-interval has expired, another retry attempt will be treated as a failure and if
-possible, the update will be rolled back.
+This variable specifies how much time a state script is allowed to consume by
+returning `retry-later`, meaning retry with `StateScriptRetryIntervalSeconds`
+until `StateScriptRetryTimeoutSeconds` is spent.
+
+You can not wait indefinitely but the `StateScriptRetryTimeoutSeconds` variable
+is only limited by the size of an `int`.
+
+!! It is recommend to set a sane maximum value to handle unexpected behavior, as this could potentially disable OTA capabilities on your device for long periods.
+
+Example:
+
+```
+StateScriptRetryIntervalSeconds: 30
+StateScriptRetryTimeoutSeconds: 86400
+```
+
+The above example will allow a state script to return `retry-later` for 24 hours before
+aborting and marking the update as failed.
+
+Default value is: `1800` (30 min)
+
+See also the section about [state scripts](../../../artifacts/state-scripts).
 
 <!--AUTOVERSION: "mender v%"/ignore-->
-*Note*: Before mender v2.0.0 release, this option used to be called `StateScriptRetryIntervalSeconds`.
+*Note*: Before mender v2.0.0 release, this option used to be called
+`StateScriptRetryIntervalSeconds`.
 
 #### StateScriptTimeoutSeconds
 
-The number of seconds to wait for any state script to terminate. If a script
-exceeds this running time, its process group will be killed and Mender will
-continue, treating the script as having failed. See also the section about
-[state scripts](../../../artifacts/state-scripts).
+This variables specifies the timeout value for a state-script while executing,
+measuring time from start of script until a return code is delivered. This is
+too prevent a script "hanging/freezing" or taking to long on specific command.
+If the timer elapses the state-script will be "killed" by the Mender client and
+the update marked as failure.
+
+The default value is dimensioned to be tolerant of most scripts, but you should
+set it based on the expected execution time of your scripts.
+
+Default value is: `3600` (60 min)
+
+See also the section about [state scripts](../../../artifacts/state-scripts).
 
 #### TenantToken
 


### PR DESCRIPTION
Most significantly:

Moved the bulk of the description (updated) of the variables listed below to the Mender
client configuration section, mostly to avoid duplication of default settings and to avoid
repeating the information. This is after all an more advanced topic of the Mender client,
and does not need be covered in one single page.

- StateScriptRetryIntervalSeconds
- StateScriptRetryTimeoutSeconds
- StateScriptTimeoutSeconds

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
(cherry picked from commit 29ffe1beba78ef185fad3e61c3cd68aaec9a36f9)