### PR TITLE
2.2.x-cherry-pick: replace mentions of 'Mender Professional' with 'hosted Mender'

### DIFF
--- a/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
+++ b/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
@@ -14,13 +14,13 @@ To follow this guide, you will need the following:
 * A [Raspberry Pi 3 Model B](https://www.raspberrypi.org/products/raspberry-pi-3-model-b?target=_blank) or [B+](https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus?target=_blank), or a [Raspberry Pi 4 Model B](https://www.raspberrypi.org/products/raspberry-pi-4-model-b?target=_blank).
 * An 8 GB or larger microSD card.
 * A Raspberry Pi [universal power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply?target=_blank) or a micro USB cable.
-* Internet connectivity for your Raspberry Pi (either Ethernet or wifi configured)
-* A Mender Professional account to access the hosted server.
+* Internet connectivity for your Raspberry Pi (either Ethernet or wifi available)
+* A [hosted Mender](https://hosted.mender.io?target=_blank) account.
 
 
-### Get a Mender Professional account
+### Get a hosted Mender account
 
-Get a Mender account by [signing up here](https://mender.io/signup?target=_blank).
+Get a hosted Mender account by [signing up here](https://mender.io/signup?target=_blank).
 
 !!! We provide $120 free credit for you to use for evaluation. You can cancel at any time without incurring a cost while your usage remains under $120.
 
@@ -29,7 +29,7 @@ You can also try it on-premise, but it requires more effort getting setup. See t
 
 ### Prepare your device
 
-Make sure your Raspberry Pi has Raspbian OS installed. 
+Make sure your Raspberry Pi has Raspbian OS installed.
 
 * Download Raspbian OS image from [here](https://www.raspberrypi.org/downloads/raspbian?target=_blank).
 * [Follow their steps](https://www.raspberrypi.org/documentation/installation/installing-images?target=_blank) to install the OS image to your device and [enable SSH](https://www.raspberrypi.org/documentation/remote-access/ssh/README.md?target=_blank) on your device. This should take less than 15 minutes.
@@ -37,7 +37,7 @@ Make sure your Raspberry Pi has Raspbian OS installed.
 Your first deployment is easy with 5 short steps:
 
 
-### Step 1 - SSH into your Raspberry Pi device 
+### Step 1 - SSH into your Raspberry Pi device
 
 SSH into your device:
 
@@ -55,10 +55,9 @@ pi@raspberrypi:~ $
 
 Keep this terminal open as we will shortly use it to install the Mender client.
 
+### Step 2 - Login to hosted Mender
 
-### Step 2 - Login to Mender Professional
-
-Login to your [Mender Professional account](https://hosted.mender.io/ui/#/login?target=_blank), and when on the main page for the first time new users will get a tutorial in the Mender web GUI.
+Login to your [hosted Mender](https://hosted.mender.io?target=_blank) account, and when on the main page for the first time new users will get a tutorial in the Mender web GUI.
 
 Go to the **Dashboard** tab and click on **Connect a device**. Then Click on **Connect my own device**. Select your Raspberry Pi model and click **Next**. You should see a screen similar to the below. Keep this open as we will use it in the next step.
 
@@ -78,7 +77,7 @@ Once the client has started, the Mender client will attempt to connect to the se
 ![image alt text](image_1.png)
 
 
-### Step 4 - Create a Deployment 
+### Step 4 - Create a Deployment
 
 There is already a mender-demo Artifact available under *Releases* the first time you use Mender. It contains a small web server your device can run.
 
@@ -105,7 +104,7 @@ Simply follow the tooltips to update your newly deployed application!
 
 ## Running Mender on-premise
 
-For the easiest and fastest experience, we recommend using the hosted version of Mender for your first evaluation. You can also try the same deployment above using the on-premise version by installing a Mender demo server on a host machine, however this will take you a bit longer. You will need to install [Docker Engine](https://docs.docker.com/install/linux/docker-ce/ubuntu?target=_blank) (on device) and [Docker Compose](https://docs.docker.com/compose/install?target=_blank) in your deployment environment. 
+For the easiest and fastest experience, we recommend using the hosted version of Mender for your first evaluation. You can also try the same deployment above using the on-premise version by installing a Mender demo server on a host machine, however this will take you a bit longer. You will need to install [Docker Engine](https://docs.docker.com/install/linux/docker-ce/ubuntu?target=_blank) (on device) and [Docker Compose](https://docs.docker.com/compose/install?target=_blank) in your deployment environment.
 
 Next, you will need to download the Mender integration environment in the working directory:
 
@@ -124,15 +123,15 @@ And finally fire up the demo server environment with:
 
 Note that the demo up script starts the Mender services, adds a demo user with the username mender-demo@example.com, and assigns a random password in which you can change after you log in to the Mender web UI. The Mender UI can be found on [https://localhost](https://localhost?target=_blank).
 
-After you log into the UI on the ‘localhost’ you can follow steps 1 through 5 listed above. 
+After you log into the UI on the ‘localhost’ you can follow steps 1 through 5 listed above.
 
-## Have any questions? 
+## Have any questions?
 
 If you need help and have any questions:
 
 * Visit our community forum at [Mender Hub](https://hub.mender.io/) dedicated to OTA updates where you can discuss any issues you may be having. Share and learn from other Mender users.
 
-* Learn more about Mender by reading the rest of the documentation. 
+* Learn more about Mender by reading the rest of the documentation.
 
-[Compare plans](https://mender.io/products/pricing?target=_blank) and choose a plan that fits your requirements. 
+[Compare plans](https://mender.io/products/pricing?target=_blank) and choose a plan that fits your requirements.
 

--- a/01.Getting-started/02.On-premise-installation/05.Download-test-images/docs.md
+++ b/01.Getting-started/02.On-premise-installation/05.Download-test-images/docs.md
@@ -10,13 +10,13 @@ Pre-built demo images for a set of reference boards are provided below, so you d
 
 !!! Steps to build Artifacts for other device types and with custom software are provided at [Building a Mender Yocto Project image](../../../artifacts/yocto-project/building), however we recommend using the demo images first.
 
-! Do not use these images if you are using [Mender Professional](https://mender.io/products/mender-professional?target=_blank). Instead, use the images customized for your account from [the Help section](https://hosted.mender.io/ui/#/help/connecting-devices/demo-artifacts?target=_blank).
+! Do not use these images if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, use the images customized for your account from [the Help section](https://hosted.mender.io/ui/#/help/connecting-devices/demo-artifacts?target=_blank).
 
 There are two types of images:
 * Disk images (`*.sdimg`): Used to provision the device storage for devices without Mender running already.
 * Mender Artifacts (`*.mender`): Upload them to the Mender server in order to deploy new root file systems to devices already running Mender and registered with the server.
 
-Mender will skip deployments if the Artifact installed is the same as the one being deployed. Therefore, two Artifacts are provided for each device type so that you can do several deployments 
+Mender will skip deployments if the Artifact installed is the same as the one being deployed. Therefore, two Artifacts are provided for each device type so that you can do several deployments
 by deploying back and forth between these two Artifacts.
 
 Download the Artifacts for your desired device types below:

--- a/01.Getting-started/02.On-premise-installation/docs.md
+++ b/01.Getting-started/02.On-premise-installation/docs.md
@@ -10,6 +10,6 @@ For a high-level introduction to Mender and its architecture, we recommend readi
 
 This section of the documentation contains tutorials to help you set up a demo server and deploy your first update with Mender. Going from a fresh system to completing your first deployment with Mender, including server setup, should take **less than 30 minutes**.
 
-! Do not follow this getting started documentation if you are using [Mender Professional](https://mender.io/products/mender-professional?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
+! Do not follow this getting started documentation if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
 
 To begin on-premise installation, first take a look at the [requirements](requirements).

--- a/03.Devices/10.Update-Modules/docs.md
+++ b/03.Devices/10.Update-Modules/docs.md
@@ -43,7 +43,7 @@ Refer to [further reading](#further-reading) for more details.
 
 You will need a Mender server if you are using [managed mode](../../architecture/overview#modes-of-operation).
 
-For easy setup, use [Mender Professional](https://mender.io/products/mender-professional?target=_blank) or the [on-premise demo server](../../getting-started/on-premise-installation).
+For easy setup, use [hosted Mender](https://hosted.mender.io?target=_blank) or the [on-premise demo server](../../getting-started/on-premise-installation).
 
 ### Device with Mender client
 

--- a/04.Artifacts/01.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/01.Yocto-project/01.Building/docs.md
@@ -44,7 +44,7 @@ adjustment you might need to make before building.
 Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is
 already integrated.
 If you encounter any issues and want to save time, you can use
-the [Mender professional services to integrate your board](https://mender.io/support-and-services/board-integration?target=_blank).
+the [Mender Consulting services to integrate your board](https://mender.io/support-and-services/board-integration?target=_blank).
 
 
 ### Correct clock on device
@@ -103,7 +103,7 @@ MENDER_ARTIFACT_NAME = "release-1"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
-# Build for Mender Professional
+# Build for hosted Mender
 #
 # To get your tenant token:
 #    - log in to https://hosted.mender.io
@@ -142,7 +142,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 !!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
 
-!!! If you are building for **Mender Professional**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
+!!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
 !!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
 
@@ -225,7 +225,7 @@ VIRTUAL-RUNTIME_initscripts = ""
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
-# Build for Mender Professional
+# Build for hosted Mender
 #
 # To get your tenant token:
 #    - log in to https://hosted.mender.io
@@ -264,7 +264,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 !!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
 
-!!! If you are building for **Mender Professional**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
+!!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
 !!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
 

--- a/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
@@ -37,9 +37,9 @@ MENDER_TENANT_TOKEN='<YOUR-MENDER-TENANT-TOKEN>'
 mender-artifact modify artifact.mender --server-uri "$MENDER_SERVER_URL" --tenant-token "$MENDER_TENANT_TOKEN"
 ```
 
-!!! The `--tenant-token` parameter is only needed for multi-tenant Mender servers like Mender Professional. In Mender Professional you can find it under [My organization](https://hosted.mender.io/ui/?target=_blank#/settings/my-organization).
+!!! The `--tenant-token` parameter is only needed for multi-tenant Mender servers like [hosted Mender](https://hosted.mender.io?target=_blank). You can find it under the [My organization](https://hosted.mender.io/ui/?target=_blank#/settings/my-organization) tab.
 
-If you are using a self-signed certificate for the Mender server (not needed for Mender Professional), you can
+If you are using a self-signed certificate for the Mender server (not needed for hosted Mender), you can
 include it in the Artifact using the `--server-cert` parameter:
 
 ```bash

--- a/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
+++ b/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
@@ -149,7 +149,7 @@ See also the section about [state scripts](../../../artifacts/state-scripts).
 #### TenantToken
 
 A token which identifies which tenant a device belongs to. This is only relevant
-if using Mender Professional.
+if using a multi-tenant environment such as [hosted Mender](https://hosted.mender.io?target=_blank).
 
 #### UpdateLogPath
 

--- a/05.Client-configuration/06.Installing/docs.md
+++ b/05.Client-configuration/06.Installing/docs.md
@@ -53,9 +53,9 @@ Copy the demo configuration file:
 sudo cp /etc/mender/mender.conf.demo /etc/mender/mender.conf
 ```
 
-##### Configuration for Mender Professional server
+##### Configuration for hosted Mender server
 
-To configure the Mender client for Mender Professional, you need to edit `/etc/mender/mender.conf` and insert your Tenant Token
+To configure the Mender client for [hosted Mender](https://hosted.mender.io?target=_blank), you need to edit `/etc/mender/mender.conf` and insert your Tenant Token
 where it says "Paste your Hosted Mender token here".
 
 Set the `TENANT_TOKEN` variable:

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -11,7 +11,7 @@ taxonomy:
 <!-- AUTOMATION: execute=ORIG_DIR=$PWD; function cleanup() { set +e; cd $ORIG_DIR/mender-server/production; ./run down -v; docker volume rm mender-artifacts mender-db mender-elasticsearch-db mender-redis-db; cd $ORIG_DIR; rm -rf mender-server; } -->
 <!-- AUTOMATION: execute=trap cleanup EXIT -->
 
-!!! You can save time by using [Mender Professional](https://mender.io/products/mender-professional?target=_blank); a secure Mender server ready to use, maintained by the Mender developers.
+!!! You can save time by using [hosted Mender](https://hosted.mender.io?target=_blank), a secure Mender server ready to use, maintained by the Mender developers.
 
 This is a step by step guide for deploying the Mender Server for production
 environments, and will cover relevant security and reliability aspects of Mender
@@ -867,7 +867,7 @@ Below you can see typical output for the Enterprise server. The Open Source
 server will be similar, but will have fewer services running.
 
 > ```
->                         Name                                      Command               State           Ports          
+>                         Name                                      Command               State           Ports
 > ----------------------------------------------------------------------------------------------------------------------
 > menderproduction_mender-api-gateway_1                  /entrypoint.sh                   Up      0.0.0.0:443->443/tcp
 > menderproduction_mender-conductor_1                    /srv/start_conductor.sh          Up      8080/tcp, 8090/tcp

--- a/07.Administration/chapter.md
+++ b/07.Administration/chapter.md
@@ -9,4 +9,4 @@ taxonomy:
 # Administration
 
 Configuration and administration of Mender services.
-Use [Mender Professional](https://mender.io/products/mender-professional?target=_blank) to save time setting up and maintaining the Mender server.
+Use [hosted Mender](https://hosted.mender.io?target=_blank) to save time setting up and maintaining the Mender server.

--- a/201.Troubleshooting/03.Mender-Client/docs.md
+++ b/201.Troubleshooting/03.Mender-Client/docs.md
@@ -100,7 +100,7 @@ The message shows that the Mender client rejects the Mender server's certificate
 authority (CA).
 
 If your server is using a certificate that is signed by an official Certificate Authority, then you likely
-need to update your client's root certificate store. For example, [Mender Professional](https://mender.io/products/mender-professional?target=_blank)
+need to update your client's root certificate store. For example, [hosted Mender](https://hosted.mender.io?target=_blank)
 uses an official CA so the only reason your client would reject this is if it does not have updated root certificates
 in its system store.
 


### PR DESCRIPTION
As we have now introduced several plans on 'hosted.mender.io', lets
use a more generic reference.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
(cherry picked from commit 3cc93a8bcebe8d3f8da18e72735d6567eb59c5c9)

 Conflicts:
	01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
        04.Artifacts/02.Debian-family/docs.md
	04.Artifacts/05.Modifying-a-Mender-Artifact/docs.md
	04.Artifacts/15.Debian-family/02.image-configuration/docs.md
	05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
	05.Client-configuration/06.Installing/docs.md