### PR TITLE
MEN-2966: Align variable default descriptions with the Debian list.

### DIFF
--- a/04.Artifacts/01.Yocto-project/99.Variables/docs.md
+++ b/04.Artifacts/01.Yocto-project/99.Variables/docs.md
@@ -13,6 +13,7 @@ and used by Mender.
 
 #### ARTIFACTIMG_FSTYPE
 
+> Value: `ext4` (default) / <filesystem type>
 
 Defines which file system type Mender will build for the rootfs partitions in
 the `.biosimg`, `.sdimg`, `.uefiimg` and the `.mender` file. See [File system
@@ -22,11 +23,15 @@ for more information.
 
 #### ARTIFACTIMG_NAME
 
+> Value: <any string> (defaults to the image name being built)
+
 Overrides the default internal image name that mender will use to build the
 `.mender` file with.
 
 
 #### IMAGE_ROOTFS_SIZE
+
+> Value: <size in KiB> (default calculated from several factors, see below)
 
 The size of the generated rootfs, expressed in kiB. This will be the size that
 is shipped in a `.mender` update. This variable is a standard Yocto Project
@@ -40,8 +45,14 @@ automatically. See
 [`MENDER_STORAGE_TOTAL_SIZE_MB`](#mender_storage_total_size_mb) for more
 information.
 
+It is recommended not to set this variable, but instead set
+`MENDER_STORAGE_TOTAL_SIZE_MB` and let this variable be set automatically from
+that.
+
 
 #### MENDER_ARTIFACT_EXTRA_ARGS
+
+> Value: <mender artifact arguments> (default: empty)
 
 Flags added to this variable will be used as extra arguments to the
 `mender-artifact` tool when creating the `.mender` artifact. For example:
@@ -55,12 +66,16 @@ The above example builds an artifact with the version 1 format.
 
 #### MENDER_ARTIFACT_NAME
 
+> Value: <name of artifact> (no default, must be set)
+
 The name of the image or update that will be built. This is what the device will
 report that it is running, and different updates must have different names. This
 variable must be defined or the build will fail.
 
 
 #### MENDER_ARTIFACT_SIGNING_KEY
+
+> Value: <key used to sign artifact> (default: empty)
 
 Can be set to a private key which will be used to sign the update artifact. The
 default is empty, which means the artifact won't be signed.
@@ -71,6 +86,8 @@ Mender Artifacts](../../signing-and-verification#signing).
 
 
 #### MENDER_ARTIFACT_VERIFY_KEY
+
+> Value: <key used to verify artifact> (default: empty)
 
 If set, this will add the given public verification key to the client
 configuration, which means that the client will reject updates which are not
@@ -95,6 +112,8 @@ Note that you cannot both use `MENDER_ARTIFACT_VERIFY_KEY` and have
 
 #### MENDER_BOOT_PART
 
+> Value: <block device> (default: 1st partition on `MENDER_STORAGE_DEVICE`)
+
 The partition Mender uses as the boot partition. See [More detailed storage
 configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
 for more information.
@@ -102,12 +121,16 @@ for more information.
 
 #### MENDER_BOOT_PART_FSTYPE
 
+> Value: auto (default) / <filesystem type>
+
 Filesystem type of boot partition. This configuration is only used in fstab.
 Most filesystems can be auto detected, but some can not and hence this variable
 exists to override the auto detection.
 
 
 #### MENDER_BOOT_PART_SIZE_MB
+
+> Value: 16 (default)
 
 The size of the boot partition in the generated `.biosimg`, `.sdimg` or
 `.uefiimg` file. See [Configuring the partition
@@ -117,6 +140,8 @@ for more information.
 
 #### MENDER_DATA_PART
 
+> Value: <block device> (default: 4th partition on `MENDER_STORAGE_DEVICE`)
+
 The partition Mender uses as the persistent data partition. See [More detailed
 storage
 configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
@@ -124,6 +149,8 @@ for more information.
 
 
 #### MENDER_DATA_PART_DIR
+
+> Value: <directory> (default: empty)
 
 <!--AUTOVERSION: "Yocto Project 2.5 % and later"/ignore-->
 !!! This variable and the associated method is obsolete in Yocto Project 2.5 sumo and later.
@@ -161,12 +188,16 @@ MENDER_DATA_PART_DIR = "${DEPLOY_DIR_IMAGE}/persist"
 
 #### MENDER_DATA_PART_FSTYPE
 
+> Value: auto (default) / <filesystem type>
+
 Filesystem type of data partition. This configuration is only used in fstab.
 Most filesystems can be auto detected, but some can not and hence this variable
 exists to override the auto detection.
 
 
 #### MENDER_DATA_PART_SIZE_MB
+
+> Value: 128 (default)
 
 The size of the persistent data partition in the generated `.biosimg`, `.sdimg`
 or `.uefiimg` file. See [Configuring the partition
@@ -175,6 +206,8 @@ for more information.
 
 
 #### MENDER_DEMO_HOST_IP_ADDRESS
+
+> Value: <IP address> (default: empty)
 
 As the name indicates, this variable is only relevant if you are building Mender
 with the `meta-mender-demo` layer. If set to an IP address, this variable sets
@@ -186,25 +219,27 @@ its own DNS server).
 
 #### MENDER_DEVICE_TYPE
 
+> Value: <any string> (default: value of `${MACHINE}`)
+
 A string that defines the type of device this image will be installed on. This
 variable is only relevant when building a complete partitioned image (any suffix
 ending in `img`). Once a device is flashed with this, it will not change, even
 if the device is updated.
 
-It defaults to the value of `${MACHINE}`.
-
 
 #### MENDER_DEVICE_TYPES_COMPATIBLE
+
+> Value: <strings> (default: value of `${MACHINE}`)
 
 A space separated string of device types that determine which types of devices
 this update is suitable for. This complements the `MENDER_DEVICE_TYPE` variable,
 and is only relevant when building a `.mender` update, not when building a
 partitioned image (any suffix ending in `img`).
 
-It defaults to the value of `${MACHINE}`.
-
 
 #### MENDER_FEATURES_DISABLE
+
+> Value: <mender features> (default: empty)
 
 Features appended to this variable will be disabled in the build. See [the
 section on features](../image-configuration/features) for more information.
@@ -212,11 +247,15 @@ section on features](../image-configuration/features) for more information.
 
 #### MENDER_FEATURES_ENABLE
 
+> Value: <mender features> (default: platform dependent)
+
 Features appended to this variable will be enabled in the build. See [the
 section on features](../image-configuration/features) for more information.
 
 
 #### MENDER_GRUB_STORAGE_DEVICE
+
+> Value: <GRUB storage device> (default: empty)
 
 The storage device, as referred to by GRUB (e.g. `hd1`). This variable can be
 used in cases where the Linux kernel and GRUB refer to the same device with
@@ -225,8 +264,13 @@ indexes of storage
 devices](../../../troubleshooting/yocto-project-build#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-index)
 for more information.
 
+If the variable is empty, it is automatically deduced from
+`MENDER_STORAGE_DEVICE`.
+
 
 #### MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET
+
+> Value: <sector number> (default: platform dependent)
 
 Together with `MENDER_IMAGE_BOOTLOADER_FILE`, this sets the offset where the
 bootloader should be placed, counting from the start of the storage medium. The
@@ -236,12 +280,16 @@ non-zero, or the partition table itself would be overwritten.
 
 #### MENDER_IMAGE_BOOTLOADER_FILE
 
+> Value: <bootloader filename> (default: platform dependent)
+
 Together with `MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET`, this specifies a file
 that you would like to write directly into the boot sector, in the intervening
 space between the partition table and the first partition.
 
 
 #### MENDER_IS_ON_MTDID
+
+> Value: <MTD ID> (default: first MTD ID in `MENDER_MTDIDS`)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../image-configuration/features#list-of-features) is enabled. The
@@ -261,6 +309,8 @@ See also [`MENDER_MTDIDS`](#mender-mtdids).
 
 #### MENDER_KERNEL_IMAGETYPE_FORCE
 
+> Value: <kernel image type> (default: value of `KERNEL_IMAGETYPE`)
+
 In certain build scenarios, the detection of kernel image type may not work for
 specific boards. This is usually caused by custom post-processing steps required
 to generate the images bypassing the standard Yocto logic. Setting this variable
@@ -268,6 +318,8 @@ will ensure that Mender packages the proper files in these cases.
 
 
 #### MENDER_MBR_BOOTLOADER_FILE
+
+> Value: <MBR bootloader filename> (default: platform dependent)
 
 Specifies a first stage bootloader to flash to the very first sector of the
 storage device (Master Boot Record, or "MBR"), in the same sector as the
@@ -286,11 +338,15 @@ otherwise the default is empty.
 
 #### MENDER_MBR_BOOTLOADER_LENGTH
 
+> Value: 446 (default)
+
 The number of bytes to flash into the Master Boot Record (MBR) using
 [`MENDER_MBR_BOOTLOADER_FILE`](#mender_mbr_bootloader_file).
 
 
 #### MENDER_MTD_UBI_DEVICE_NAME
+
+> Value: `ubi` (default)
 
 The MTD part name where UBI volumes are stored.
 
@@ -299,6 +355,8 @@ otherwise the default is empty.
 
 
 #### MENDER_MTDIDS
+
+> Value: <mtdids string> (no default, must be set if using UBI)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../image-configuration/features#list-of-features) is enabled, in which
@@ -314,6 +372,8 @@ must be set too.
 
 
 #### MENDER_MTDPARTS
+
+> Value: <mtdparts string> (default calculated from several factors)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../image-configuration/features#list-of-features) is enabled. The
@@ -337,20 +397,26 @@ See also [`MENDER_MTDIDS`](#mender-mtdids).
 
 #### MENDER_NAND_FLASH_PAGE_SIZE
 
+> Value: 2048 (default)
+
 This variable sets the page size, in bytes, of the NAND flash on the device, and
 is used to calculate parameters for the UBI volumes.
 
 
-#### MENDER_PARTITIONING_OVERHEAD_MB
+#### MENDER_PARTITIONING_OVERHEAD_KB
 
-A rough estimate of space lost due to partition alignment, expressed in MB. The
+> Value: <number> (default calculated from several factors)
+
+A rough estimate of space lost due to partition alignment, expressed in KiB. The
 build process will calculate that automatically using a simple heuristic. See
-the definition of `MENDER_PARTITIONING_OVERHEAD_MB` in
+the definition of `MENDER_PARTITIONING_OVERHEAD_KB` in
 [meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank) for
 details on the calculation.
 
 
 #### MENDER_PARTITION_ALIGNMENT
+
+> Value: <number> (default: value of `MENDER_STORAGE_PEB_SIZE`)
 
 Alignment of partitions used when building partitioned images, expressed in
 bytes. Note that this is not always a whole number of KiB, particularly when the
@@ -359,6 +425,8 @@ storage device is a UBI volume.
 
 #### MENDER_ROOTFS_PART_A
 
+> Value: <block device> (default: 2nd partition on `MENDER_STORAGE_DEVICE`)
+
 The partition Mender uses as the first (A) rootfs partition. See [More detailed
 storage
 configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
@@ -366,6 +434,8 @@ for more information.
 
 
 #### MENDER_ROOTFS_PART_A_NAME
+
+> Value: <name> (default: platform dependent)
 
 Alternative name for `MENDER_ROOTFS_PART_A`. Used if you need two different
 references to `MENDER_ROOTFS_PART_A`.
@@ -384,6 +454,8 @@ Defaults to `${MENDER_STORAGE_DEVICE}:rootfsa` when building `.ubimg`.
 
 #### MENDER_ROOTFS_PART_B
 
+> Value: <block device> (default: 3rd partition on `MENDER_STORAGE_DEVICE`)
+
 The partition Mender uses as the second (B) rootfs partition. See [More detailed
 storage
 configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
@@ -391,6 +463,8 @@ for more information.
 
 
 #### MENDER_ROOTFS_PART_B_NAME
+
+> Value: <name> (default: platform dependent)
 
 See [`MENDER_ROOTFS_PART_A_NAME`](#mender_rootfs_part_a_name)
 
@@ -402,17 +476,22 @@ Defaults to `${MENDER_STORAGE_DEVICE}:rootfsb` when building `.ubimg`.
 
 #### MENDER_SERVER_URL
 
-Variable to override the URL of the server for the client to connect to. Default
-value is `https://docker.mender.io`
+> Value: `https://docker.mender.io` (default)
+
+Variable to override the URL of the server for the client to connect to.
 
 
 #### MENDER_STATE_SCRIPTS
+
+> Value: `${S}/mender-state-scripts ${MENDER_STATE_SCRIPTS_DIR}` (default)
 
 Variable to override the location of state scripts. See
 [MENDER_STATE_SCRIPTS_DIR](#mender-state-scripts-dir) for more information.
 
 
 #### MENDER_STATE_SCRIPTS_DIR
+
+> Value: `${B}/mender-state-scripts` (default)
 
 Only usable inside recipes that inherit `mender-state-scripts`. Recipes can put
 executable binaries or scripts into this location to have the scripts be
@@ -433,6 +512,8 @@ The three methods should not be mixed.
 
 #### MENDER_STORAGE_DEVICE
 
+> Value: `/dev/mmcblk0` (default)
+
 The storage device holding all partitions (rootfs, boot, data) used by Mender.
 See [Configuring
 storage](../../../devices/yocto-project/partition-configuration#configuring-storage)
@@ -441,11 +522,15 @@ for more information.
 
 #### MENDER_STORAGE_PEB_SIZE
 
+> Value: 8388608 (default)
+
 Holds the size, in bytes, of the physical erase blocks (PEBs) on the Flash
 device.
 
 
 #### MENDER_STORAGE_TOTAL_SIZE_MB
+
+> Value: 1024 (default)
 
 Total size of the physical storage medium that mender partitioned images will be
 written to, expressed in MiB. The size of rootfs partition will be calculated
@@ -459,6 +544,8 @@ value is `1024`.
 
 #### MENDER_SWAP_PART_SIZE_MB
 
+> Value: 0 (default)
+
 <!--AUTOVERSION: "introduced in the Yocto Project 2.7 (%)"/ignore--> 
 !!! This variable was introduced in the Yocto Project 2.7 (warrior) release.
 
@@ -470,12 +557,17 @@ The size of the optional swap partition in the generated `.biosimg`, `.sdimg` or
 
 #### MENDER_TENANT_TOKEN
 
+> Value: <tenant token string> (default: empty)
+
 Set this variable in `local.conf` in order to make the device recognize the
 organization to which it belongs. This option should always be set, except when
 running a custom Mender server installation with multitenancy module disabled.
 
 
 #### MENDER_UBI_LEB_PEB_BLOCK_OVERHEAD
+
+> Value: <number> (default: 128 for NOR Flash, `${MENDER_NAND_FLASH_PAGE_SIZE} *
+> 2` for NAND Flash)
 
 The overhead that each logical erase block (LEB) of the UBI device adds to the
 physical erase block (PEB), in bytes. In other words, how many bytes are
@@ -484,12 +576,17 @@ physical erase block (PEB), in bytes. In other words, how many bytes are
 
 #### MENDER_UBI_LEB_SIZE
 
+> Value: <number> (default: `${MENDER_STORAGE_PEB_SIZE} -
+> ${MENDER_UBI_LEB_PEB_BLOCK_OVERHEAD}`)
+
 The size of each logical erase block (LEB) on the UBI device, in bytes. Usually
 set automatically from the various `MENDER_UBI_*_OVERHEAD` variables, but can be
 overridden.
 
 
 #### MENDER_UBI_TOTAL_BAD_PEB_OVERHEAD
+
+> Value: <number> (default: 0 for NOR Flash, 20 per PEB block for NAND Flash)
 
 Total overhead on the whole UBI device, in bytes, that is reserved for bad
 physical erase blocks (PEBs). Usually zero for NOR Flash or [a variable
@@ -499,6 +596,8 @@ Flash.
 
 #### MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET
 
+> Value: <number> (default: Value of `MENDER_PARTITION_ALIGNMENT`)
+
 Specifies the offset from the start of the raw block storage where the U-Boot
 environment should be stored, expressed in bytes. The default is equal to
 `MENDER_PARTITION_ALIGNMENT_KB` (converted to bytes), and if the value is
@@ -507,17 +606,23 @@ overridden, it must also be aligned to `MENDER_PARTITION_ALIGNMENT_KB`.
 
 #### MENDER_UBOOT_POST_SETUP_COMMANDS
 
+> Value: <U-Boot command string> (default: empty)
+
 A set of U-Boot commands to be executed at the end of the MENDER_SETUP code in
 the MENDER_BOOTENV.
 
 
 #### MENDER_UBOOT_PRE_SETUP_COMMANDS
 
+> Value: <U-Boot command string> (default: empty)
+
 A set of U-Boot commands to be executed at the beginning of the MENDER_SETUP
 code in the MENDER_BOOTENV.
 
 
 #### MENDER_UBOOT_STORAGE_DEVICE
+
+> Value: <U-Boot storage device> (default: empty)
 
 The storage device, as referred to by U-Boot (e.g. `1`). This variable can be
 used in cases where the Linux kernel and U-Boot refer to the same device with
@@ -526,8 +631,13 @@ indexes of storage
 devices](../../../troubleshooting/yocto-project-build#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-index)
 for more information.
 
+If the variable is empty, it is automatically deduced from
+`MENDER_STORAGE_DEVICE`.
+
 
 #### MENDER_UBOOT_STORAGE_INTERFACE
+
+> Value: <U-Boot storage interface> (default: empty)
 
 The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can
 be used in cases where the Linux kernel and U-Boot refer to the same device with
@@ -536,8 +646,13 @@ indexes of storage
 devices](../../../troubleshooting/yocto-project-build#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-index)
 for more information.
 
+If the variable is empty, it is automatically deduced from
+`MENDER_STORAGE_DEVICE`.
+
 
 #### SYSTEMD_AUTO_ENABLE_pn-mender
+
+> Value: `enable` (default)
 
 Controls whether to run Mender as a systemd service. See [Modes of
 operations](../../../architecture/overview#modes-of-operation) and [Image


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>