### PR TITLE
Adjust Quickstart steps for on-prem installation.

### DIFF
--- a/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
+++ b/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
@@ -182,7 +182,7 @@ And finally fire up the demo server environment with:
 
 Note that the demo up script starts the Mender services, adds a demo user with the username mender-demo@example.com, and assigns a random password in which you can change after you log in to the Mender web UI. The Mender UI can be found on [https://localhost](https://localhost?target=_blank).
 
-After you log into the UI on the localhost you can follow steps 1 through 6 listed above.
+After you log into the UI on the localhost you can follow the steps above, starting with ["Prepare your Raspberry Pi"](#prepare-your-raspberry-pi).
 
 ## Have any questions?
 


### PR DESCRIPTION
The on-prem Quickstart is telling you to start by SSH'ing to the
device, but you need to start by flashing it, as for Hosted Mender.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>