### PR TITLE
Fix compatibility with Mac OS X sed version

### DIFF
--- a/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -20,8 +20,8 @@ taxonomy:
 <!-- AUTOMATION: execute=git checkout -b my-production-setup -->
 <!-- AUTOMATION: execute=cd production -->
 <!-- AUTOMATION: execute=cp config/prod.yml.template config/prod.yml -->
-<!-- AUTOMATION: execute=sed -i '0,/set-my-alias-here.com/s/set-my-alias-here.com/s3.docker.mender.io/' config/prod.yml -->
-<!-- AUTOMATION: execute=sed -i 's|DEPLOYMENTS_AWS_URI:.*|DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000|' config/prod.yml -->
+<!-- AUTOMATION: execute=sed -i.bak '0,/set-my-alias-here.com/s/set-my-alias-here.com/s3.docker.mender.io/' config/prod.yml -->
+<!-- AUTOMATION: execute=sed -i.bak 's|DEPLOYMENTS_AWS_URI:.*|DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000|' config/prod.yml -->
 <!-- AUTOMATION: execute=CERT_API_CN=s3.docker.mender.io CERT_STORAGE_CN=s3.docker.mender.io ../keygen -->
 <!-- AUTOMATION: execute=docker volume create --name=mender-artifacts -->
 <!-- AUTOMATION: execute=docker volume create --name=mender-db -->
@@ -151,7 +151,7 @@ connect without a tenant token.
    variable, and make sure its value is set to the **tenant token** that was
    fetched in the previous step
 
-   <!-- AUTOMATION: execute=sed -i -e "s;DEVICEAUTH_DEFAULT_TENANT_TOKEN:;DEVICEAUTH_DEFAULT_TENANT_TOKEN: $TENANT_TOKEN;" config/enterprise.yml -->
+   <!-- AUTOMATION: execute=sed -i.bak -e "s;DEVICEAUTH_DEFAULT_TENANT_TOKEN:;DEVICEAUTH_DEFAULT_TENANT_TOKEN: $TENANT_TOKEN;" config/enterprise.yml -->
 
 4. Start the server again:
    ```bash

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -414,8 +414,8 @@ MINIO_SECRET_KEY_GENERATED=$(pwgen 16 1) && echo $MINIO_SECRET_KEY_GENERATED
 Insert the access and secret keys into `config/prod.yml` with the following commands:
 
 ```bash
-sed -i "s/MINIO_ACCESS_KEY:.*/MINIO_ACCESS_KEY: mender-deployments/g" config/prod.yml
-sed -i "s/MINIO_SECRET_KEY:.*/MINIO_SECRET_KEY: $MINIO_SECRET_KEY_GENERATED/g" config/prod.yml
+sed -i.bak "s/MINIO_ACCESS_KEY:.*/MINIO_ACCESS_KEY: mender-deployments/g" config/prod.yml
+sed -i.bak "s/MINIO_SECRET_KEY:.*/MINIO_SECRET_KEY: $MINIO_SECRET_KEY_GENERATED/g" config/prod.yml
 ```
 
 The updated entry should look similar to this, you can verify with `git diff`:
@@ -445,13 +445,13 @@ Run the following commands to set `DEPLOYMENTS_AWS_AUTH_KEY` and
 and `MINIO_SECRET_KEY`, respectively.
 
 ```bash
-sed -i "s/DEPLOYMENTS_AWS_AUTH_KEY:.*/DEPLOYMENTS_AWS_AUTH_KEY: mender-deployments/g" config/prod.yml
-sed -i "s/DEPLOYMENTS_AWS_AUTH_SECRET:.*/DEPLOYMENTS_AWS_AUTH_SECRET: $MINIO_SECRET_KEY_GENERATED/g" config/prod.yml
+sed -i.bak "s/DEPLOYMENTS_AWS_AUTH_KEY:.*/DEPLOYMENTS_AWS_AUTH_KEY: mender-deployments/g" config/prod.yml
+sed -i.bak "s/DEPLOYMENTS_AWS_AUTH_SECRET:.*/DEPLOYMENTS_AWS_AUTH_SECRET: $MINIO_SECRET_KEY_GENERATED/g" config/prod.yml
 ```
 Also, run the following command so `DEPLOYMENTS_AWS_URI` points to your Storage proxy (including the right port, 9000 by default):
 
 ```bash
-sed -i "s/https:\/\/set-my-alias-here.com/https:\/\/$STORAGE_PROXY_DOMAIN_NAME:9000/g" config/prod.yml
+sed -i.bak "s/https:\/\/set-my-alias-here.com/https:\/\/$STORAGE_PROXY_DOMAIN_NAME:9000/g" config/prod.yml
 ```
 
 After these three commands, the updated entry should look like this (you can again verify with `git diff`):
@@ -476,7 +476,7 @@ Add your storage server's DNS name under the key `networks.mender.aliases` key
 by running the following command:
 
 ```bash
-sed -i "s/set-my-alias-here.com/$STORAGE_PROXY_DOMAIN_NAME/g" config/prod.yml
+sed -i.bak "s/set-my-alias-here.com/$STORAGE_PROXY_DOMAIN_NAME/g" config/prod.yml
 ```
 
 The entry should now look like this:
@@ -507,7 +507,7 @@ Change the placeholder value `my-gateway-dns-name` to a valid hostname, by runni
 the following command:
 
 ```bash
-sed -i "s/my-gateway-dns-name/$API_GATEWAY_DOMAIN_NAME/g" config/prod.yml
+sed -i.bak "s/my-gateway-dns-name/$API_GATEWAY_DOMAIN_NAME/g" config/prod.yml
 ```
 
 The updated entry should look like this:


### PR DESCRIPTION
On Mac OS X, the -i option of the sed command requires an explicit
backup prefix.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>