### PR TITLE
Remove section describing device limit configuration

### DIFF
--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -534,25 +534,6 @@ you can supply a whitespace-separated list of hostnames as follows:
 ```
 
 
-#### Device Authentication Service (optional)
-
-It is possible to set a default limit on the number of devices each organization (created below) can accept.
-If you do not need this, you can skip this configuration.
-
-If you would like to set a limit, locate the `mender-device-auth` service in the configuration file.
-Add the `environment` section if it is absent. In the `environment` section add the `DEVICEAUTH_MAX_DEVICES_LIMIT_DEFAULT` variable with an integer value. `0` represents `no limit` and is the default.
-The updated entry should look like this:
-
-```yaml
-    ...
-    mender-device-auth:
-        ...
-        environment:
-            DEVICEAUTH_MAX_DEVICES_LIMIT_DEFAULT: 500
-    ...
-```
-
-
 #### Logging
 
 The setup uses Docker's default `json-file` logging driver, which exposes two important log


### PR DESCRIPTION
The configuration has been removed as it becomes ineffective in
multi-tenant setups, and has no value in single-tenant setups.
Instead, the enterprise device limit per/plan is made configurable and
is documented in the production template in mendersoftware/integration.