### PR TITLE
Fix and beautify pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 stages:
   - test
-  - build
   - trigger
 
 include:
@@ -9,8 +8,8 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-python3-format.yml'
 
-build:
-  stage: build
+test:
+  stage: test
   image: tiangolo/docker-with-compose
   services:
     - docker:19.03.5-dind
@@ -22,7 +21,7 @@ build:
     - ./test_autoversion.py
     - ./autoversion.py --check
     - env TEST_OPEN_SOURCE=1 ./test_docs.py 07.Administration/02.Production-installation/docs.md
-    - if [ -n "$REGISTRY_MENDER_IO_PASSWORD" ]; then 
+    - if [ -n "$REGISTRY_MENDER_IO_PASSWORD" ]; then
         docker login -u ntadm_menderci -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io;
       fi
     - if [ -n "$REGISTRY_MENDER_IO_PASSWORD" ]; then

--- a/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -72,19 +72,19 @@ docker volume create --name=mender-redis-db-backup
 Clone the contents of the original volumes to the backup volumes:
 
 ```bash
-docker run --rm -ti -v mender-artifacts:/from        -v mender-artifacts-backup:/to        alpine cp -a /from /to
-docker run --rm -ti -v mender-db:/from               -v mender-db-backup:/to               alpine cp -a /from /to
-docker run --rm -ti -v mender-elasticsearch-db:/from -v mender-elasticsearch-db-backup:/to alpine cp -a /from /to
-docker run --rm -ti -v mender-redis-db:/from         -v mender-redis-db-backup:/to         alpine cp -a /from /to
+docker run --rm -v mender-artifacts:/from        -v mender-artifacts-backup:/to        alpine cp -a /from /to
+docker run --rm -v mender-db:/from               -v mender-db-backup:/to               alpine cp -a /from /to
+docker run --rm -v mender-elasticsearch-db:/from -v mender-elasticsearch-db-backup:/to alpine cp -a /from /to
+docker run --rm -v mender-redis-db:/from         -v mender-redis-db-backup:/to         alpine cp -a /from /to
 ```
 
 This backup can later be restored with this command:
 
 ```bash
-docker run --rm -ti -v mender-artifacts:/to        -v mender-artifacts-backup:/from        alpine cp -a /from /to
-docker run --rm -ti -v mender-db:/to               -v mender-db-backup:/from               alpine cp -a /from /to
-docker run --rm -ti -v mender-elasticsearch-db:/to -v mender-elasticsearch-db-backup:/from alpine cp -a /from /to
-docker run --rm -ti -v mender-redis-db:/to         -v mender-redis-db-backup:/from         alpine cp -a /from /to
+docker run --rm -v mender-artifacts:/to        -v mender-artifacts-backup:/from        alpine cp -a /from /to
+docker run --rm -v mender-db:/to               -v mender-db-backup:/from               alpine cp -a /from /to
+docker run --rm -v mender-elasticsearch-db:/to -v mender-elasticsearch-db-backup:/from alpine cp -a /from /to
+docker run --rm -v mender-redis-db:/to         -v mender-redis-db-backup:/from         alpine cp -a /from /to
 ```
 
 You can try the above command immediately, it will just restore the already

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -739,6 +739,7 @@ cannot be turned off. Below follows a guide for setting up a single
 organization. For additional information on administering organizations, see the
 help screen from:
 
+<!--AUTOMATION: ignore -->
 ```bash
 ./run exec mender-tenantadm /usr/bin/tenantadm --help
 ```


### PR DESCRIPTION
- [test_docs] Changes in production docs commands to fix CI build
Ignore the tenantadm --help command (not very important) and remove -it
flags from docker run commands.
These changes fix "the input device is not a TTY" errors seen in the CI
pipeline.

- [pipeline] Move test job to test stage
Minor nitpick, but let's explicitly state that this repo does not
"build" anything.