### PR TITLE
Used absolute urls for 2 links that were building incorrectly in 2.3 …

### DIFF
--- a/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
+++ b/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
@@ -104,7 +104,7 @@ When [building a Mender Yocto Project image](../../../artifacts/yocto-project/bu
 | &lt;BOOT&gt; | Store the bootloader.                                   | 16 MB        | `MENDER_BOOT_PART_SIZE_MB`     |
 | `/data`      | Store persistent data, preserved during Mender updates. | 128 MB       | `MENDER_DATA_PART_SIZE_MB`     |
 
-!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](../../../artifacts/yocto-project/image-configuration/features) for more information.
+!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](/2.3/artifacts/yocto-project/image-configuration/features) for more information.
 
 The value of &lt;BOOT&gt; depends on what features are enabled:
 * If `mender-uboot` is enabled: `/uboot`

--- a/03.Devices/03.Debian-family/docs.md
+++ b/03.Devices/03.Debian-family/docs.md
@@ -48,7 +48,7 @@ all that you need to integrate a new device with an unsupported OS.
 ### Common customizations
 
 In many cases it will be required to provide a 
-[custom configuration file](../../artifacts/debian-family/image-configuration#configuration-files) 
+[custom configuration file](/2.3/artifacts/debian-family/image-configuration#configuration-files) 
 to provide details that cannot be determined at probe time. Common configuration
 variables are:
 


### PR DESCRIPTION
…branch

Changelog: None

Signed-off-by: Michael Clelland <michael.clelland@mender.io>