### PR TITLE
Specify full package versions using PREFERRED_VERSION_pn.

### DIFF
--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -75,10 +75,9 @@ support Mender.
 
 !!! The configuration from [Mender Hub](https://hub.mender.io?target=_blank) will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../../architecture/overview#modes-of-operation). See the [section on customizations](../image-configuration#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
 
-
 The following settings will be present in the default `conf/local.conf` after running the steps from [Mender Hub](https://hub.mender.io?target=_blank). These are likely to need customization for your setup.
 
-<!--AUTOVERSION: "Mender %"/mender "releases % and older"/ignore-->
+<!--AUTOVERSION: "Mender %"/mender "releases % and older"/ignore "PREFERRED_VERSION_pn-mender = \"%\""/mender "PREFERRED_VERSION_pn-mender-artifact = \"%\""/mender-artifact "PREFERRED_VERSION_pn-mender-artifact-native = \"%\""/mender-artifact-->
 ```bash
 # The name of the disk image and Artifact that will be built.
 # This is what the device will report that it is running, and different updates must have different names
@@ -97,9 +96,9 @@ MENDER_ARTIFACT_NAME = "release-1"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "1.1.%"
-# PREFERRED_VERSION_pn-mender-artifact = "2.0.%"
-# PREFERRED_VERSION_pn-mender-artifact-native = "2.0.%"
+# PREFERRED_VERSION_pn-mender = "2.1.2"
+# PREFERRED_VERSION_pn-mender-artifact = "3.2.1"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.2.1"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
@@ -189,7 +188,7 @@ bitbake-layers add-layer ../meta-mender/meta-mender-demo
 
 Add these lines to the start of your `conf/local.conf`:
 
-<!--AUTOVERSION: "Mender %"/mender "releases % and older"/ignore-->
+<!--AUTOVERSION: "Mender %"/mender "releases % and older"/ignore "PREFERRED_VERSION_pn-mender = \"%\""/mender "PREFERRED_VERSION_pn-mender-artifact = \"%\""/mender-artifact "PREFERRED_VERSION_pn-mender-artifact-native = \"%\""/mender-artifact-->
 ```bash
 # The name of the disk image and Artifact that will be built.
 # This is what the device will report that it is running, and different updates must have different names
@@ -214,9 +213,9 @@ MACHINE = "<YOUR-MACHINE>"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "1.1.%"
-# PREFERRED_VERSION_pn-mender-artifact = "2.0.%"
-# PREFERRED_VERSION_pn-mender-artifact-native = "2.0.%"
+# PREFERRED_VERSION_pn-mender = "2.1.2"
+# PREFERRED_VERSION_pn-mender-artifact = "3.2.1"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.2.1"
 
 # The following settings to enable systemd are needed for all Yocto
 # releases sumo and older.  Newer releases have these settings conditionally


### PR DESCRIPTION
Since we use DEFAULT_PREFERENCE settings to ensure that updates which break
backward compatibility, a full explicit version is needed instead of
relying on wildcards.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>