### PR TITLE
MEN-2825: Remove references to outdated release_2 artifacts - 2.2.x

### DIFF
--- a/01.Getting-started/02.On-premise-installation/05.Download-test-images/docs.md
+++ b/01.Getting-started/02.On-premise-installation/05.Download-test-images/docs.md
@@ -21,26 +21,20 @@ by deploying back and forth between these two Artifacts.
 
 Download the Artifacts for your desired device types below:
 
-
-| Device type      | Disk image | Artifact 1 | Artifact 2 |
-|------------------|------------|------------|------------|
-| BeagleBone Black | [mender-beagleboneblack.sdimg.gz][mender-beagleboneblack_x.x.x.sdimg.gz] | [beagleboneblack_release_1.mender][beagleboneblack_release_1_x.x.x.mender] | [beagleboneblack_release_2.mender][beagleboneblack_release_2_x.x.x.mender] |
-| Raspberry Pi 3   | [mender-raspberrypi3.sdimg.gz][mender-raspberrypi3_x.x.x.sdimg.gz] | [raspberrypi3_release_1.mender][raspberrypi3_release_1_x.x.x.mender] | [raspberrypi3_release_2.mender][raspberrypi3_release_2_x.x.x.mender] |
-
+| Device type      | Disk image | Artifact 1 |
+|------------------|------------|------------|
+| BeagleBone Black | [mender-beagleboneblack.sdimg.gz][mender-beagleboneblack_x.x.x.sdimg.gz] | [beagleboneblack_release_1.mender][beagleboneblack_release_1_x.x.x.mender] |
+| Raspberry Pi 3   | [mender-raspberrypi3.sdimg.gz][mender-raspberrypi3_x.x.x.sdimg.gz] | [raspberrypi3_release_1.mender][raspberrypi3_release_1_x.x.x.mender] |
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "%.sdimg.gz"/mender -->
 [mender-beagleboneblack_x.x.x.sdimg.gz]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/beagleboneblack/mender-beagleboneblack_2.1.1.sdimg.gz
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "release_1_%"/mender -->
 [beagleboneblack_release_1_x.x.x.mender]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/beagleboneblack/beagleboneblack_release_1_2.1.1.mender
-<!--AUTOVERSION: "cloudfront.net/%/"/mender "release_2_%"/mender -->
-[beagleboneblack_release_2_x.x.x.mender]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/beagleboneblack/beagleboneblack_release_2_2.1.1.mender
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "%.sdimg.gz"/mender -->
 [mender-raspberrypi3_x.x.x.sdimg.gz]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/raspberrypi3/mender-raspberrypi3_2.1.1.sdimg.gz
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "release_1_%"/mender -->
 [raspberrypi3_release_1_x.x.x.mender]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/raspberrypi3/raspberrypi3_release_1_2.1.1.mender
-<!--AUTOVERSION: "cloudfront.net/%/"/mender "release_2_%"/mender -->
-[raspberrypi3_release_2_x.x.x.mender]: https://d1b0l86ne08fsf.cloudfront.net/2.1.1/raspberrypi3/raspberrypi3_release_2_2.1.1.mender
 
 If you have a BeagleBone Black or Raspberry Pi 3 you want to test Mender with
 as well, download the *disk image and both Artifacts* for it.


### PR DESCRIPTION
Cherry-pick (and conflicts fix) of #808 

For upcoming Mender client 2.1.2 release we will not publish the `release_2` Artifacts, so we need to remove the references in this branch also.