### PR TITLE
Rephrase System updadates section in Getting Started > Install client

### DIFF
--- a/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
+++ b/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
@@ -21,6 +21,16 @@ For partial updates such as application updates, you can [install Mender on your
 
 The most robust approach is full rootfs system updates. This approach also enables support for partial updates, but there are some device partition layout requirements so the board integration is more effort.
 
-For this, the Mender client needs to be integrated as part of the disk image, which can be done by [building with Yocto](../../../devices/yocto-project) or [converting an existing Debian disk image](../../../devices/debian-family). Check out the board integrations at [Mender Hub](https://hub.mender.io/c/board-integrations) to see if your board has already been integrated. There are over 40 different board and OS combinations, and more being added by the community. If you would like professional assistance supporting your board and OS, please refer to the [commercial device support offering](https://mender.io/support-and-services/board-integration?target=_blank).
+For this, the Mender client needs to be integrated as part of the disk image,
+which can be done by [building with Yocto](../../../devices/yocto-project) or
+[converting an existing Debian disk image](../../../devices/debian-family).
+Check out [the Downloads section](../../../downloads#disk-images) to the disk
+image for your board, or the board integrations at
+[Mender Hub](https://hub.mender.io/c/board-integrations) to see if your board
+has already been integrated. There are over 40 different board and OS
+combinations, and more being added by the community. If you would like
+professional assistance supporting your board and OS, please refer to the
+[commercial device support offering](https://mender.io/support-and-services/board-integration?target=_blank).
 
-If you have a Raspberry Pi 3 or BeagleBone, you can test out system updates by following the tutorial [deploy a system update demo](../deploy-a-system-update-demo).
+If you have a Raspberry Pi 3, you can test out system updates by following the
+tutorial [deploy a system update demo](../deploy-a-system-update-demo).


### PR DESCRIPTION
Add a mention to the Downloads section where to find Mender ready disk
images and remove the BeableBone Black reference for the tutorial (only
RPi 3 atm).