### PR TITLE
MEN-4366: Update Docker image tags for the new versionig

### DIFF
--- a/07.Administration/06.Upgrading/docs.md
+++ b/07.Administration/06.Upgrading/docs.md
@@ -128,7 +128,7 @@ First, pull in new container images:
 ```bash
 ./run pull
 ```
-<!--AUTOVERSION: "%: Pulling from mendersoftware/deviceauth"/deviceauth "%: Pulling from mendersoftware/gui"/gui "%: Pulling from mendersoftware/api-gateway"/api-gateway "mendersoftware/deviceauth:%"/deviceauth "mendersoftware/gui:%"/gui "mendersoftware/api-gateway:%"/api-gateway-->
+<!--AUTOVERSION: "mender-%: Pulling from mendersoftware/deviceauth"/integration "mender-%: Pulling from mendersoftware/gui"/integration "mender-%: Pulling from mendersoftware/api-gateway"/integration "mendersoftware/deviceauth:mender-%"/integration "mendersoftware/gui:mender-%"/integration "mendersoftware/api-gateway:mender-%"/integration-->
 > ```
 > Pulling mender-mongo (mongo:3.4)...  
 > 3.4: Pulling from library/mongo  
@@ -139,18 +139,18 @@ First, pull in new container images:
 > Digest: sha256:0ded6733900e6e09760cd9a7c79ba4981dea6f6b142352719f7a4157b4a3352d  
 > Status: Image is up to date for mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z  
 > ...  
-> Pulling mender-device-auth (mendersoftware/deviceauth:master)...  
-> master: Pulling from mendersoftware/deviceauth  
+> Pulling mender-device-auth (mendersoftware/deviceauth:mender-master)...  
+> mender-master: Pulling from mendersoftware/deviceauth  
 > Digest: sha256:07ed10f6fdee40df1de8e10efc3115cb64b0c190bcf5bcd194b9f34086396058  
-> Status: Image is up to date for mendersoftware/deviceauth:master  
-> Pulling mender-gui (mendersoftware/gui:master)...  
-> master: Pulling from mendersoftware/gui  
+> Status: Image is up to date for mendersoftware/deviceauth:mender-master  
+> Pulling mender-gui (mendersoftware/gui:mender-master)...  
+> mender-master: Pulling from mendersoftware/gui  
 > Digest: sha256:af2d2349f27dd96ca21940672aa3a91335b17153f8c7ef2ca865a9a7fdf2fd22  
-> Status: Image is up to date for mendersoftware/gui:master  
-> Pulling mender-api-gateway (mendersoftware/api-gateway:master)...  
-> master: Pulling from mendersoftware/api-gateway  
+> Status: Image is up to date for mendersoftware/gui:mender-master  
+> Pulling mender-api-gateway (mendersoftware/api-gateway:mender-master)...  
+> mender-master: Pulling from mendersoftware/api-gateway  
 > Digest: sha256:0a2033a57f88afc38253a45301c83484e532047d75858df95d46c12b48f1f2f8  
-> Status: Image is up to date for mendersoftware/api-gateway:master````  
+> Status: Image is up to date for mendersoftware/api-gateway:mender-master````  
 > ```
 
 Then stop and remove existing containers:


### PR DESCRIPTION
From 2.4.x on, the backend services will use tags like mender-1.2.3,
where 1.2.3 is the integration version (not the git version of the
component).