### PR TITLE
use 2.0.x branch for mender-convert git clone

### DIFF
--- a/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
+++ b/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
@@ -93,9 +93,8 @@ documentation for your host OS if you encounter connection issues with docker.
 
 Clone `mender-convert` from the official repository:
 
-<!--AUTOVERSION: "-b % https://github.com/mendersoftware/mender-convert"/mender-convert-->
 ```bash
-git clone -b 2.0.0 https://github.com/mendersoftware/mender-convert.git
+git clone -b 2.0.x https://github.com/mendersoftware/mender-convert.git
 ```
 
 ## Build the mender-convert container image


### PR DESCRIPTION
The 2.0.0 tag is broken because the Docker base
image we used got removed, meaning that './docker-build'
fails with errors similar to this:

    > Err:4 http://archive.ubuntu.com/ubuntu disco Release
    >   404  Not Found [IP: 91.189.88.152 80]

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>