### PR TITLE
[autoversion] Add new parameter mender-convert-client-version

### DIFF
--- a/08.Downloads/docs.md
+++ b/08.Downloads/docs.md
@@ -26,7 +26,7 @@ Mender provides images based on the following distributions:
 |------------------|----------------------|--------------------------------------------------------------------------|
 | Raspberry Pi 3   | Raspbian Buster Lite | [raspbian-buster-lite-mender.img.xz][raspbian-buster-lite-mender.img.xz] |
 
-<!--AUTOVERSION: "mender-%.img.xz"/mender -->
+<!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
 [raspbian-buster-lite-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-02-05-raspbian-buster-lite/arm/2020-02-05-raspbian-buster-lite-mender-master.img.xz
 
 You can find images for other devices in our Mender Hub community forum, see

--- a/autoversion.py
+++ b/autoversion.py
@@ -357,6 +357,10 @@ def main():
         "--mender-convert-version", help="Mender-convert version to update to"
     )
     parser.add_argument(
+        "--mender-convert-client-version",
+        help="Mender client version used in mender-convert to update to",
+    )
+    parser.add_argument(
         "--meta-mender-version",
         help="meta-mender version to update to (usually a branch)",
     )
@@ -385,6 +389,14 @@ def main():
                 'Not replacing "mender-convert" instances, since it was not specified'
             )
             VERSION_CACHE["mender-convert"] = False
+
+        if args.mender_convert_client_version is not None:
+            VERSION_CACHE["mender-convert-client"] = args.mender_convert_client_version
+        else:
+            print(
+                'Not replacing "mender-convert-client" instances, since it was not specified'
+            )
+            VERSION_CACHE["mender-convert-client"] = False
 
         if args.meta_mender_version is not None:
             if args.poky_version is None:


### PR DESCRIPTION
To let the release responsible update this independently of mender
client tagging.