### PR TITLE
Use unnumbered relative links.

### DIFF
--- a/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
+++ b/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
@@ -104,7 +104,7 @@ When [building a Mender Yocto Project image](../../../artifacts/yocto-project/bu
 | &lt;BOOT&gt; | Store the bootloader.                                   | 16 MB        | `MENDER_BOOT_PART_SIZE_MB`     |
 | `/data`      | Store persistent data, preserved during Mender updates. | 128 MB       | `MENDER_DATA_PART_SIZE_MB`     |
 
-!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md) for more information.
+!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](../../../artifacts/yocto-project/image-configuration/features) for more information.
 
 The value of &lt;BOOT&gt; depends on what features are enabled:
 * If `mender-uboot` is enabled: `/uboot`

--- a/03.Devices/03.Debian-family/docs.md
+++ b/03.Devices/03.Debian-family/docs.md
@@ -1,4 +1,4 @@
----
+--
 title: Debian family
 taxonomy:
     category: docs
@@ -48,7 +48,7 @@ all that you need to integrate a new device with an unsupported OS.
 ### Common customizations
 
 In many cases it will be required to provide a [custom configuration
-file](../../04.Artifacts/15.Debian-family/02.image-configuration/docs.md#configuration-files)
+file](../../artifacts/debian-family/image-configuration#configuration-files)
 to provide details that cannot be determined at probe time. Common configuration
 variables are:
 

--- a/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
+++ b/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
@@ -159,8 +159,8 @@ host machine.
 
 Learning to configure the converted image:
 
-[Image configuration](../02.image-configuration/docs.md)
+[Image configuration](../image-configuration)
 
 Learning about the configuration variables available:
 
-[Configuration variables](../03.variables/docs.md)
+[Configuration variables](../variables)

--- a/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
+++ b/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
@@ -40,7 +40,7 @@ MENDER_ARTIFACT_NAME=release-1 ./mender-convert \
 
 Configuration files are also a means to add customization that might be
 necessary for specific devices or distributions. For more information please
-visit the [Board-integration](../../../03.Devices/03.Debian-family/docs.md)
+visit the [Board-integration](../../../devices/debian-family)
 section.
 
 
@@ -109,7 +109,7 @@ customize the files that are included in the output images.
 
 One example of a overlay-rootfs addition can be found in the
 `rootfs-overlay-demo` directory, which, after running the server setup script
-(see [Using Mender Professional](../01.building-a-mender-debian-image/docs.md#using-mender-professional))
+(see [Using Mender Professional](../building-a-mender-debian-image#using-mender-professional))
 contains:
 
 ```bash
@@ -133,4 +133,4 @@ recommended way of doing it.
 
 Learning about the configuration variables available:
 
-[Configuration variables](../03.variables/docs.md)
+[Configuration variables](../variables)

--- a/04.Artifacts/22.Snapshots/docs.md
+++ b/04.Artifacts/22.Snapshots/docs.md
@@ -57,7 +57,7 @@ mender snapshot dump --compression gzip > /mnt/root-part.ext4.gz
 !!! Don't forget the `.gz` extension in the target filename.
 
 In this case, passing `root-part.ext4` (or `root-part.ext4.gz`) as the 
-file-parameter to [mender-artifact](../../08.Downloads/docs.md#mender-artifact)
+file-parameter to [mender-artifact](../../downloads#mender-artifact)
 produces a deployment ready Mender Artifact:
 ```bash
 mender-artifact write rootfs-image -f /mnt/root-part.ext4 \


### PR DESCRIPTION
This allows the outline order to change without invalidating the links.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>