### PR TITLE
2.3.x-cherry-pick. replace mentions of 'Mender Professional' with 'hosted Mender'

### DIFF
--- a/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
+++ b/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
@@ -15,12 +15,11 @@ To follow this guide, you will need the following:
 * An 8 GB or larger microSD card.
 * A Raspberry Pi [universal power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply?target=_blank) or a micro USB cable.
 * Internet connectivity for your Raspberry Pi (either Ethernet or wifi available)
-* A Mender Professional account to access the [hosted server](https://hosted.mender.io).
+* A [hosted Mender](https://hosted.mender.io?target=_blank) account
 
+### Get a hosted Mender account
 
-### Get a Mender Professional account
-
-Get a Mender account by [signing up here](https://mender.io/signup?target=_blank).
+Get a hosted Mender account by [signing up here](https://mender.io/signup?target=_blank).
 
 !!! We provide $120 free credit for you to use for evaluation. You can cancel at any time without incurring a cost while your usage remains under $120.
 
@@ -49,7 +48,7 @@ Boot the device with the newly flashed SD card, then:
 Your first application deployment is easy with 5 short steps:
 
 
-### Step 1 - SSH into your Raspberry Pi device 
+### Step 1 - SSH into your Raspberry Pi device
 
 SSH into your device:
 
@@ -67,10 +66,9 @@ pi@raspberrypi:~ $
 
 Keep this terminal open as we will shortly use it to install the Mender client.
 
+### Step 2 - Login to hosted Mender
 
-### Step 2 - Login to Mender Professional
-
-Login to your [Mender Professional account](https://hosted.mender.io/ui/#/login?target=_blank), and when on the main page for the first time new users will get a tutorial in the Mender web GUI.
+Login to your [hosted Mender](https://hosted.mender.io?target=_blank) account, and when on the main page for the first time new users will get a tutorial in the Mender web GUI.
 
 Go to the **Dashboard** tab and click on **Connect a device**. Then Click on **Connect my own device**. Select your Raspberry Pi model and click **Next**. You should see a screen similar to the one below. Keep this open as we will use it in the next step.
 
@@ -92,7 +90,7 @@ Once the client has started, the Mender client will attempt to connect to the se
 ![accepting the device](image_1.png)
 
 
-### Step 4 - Create a Deployment 
+### Step 4 - Create a Deployment
 
 There is already a mender-demo Artifact available under *Releases* the first time you use Mender. It contains a small web server your device can run.
 
@@ -157,7 +155,7 @@ To read more about system snapshots see the documentation on [Artifact from syst
 
 ## Running Mender on-premise
 
-For the easiest and fastest experience, we recommend using the hosted version of Mender for your first evaluation. You can also try the same deployment above using the on-premise version by installing a Mender demo server on a host machine, however this will take you a bit longer. You will need to install [Docker Engine](https://docs.docker.com/install/linux/docker-ce/ubuntu?target=_blank) (on device) and [Docker Compose](https://docs.docker.com/compose/install?target=_blank) in your deployment environment. 
+For the easiest and fastest experience, we recommend using the hosted version of Mender for your first evaluation. You can also try the same deployment above using the on-premise version by installing a Mender demo server on a host machine, however this will take you a bit longer. You will need to install [Docker Engine](https://docs.docker.com/install/linux/docker-ce/ubuntu?target=_blank) (on device) and [Docker Compose](https://docs.docker.com/compose/install?target=_blank) in your deployment environment.
 
 Next, you will need to download the Mender integration environment in the working directory:
 
@@ -178,12 +176,12 @@ Note that the demo up script starts the Mender services, adds a demo user with t
 
 After you log into the UI on the localhost you can follow steps 1 through 6 listed above.
 
-## Have any questions? 
+## Have any questions?
 
 If you need help and have any questions:
 
 * Visit our community forum at [Mender Hub](https://hub.mender.io/) dedicated to OTA updates where you can discuss any issues you may be having. Share and learn from other Mender users.
 
-* Learn more about Mender by reading the rest of the documentation. 
+* Learn more about Mender by reading the rest of the documentation.
 
 [Compare plans](https://mender.io/products/pricing?target=_blank) and choose a plan that fits your requirements.

--- a/01.Getting-started/02.On-premise-installation/docs.md
+++ b/01.Getting-started/02.On-premise-installation/docs.md
@@ -10,6 +10,6 @@ For a high-level introduction to Mender and its architecture, we recommend readi
 
 This section of the documentation contains tutorials to help you set up a demo server and deploy your first update with Mender. Going from a fresh system to completing your first deployment with Mender, including server setup, should take **less than 30 minutes**.
 
-! Do not follow this getting started documentation if you are using [Mender Professional](https://mender.io/products/mender-professional?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
+! Do not follow this getting started documentation if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
 
 To begin on-premise installation, first take a look at the [requirements](requirements).

--- a/03.Devices/10.Update-Modules/docs.md
+++ b/03.Devices/10.Update-Modules/docs.md
@@ -43,7 +43,7 @@ Refer to [further reading](#further-reading) for more details.
 
 You will need a Mender server if you are using [managed mode](../../architecture/overview#modes-of-operation).
 
-For easy setup, use [Mender Professional](https://mender.io/products/mender-professional?target=_blank) or the [on-premise demo server](../../getting-started/on-premise-installation).
+For easy setup, use [hosted Mender](https://hosted.mender.io?target=_blank) or the [on-premise demo server](../../getting-started/on-premise-installation).
 
 ### Device with Mender client
 

--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -44,7 +44,7 @@ adjustment you might need to make before building.
 Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is
 already integrated.
 If you encounter any issues and want to save time, you can use
-the [Mender professional services to integrate your board](https://mender.io/support-and-services/board-integration?target=_blank).
+the [Mender Consulting services to integrate your board](https://mender.io/support-and-services/board-integration?target=_blank).
 
 
 ### Correct clock on device
@@ -103,7 +103,7 @@ MENDER_ARTIFACT_NAME = "release-1"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
-# Build for Mender Professional
+# Build for hosted Mender
 #
 # To get your tenant token:
 #    - log in to https://hosted.mender.io
@@ -142,7 +142,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 !!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
 
-!!! If you are building for **Mender Professional**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
+!!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
 !!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
 
@@ -228,7 +228,7 @@ VIRTUAL-RUNTIME_initscripts = ""
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
-# Build for Mender Professional
+# Build for hosted Mender
 #
 # To get your tenant token:
 #    - log in to https://hosted.mender.io
@@ -267,7 +267,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 !!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
 
-!!! If you are building for **Mender Professional**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
+!!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
 !!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
 

--- a/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
+++ b/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
@@ -116,13 +116,13 @@ dependencies for `mender-convert`:
 ## Configure the Mender client server configuration
 
 The easiest, and most straight-forward way, is to integrate the client with
-Mender Professional:
+[hosted Mender](https://hosted.mender.io?target=_blank):
 
-#### Using [Mender Professional](https://mender.io/products/mender-professional)
+#### Using [hosted Mender](https://hosted.mender.io?target=_blank)
 ```bash
 ./scripts/bootstrap-rootfs-overlay-hosted-server.sh \
     --output-dir ${PWD}/rootfs_overlay_demo \
-    --tenant-token "Paste token from Mender Professional"
+    --tenant-token "Paste token from https://hosted.mender.io/ui/#/settings/my-organization"
 ```
 
 However, there are additional scripts in the `scripts/` directory to enable

--- a/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
+++ b/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
@@ -109,7 +109,7 @@ customize the files that are included in the output images.
 
 One example of a overlay-rootfs addition can be found in the
 `rootfs-overlay-demo` directory, which, after running the server setup script
-(see [Using Mender Professional](../building-a-mender-debian-image#using-mender-professional))
+(see [Using hosted Mender](../building-a-mender-debian-image#using-mender-professional))
 contains:
 
 ```bash

--- a/04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md
@@ -37,9 +37,9 @@ MENDER_TENANT_TOKEN='<YOUR-MENDER-TENANT-TOKEN>'
 mender-artifact modify artifact.mender --server-uri "$MENDER_SERVER_URL" --tenant-token "$MENDER_TENANT_TOKEN"
 ```
 
-!!! The `--tenant-token` parameter is only needed for multi-tenant Mender servers like [Mender Professional](https://mender.io/products/mender-professional) or [Mender Enterprise](https://mender.io/products/mender-enterprise). For Mender Professional you can find it under the [My organization](https://hosted.mender.io/ui/?target=_blank#/settings/my-organization) tab at [hosted.mender.io](https://hosted.mender.io).
+!!! The `--tenant-token` parameter is only needed for multi-tenant Mender servers like [hosted Mender](https://hosted.mender.io?target=_blank). You can find it under the [My organization](https://hosted.mender.io/ui/?target=_blank#/settings/my-organization) tab.
 
-If you are using a self-signed certificate for the Mender server (not needed for hosted.mender.io), you can
+If you are using a self-signed certificate for the Mender server (not needed for hosted Mender), you can
 include it in the Artifact using the `--server-cert` parameter:
 
 ```bash

--- a/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
+++ b/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
@@ -58,7 +58,7 @@ system based on Yocto configuration and rarely needs to be modified.
 An array of json objects on the form
 `[{"ServerURL": "https://mender-server.com"},
 {"ServerURL": "https://mender-server2.com"}, ...]`, where `ServerURL` has the
-same interpretation as the root [`ServerURL` attribute](#ServerURL). 
+same interpretation as the root [`ServerURL` attribute](#ServerURL).
 If `Servers` entry is specified, the configuration cannot contain an additional
 `ServerURL` entry in the top level of the json configuration. Upon an unserved
 request (4XX/5XX-response codes) the client will attempt the next server on the
@@ -149,7 +149,7 @@ See also the section about [state scripts](../../../artifacts/state-scripts).
 #### TenantToken
 
 A token which identifies which tenant a device belongs to. This is only relevant
-if using Mender Professional.
+if using a multi-tenant environment such as [hosted Mender](https://hosted.mender.io?target=_blank).
 
 #### UpdateLogPath
 

--- a/05.Client-configuration/06.Installing/docs.md
+++ b/05.Client-configuration/06.Installing/docs.md
@@ -57,7 +57,7 @@ input is desired.
 The setup is different depending on your server configuration and the most common cases
 are shown below. Use `mender setup --help` to learn about all configuration options.
 
-- Connecting to [hosted.mender.io](https://hosted.mender.io) using demo settings
+- Connecting to [hosted Mender](https://hosted.mender.io) using demo settings
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
 ```bash

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -11,7 +11,7 @@ taxonomy:
 <!-- AUTOMATION: execute=ORIG_DIR=$PWD; function cleanup() { set +e; cd $ORIG_DIR/mender-server/production; ./run down -v; docker volume rm mender-artifacts mender-db mender-elasticsearch-db mender-redis-db; cd $ORIG_DIR; rm -rf mender-server; } -->
 <!-- AUTOMATION: execute=trap cleanup EXIT -->
 
-!!! You can save time by using [Mender Professional](https://mender.io/products/mender-professional?target=_blank); a secure Mender server ready to use, maintained by the Mender developers.
+!!! You can save time by using [hosted Mender](https://hosted.mender.io?target=_blank), a secure Mender server ready to use, maintained by the Mender developers.
 
 This is a step by step guide for deploying the Mender Server for production
 environments, and will cover relevant security and reliability aspects of Mender
@@ -869,7 +869,7 @@ Below you can see typical output for the Enterprise server. The Open Source
 server will be similar, but will have fewer services running.
 
 > ```
->                         Name                                      Command               State           Ports          
+>                         Name                                      Command               State           Ports
 > ----------------------------------------------------------------------------------------------------------------------
 > menderproduction_mender-api-gateway_1                  /entrypoint.sh                   Up      0.0.0.0:443->443/tcp
 > menderproduction_mender-conductor_1                    /srv/start_conductor.sh          Up      8080/tcp, 8090/tcp

--- a/07.Administration/chapter.md
+++ b/07.Administration/chapter.md
@@ -9,4 +9,4 @@ taxonomy:
 # Administration
 
 Configuration and administration of Mender services.
-Use [Mender Professional](https://mender.io/products/mender-professional?target=_blank) to save time setting up and maintaining the Mender server.
+Use [hosted Mender](https://hosted.mender.io?target=_blank) to save time setting up and maintaining the Mender server.

--- a/201.Troubleshooting/03.Mender-Client/docs.md
+++ b/201.Troubleshooting/03.Mender-Client/docs.md
@@ -100,7 +100,7 @@ The message shows that the Mender client rejects the Mender server's certificate
 authority (CA).
 
 If your server is using a certificate that is signed by an official Certificate Authority, then you likely
-need to update your client's root certificate store. For example, [Mender Professional](https://mender.io/products/mender-professional?target=_blank)
+need to update your client's root certificate store. For example, [hosted Mender](https://hosted.mender.io?target=_blank)
 uses an official CA so the only reason your client would reject this is if it does not have updated root certificates
 in its system store.
 


### PR DESCRIPTION
As we have now introduced several plans on 'hosted.mender.io', lets
use a more generic reference.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
(cherry picked from commit 3cc93a8bcebe8d3f8da18e72735d6567eb59c5c9)

 Conflicts:
	01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md