### PR TITLE
Switch from docker-compose to docker for deviceauth maintenance

### DIFF
--- a/201.Troubleshooting/04.Mender-Server/docs.md
+++ b/201.Troubleshooting/04.Mender-Server/docs.md
@@ -32,7 +32,7 @@ introduces example tools provided in Mender integration repository.
 
 To clean up the deviceauth database, run the following from within the integration repository:
 ```
-docker-compose exec mender-device-auth /usr/bin/deviceauth maintenance --decommissioning-cleanup
+docker exec $(docker ps -q -n 1 -f 'name=device-auth') /usr/bin/deviceauth maintenance --decommissioning-cleanup
 ```
 
 ## The virtual QEMU device is not showing up in demo mode


### PR DESCRIPTION
Use docker exec instead of the docker-compose command in order to avoid the error:
ERROR: Service 'mender-deployments' depends on service 'storage-proxy' which is undefined.

Thank you @koptermax