### PR TITLE
QA: Add internal link checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.bak
 *.pyc
+node_modules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,14 @@ test:
         env TEST_ENTERPRISE=1 ./test_docs.py 07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md;
       fi
 
+test:internal-links:
+  stage: test
+  image: node:14-alpine
+  script:
+    - apk add --no-cache git
+    - npm install
+    - node checkInternalLinks.js
+
 trigger:mender-docs-site:
   image: alpine
   stage: trigger

--- a/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
+++ b/01.Getting-started/01.Quickstart-with-raspberry-pi/docs.md
@@ -135,7 +135,7 @@ So far we have deployed application updates. However, Mender also supports robus
 
 The easiest way to create system level updates is to use the *snapshot* functionality in Mender, which will create a snapshot of the full system on a currently running device and package it as a Mender Artifact (.mender file) that you can deploy to other devices.
 
-To try it out, first follow the steps to [download and install the mender-artifact tool](../../downloads#mender-artifact) on your workstation (e.g. laptop).
+To try it out, first follow the steps to [download and install the mender-artifact tool](../../08.Downloads/docs.md#mender-artifact) on your workstation (e.g. laptop).
 Then run the following command on your workstation:
 
 ```bash
@@ -158,7 +158,7 @@ simply deploy this snapshot to your device again from the Mender server! A full 
 
 You can make arbitrary modifications to the system, take another snapshot and deploy this to groups of devices, and this way deploy robust system updates with rollback support.
 
-To read more about system snapshots see the documentation on [Artifact from system snapshot](../../artifacts/snapshots).
+To read more about system snapshots see the documentation on [Artifact from system snapshot](../../04.Artifacts/22.Snapshots/docs.md).
 
 
 ## Running Mender on-premise

--- a/01.Getting-started/02.On-premise-installation/01.Requirements/docs.md
+++ b/01.Getting-started/02.On-premise-installation/01.Requirements/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 For quickly testing the Mender server, we have created a demo version that
 does not take into account production-grade issues like security and scalability.
 When you are ready to install for production, please follow
-the [Production installation documentation](../../../administration/production-installation).
+the [Production installation documentation](../../../07.Administration/02.Production-installation/docs.md).
 
 The Mender server is using the microservices design pattern, meaning that
 multiple small, isolated services make up the server. 
@@ -50,10 +50,10 @@ connection in order to avoid long wait times.
 The Mender updater client is designed to run on embedded Linux devices and connects to the server
 so that deployments can be managed across many devices.
 
-If you need support for application updates (but not full system updates), no device integration is required. In this case you can install Mender on an existing device and OS by following the documentation on [installing the Mender client](../../../client-configuration/installing). For first-time Mender users, the Mender server onboarding will guide you through this process. All you need is an ARM-based device with a Debian-family OS (e.g. Debian, Raspbian, Ubuntu) pre-installed and network connectivity set up.
+If you need support for application updates (but not full system updates), no device integration is required. In this case you can install Mender on an existing device and OS by following the documentation on [installing the Mender client](../../../05.Client-configuration/06.Installing/docs.md). For first-time Mender users, the Mender server onboarding will guide you through this process. All you need is an ARM-based device with a Debian-family OS (e.g. Debian, Raspbian, Ubuntu) pre-installed and network connectivity set up.
 
-On the other hand, to get support for robust system updates with rollback, Mender must be [integrated with production devices](../../../devices).
+On the other hand, to get support for robust system updates with rollback, Mender must be [integrated with production devices](../../../03.Devices/chapter.md).
 
 ## Trying Mender
 
-After installing the above prerequisites, follow the steps in [Install a Mender demo server](../create-a-test-environment).
+After installing the above prerequisites, follow the steps in [Install a Mender demo server](../02.Create-a-test-environment/docs.md).

--- a/01.Getting-started/02.On-premise-installation/02.Create-a-test-environment/docs.md
+++ b/01.Getting-started/02.On-premise-installation/02.Create-a-test-environment/docs.md
@@ -4,12 +4,12 @@ taxonomy:
     category: docs
 ---
 
-! Following this tutorial will create a demo installation of the Mender, appropriate for testing and experimenting. When you are ready to install for production, please follow the [Production installation documentation](../../../administration/production-installation).
+! Following this tutorial will create a demo installation of the Mender, appropriate for testing and experimenting. When you are ready to install for production, please follow the [Production installation documentation](../../../07.Administration/02.Production-installation/docs.md).
 
 
 ## Bring up the environment with Docker Compose
 
-! Make sure you satisfy the [server requirements](../requirements#demo-server-requirements) before proceeding.
+! Make sure you satisfy the [server requirements](../01.Requirements/docs.md) before proceeding.
 
 In a working directory, download the Mender integration
 environment:
@@ -66,4 +66,4 @@ __Follow the help tooltips__ in the UI to guide you through each step of deployi
 !!! If you don't see the help tooltips, there is an option to toggle them on/off from the dropdown at your user email up at the top right corner of the screen.
 
 We strongly recommend that you complete the onboarding tutorial that comes with the UI so
-that you have a basic understanding of how Mender works before moving on to [Install the Mender client](../install-the-mender-client).
+that you have a basic understanding of how Mender works before moving on to [Install the Mender client](../03.Install-the-mender-client/docs.md).

--- a/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
+++ b/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-! It is strongly recommended you **complete the Mender server onboarding to connect your first device** as outlined in [install a Mender demo server](../create-a-test-environment#open-the-mender-ui) before proceeding.
+! It is strongly recommended you **complete the Mender server onboarding to connect your first device** as outlined in [install a Mender demo server](../02.Create-a-test-environment/docs.md#open-the-mender-ui) before proceeding.
 
 Your devices first need to have the Mender client running on them in order to connect to the server.
 There are two approaches to this, depending on what kind of updates you want to do.
@@ -15,16 +15,16 @@ There are two approaches to this, depending on what kind of updates you want to 
 
 Installing this way does not offer a full Mender integration. However, it is possible to use Update Modules and update parts of the system.
 
-For partial updates such as application updates, you can [install Mender on your device using a .deb package](../../../client-configuration/installing#install-mender-using-the-debian-package). This is the quickest and easiest way to get started with Mender. A detailed introduction to partial updates using update modules can be found [here](../../../devices/update-modules).
+For partial updates such as application updates, you can [install Mender on your device using a .deb package](../../../05.Client-configuration/06.Installing/docs.md#install-mender-using-the-debian-package). This is the quickest and easiest way to get started with Mender. A detailed introduction to partial updates using update modules can be found [here](../../../03.Devices/10.Update-Modules/docs.md).
 
 ### System updates
 
 The most robust approach is full rootfs system updates. This approach also enables support for partial updates, but there are some device partition layout requirements so the board integration is more effort.
 
 For this, the Mender client needs to be integrated as part of the disk image,
-which can be done by [building with Yocto](../../../devices/yocto-project) or
-[converting an existing Debian disk image](../../../devices/debian-family).
-Check out [the Downloads section](../../../downloads#disk-images) to the disk
+which can be done by [building with Yocto](../../../03.Devices/02.Yocto-project/docs.md) or
+[converting an existing Debian disk image](../../../03.Devices/03.Debian-family/docs.md).
+Check out [the Downloads section](../../../08.Downloads/docs.md#disk-images) to the disk
 image for your board, or the board integrations at
 [Mender Hub](https://hub.mender.io/c/board-integrations) to see if your board
 has already been integrated. There are over 40 different board and OS
@@ -34,4 +34,4 @@ professional assistance supporting your board and OS, please refer to the
 
 If you have a Raspberry Pi 3 or a Raspberry Pi 4, you can test out system
 updates by following the tutorial [deploy a system update
-demo](../deploy-a-system-update-demo).
+demo](../04.Deploy-a-system-update-demo/docs.md).

--- a/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
+++ b/01.Getting-started/02.On-premise-installation/03.Install-the-mender-client/docs.md
@@ -15,7 +15,7 @@ There are two approaches to this, depending on what kind of updates you want to 
 
 Installing this way does not offer a full Mender integration. However, it is possible to use Update Modules and update parts of the system.
 
-For partial updates such as application updates, you can [install Mender on your device using a .deb package](../../../client-configuration/installing#install-mender-provided-debian-package). This is the quickest and easiest way to get started with Mender. A detailed introduction to partial updates using update modules can be found [here](../../../devices/update-modules).
+For partial updates such as application updates, you can [install Mender on your device using a .deb package](../../../client-configuration/installing#install-mender-using-the-debian-package). This is the quickest and easiest way to get started with Mender. A detailed introduction to partial updates using update modules can be found [here](../../../devices/update-modules).
 
 ### System updates
 

--- a/01.Getting-started/02.On-premise-installation/04.Deploy-a-system-update-demo/docs.md
+++ b/01.Getting-started/02.On-premise-installation/04.Deploy-a-system-update-demo/docs.md
@@ -15,7 +15,7 @@ device available.
 ## Prerequisites
 
 The test environment should be set up and working successfully
-as described in [Install a Mender demo server](../create-a-test-environment).
+as described in [Install a Mender demo server](../02.Create-a-test-environment/docs.md).
 
 We also strongly recommend that you complete the tutorial that comes with the Mender GUI so
 that you have a basic understanding of how Mender works before moving on to connecting a physical device.
@@ -33,16 +33,16 @@ so you will need one SD card (8 GB or larger) per device.
 ### Disk image
 
 Get the disk image for your board(s) from [the Downloads
-section](../../../downloads#disk-images).
+section](../../../08.Downloads/docs.md#disk-images).
 
-!!! It is possible to use this tutorial with _any_ physical board, as long as you have integrated Mender with it. In this case you cannot use the demo Artifacts we provide in this tutorial, but you need to build your own artifacts as described in [Building a Mender Yocto Project image](../../../artifacts/yocto-project/building).
+!!! It is possible to use this tutorial with _any_ physical board, as long as you have integrated Mender with it. In this case you cannot use the demo Artifacts we provide in this tutorial, but you need to build your own artifacts as described in [Building a Mender Yocto Project image](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md).
 
 ### Mender-Artifact tool
 
 Download the prebuilt `mender-artifact` binary for your platform following the links
-in [Downloads section](../../../downloads#mender-artifact).
+in [Downloads section](../../../08.Downloads/docs.md#mender-artifact).
 
-Please see [Modifying a Mender Artifact](../../../artifacts/modifying-a-mender-artifact)
+Please see [Modifying a Mender Artifact](../../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md)
 for a more detailed overview.
 
 ### Network connectivity
@@ -75,7 +75,7 @@ that your device(s) can connect to the Mender server.
 
 Locate the demo _disk image_ (`*.sdimg`) you downloaded for your device.
 This image contains _all the partitions_ of the storage device, as described in [Partition
-layout](../../../devices/general-system-requirements#partition-layout).
+layout](../../../03.Devices/01.General-system-requirements/docs.md#partition-layout).
 
 You can decompress a `.xz` image like the following:
 
@@ -92,9 +92,9 @@ gunzip <PATH-TO-YOUR-DISK-IMAGE>.sdimg.gz
 !!! The Mender images come with a predetermined size for the root filesystems,
 !!! which may be too small for some use cases where a lot of space is required
 !!! for applications. If you are building your own disk image by following
-!!! [Building a Mender Yocto Project image](../../../artifacts/yocto-project/building),
+!!! [Building a Mender Yocto Project image](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md),
 !!! you can configure the desired space usage with the Yocto Project variable
-!!! [MENDER_STORAGE_TOTAL_SIZE_MB](../../../artifacts/yocto-project/variables#mender_storage_total_size_mb).
+!!! [MENDER_STORAGE_TOTAL_SIZE_MB](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_storage_total_size_mb).
 
 If you are connecting your device with an Ethernet cable to the same LAN network
 that your workstation, skip the following subsections and jump to
@@ -157,7 +157,7 @@ should have your wpa configuration set up correctly on start up.
 
 ## Write the disk image to the SD card
 
-Please see [Write the disk image to the SD card](../../../artifacts/provisioning-a-new-device#write-the-disk-image-to-the-sd-card)
+Please see [Write the disk image to the SD card](../../../04.Artifacts/20.Provisioning-a-new-device/docs.md#write-the-disk-image-to-the-sd-card)
 for steps how to provision the device disk using the `*.sdimg`
 image you downloaded and modified above.
 
@@ -165,7 +165,7 @@ If you have several devices, please write the disk image to all their SD cards.
 
 ## Boot the device
 
-! Make sure that the Mender server is running as described in [Install a Mender demo server](../create-a-test-environment) and that the device can reach it on the IP address you configured above (`$IP_OF_MENDER_SERVER_FROM_DEVICE`). You might need to set a static IP address where the Mender server runs and disable any firewalls.
+! Make sure that the Mender server is running as described in [Install a Mender demo server](../02.Create-a-test-environment/docs.md) and that the device can reach it on the IP address you configured above (`$IP_OF_MENDER_SERVER_FROM_DEVICE`). You might need to set a static IP address where the Mender server runs and disable any firewalls.
 
 First, insert the SD card you just provisioned into the device. Then **connect
 the device to power**.
@@ -230,12 +230,12 @@ sudo systemctl restart mender-client
 ## See the device in the Mender UI
 
 If you refresh the Mender server UI (by default found at [https://localhost/](https://localhost/?target=_blank)),
-you should see one or more devices pending authorization. If you do not see your device listed in the UI, please review [troubleshooting steps.](../../../troubleshooting/device-runtime#mender-server-connection-issues)
+you should see one or more devices pending authorization. If you do not see your device listed in the UI, please review [troubleshooting steps.](../../../201.Troubleshooting/05.Device-Runtime/docs.md#mender-server-connection-issues)
 
 Once you **authorize** these devices, Mender will auto-discover
 inventory about the devices, including the device type (e.g. beaglebone)
 and the IP addresses, as shown in the example with a BeagleBone Black below.
-Which information is collected about devices is fully configurable; see the documentation on [Identity](../../../client-configuration/identity) and [Inventory](../../../client-configuration/inventory) for more information.
+Which information is collected about devices is fully configurable; see the documentation on [Identity](../../../05.Client-configuration/03.Identity/docs.md) and [Inventory](../../../05.Client-configuration/04.Inventory/docs.md) for more information.
 
 ![Mender UI - Device information for BeagleBone Black](device_information_bbb.png)
 
@@ -273,7 +273,7 @@ your device.
 !!! it, run `hostname -I` on your device.
 
 This section will create a Mender Artifact from a running device using the
-snapshots feature of Mender. See [Snapshots](../../../artifacts/snapshots) to
+snapshots feature of Mender. See [Snapshots](../../../04.Artifacts/22.Snapshots/docs.md) to
 learn more details about this feature.
 
 First you need to start SSH service in your device. For Raspbian image, start it
@@ -374,9 +374,9 @@ network with different names, you can deploy updates back and forth between them
 
 Now that you have seen how Mender works with a reference board, you might be wondering what it would take to port it to your own board.
 
-To get support for robust system updates with rollback, Mender must be [integrated with production boards](../../../devices).
+To get support for robust system updates with rollback, Mender must be [integrated with production boards](../../../03.Devices/chapter.md).
 
-On the other hand, if you only need support for application updates (not full system updates), no board integration is required. In this case you can install Mender on an existing device and OS by following the documentation on [installing the Mender client](../../../client-configuration/installing).
+On the other hand, if you only need support for application updates (not full system updates), no board integration is required. In this case you can install Mender on an existing device and OS by following the documentation on [installing the Mender client](../../../05.Client-configuration/06.Installing/docs.md).
 
 You can find images for other devices in our Mender Hub community forum, see
 [Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11) or

--- a/01.Getting-started/02.On-premise-installation/docs.md
+++ b/01.Getting-started/02.On-premise-installation/docs.md
@@ -10,6 +10,6 @@ For a high-level introduction to Mender and its architecture, we recommend readi
 
 This section of the documentation contains tutorials to help you set up a demo server and deploy your first update with Mender. Going from a fresh system to completing your first deployment with Mender, including server setup, should take **less than 30 minutes**.
 
-! Do not follow this getting started documentation if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
+! Do not follow this getting started documentation if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../01.Quickstart-with-raspberry-pi/docs.md) or the instructions you received in the welcome email when you signed up.
 
 To begin on-premise installation, first take a look at the [requirements](01.Requirements).

--- a/01.Getting-started/02.On-premise-installation/docs.md
+++ b/01.Getting-started/02.On-premise-installation/docs.md
@@ -12,4 +12,4 @@ This section of the documentation contains tutorials to help you set up a demo s
 
 ! Do not follow this getting started documentation if you are using [hosted Mender](https://hosted.mender.io?target=_blank). Instead, follow the [Quickstart guide for Raspberry Pi](../quickstart-with-raspberry-pi) or the instructions you received in the welcome email when you signed up.
 
-To begin on-premise installation, first take a look at the [requirements](requirements).
+To begin on-premise installation, first take a look at the [requirements](01.Requirements).

--- a/02.Architecture/01.Overview/docs.md
+++ b/02.Architecture/01.Overview/docs.md
@@ -27,7 +27,7 @@ Other operating systems will be added later on.
 
 It is possible to run the Mender update client in standalone or managed mode.
 
-When run in standalone mode, the deployments are triggered (`mender -install`), rebooted into (`reboot`) and made persistent (`mender -commit`) from the command line at the device or through some custom integration like a script. Any http(s) server or file path (e.g. USB stick or NFS share) can be used to serve the Artifacts; the URI is given to the `mender -install` option. If you wish to run Mender in standalone mode, you can [disable Mender as a system service](../../artifacts/yocto-project/image-configuration#disabling-mender-as-a-system-service).
+When run in standalone mode, the deployments are triggered (`mender -install`), rebooted into (`reboot`) and made persistent (`mender -commit`) from the command line at the device or through some custom integration like a script. Any http(s) server or file path (e.g. USB stick or NFS share) can be used to serve the Artifacts; the URI is given to the `mender -install` option. If you wish to run Mender in standalone mode, you can [disable Mender as a system service](../../04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md#disabling-mender-as-a-system-service).
 
 When running Mender in managed mode, the Mender client runs as a daemon and will regularly poll the server, automatically apply updates, reboot, report and commit the update. This is the best way to run Mender for most large-scale deployments, as the deployments are centrally managed across many devices, but it requires to set up and connect clients to the Mender server.
 
@@ -42,7 +42,7 @@ The simplest and most robust way to update the device is to write a new file sys
 This is the mechanism supported by the current versions of Mender.
 Other update mechanisms are possible, for example through the use of a package manager such as RPM, and they will be added later on.
 
-Please see [Mender Artifacts](../mender-artifacts) for more details on the Mender Artifact format.
+Please see [Mender Artifacts](../04.Mender-Artifacts/docs.md) for more details on the Mender Artifact format.
 
 ## Robust updates
 
@@ -70,4 +70,4 @@ If something causes the device to reboot before committing the update, the bootl
 
 One consequence of image update is that the update will replace all the files in a filesystem with new versions, thereby deleting any new or changed files that had been placed there. In other words, to be updatable a file system needs to be **stateless**.
 
-All files that are modified by the device need to be stored in a separate partition. Things that may need to be stored include network parameters, user configuration changes and so on. See [Partition layout](../../devices/general-system-requirements#partition-layout) for more information.
+All files that are modified by the device need to be stored in a separate partition. Things that may need to be stored include network parameters, user configuration changes and so on. See [Partition layout](../../03.Devices/01.General-system-requirements/docs.md#partition-layout) for more information.

--- a/02.Architecture/02.Device-authentication/docs.md
+++ b/02.Architecture/02.Device-authentication/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-Devices, identified by a set of [identity attributes](../../client-configuration/identity), must be explicitly authorized
+Devices, identified by a set of [identity attributes](../../05.Client-configuration/03.Identity/docs.md), must be explicitly authorized
 by the user before they can authenticate with the Mender server.
 
 This section describes in detail the components and workflows relevant to device authentication,
@@ -29,7 +29,7 @@ can inspect it and manually authorize it
 It is important to clear up some terminology used throughout this documentation and various APIs.
 
 A **device** represents, intuitively, a particular piece of hardware. It is uniquely identified by a
-set of **identity attributes** (MAC addresses, user-defined UIDs, etc.); think of it as an extension of a unique identifier into a multi-attribute structure (see [Identity](../../client-configuration/identity)).
+set of **identity attributes** (MAC addresses, user-defined UIDs, etc.); think of it as an extension of a unique identifier into a multi-attribute structure (see [Identity](../../05.Client-configuration/03.Identity/docs.md)).
 
 To obtain an auth token, the device sends an **authentication request** containing the identity attributes and its current
 **public key**. The request is signed with the respective private key (kept secret on the device), and the server uses
@@ -74,12 +74,12 @@ The sequence diagram below describes the API interactions between the user and D
 For details of API calls please consult the API documentation.
 
 For open source:
-* [Device Authentication Device API](../../apis/open-source/device-apis/device-authentication)
-* [Device Authentication Management API](../../apis/open-source/management-apis/device-authentication)
+* [Device Authentication Device API](../../200.APIs/01.Open-source/01.Device-APIs/01.Device-authentication/docs.md)
+* [Device Authentication Management API](../../200.APIs/01.Open-source/02.Management-APIs/02.Device-authentication/docs.md)
 
 And for Enterprise:
-* [Device Authentication Device API](../../apis/enterprise/device-apis/device-authentication)
-* [Device Authentication Management API](../../apis/enterprise/management-apis/device-authentication)
+* [Device Authentication Device API](../../200.APIs/02.Enterprise/01.Device-APIs/01.Device-authentication/docs.md)
+* [Device Authentication Management API](../../200.APIs/02.Enterprise/02.Management-APIs/02.Device-authentication/docs.md)
 
 ### Accept-on-request Flow
 An alternate flow, suitable mostly for quick prototyping and testing, is the accept-on-request flow.
@@ -108,12 +108,12 @@ The sequence diagram below describes the API interactions between the user, Devi
 For details of API calls please consult the API documentation:
 
 For open source:
-* [Device Authentication Device API](../../apis/open-source/device-apis/device-authentication)
-* [Device Authentication Management API](../../apis/open-source/management-apis/device-authentication)
+* [Device Authentication Device API](../../200.APIs/01.Open-source/01.Device-APIs/01.Device-authentication/docs.md)
+* [Device Authentication Management API](../../200.APIs/01.Open-source/02.Management-APIs/02.Device-authentication/docs.md)
 
 And for Enterprise:
-* [Device Authentication Device API](../../apis/enterprise/device-apis/device-authentication)
-* [Device Authentication Management API](../../apis/enterprise/management-apis/device-authentication)
+* [Device Authentication Device API](../../200.APIs/02.Enterprise/01.Device-APIs/01.Device-authentication/docs.md)
+* [Device Authentication Management API](../../200.APIs/02.Enterprise/02.Management-APIs/02.Device-authentication/docs.md)
 
 
 ## Authentication Token
@@ -125,7 +125,7 @@ The token does have an **expiry date** (one week period), but the Mender client 
 the process is transparent to the user. The only prerequisite is that the device's authentication set has not been
 explicitly rejected in the meantime via the Device Authentication API.
 
-For details on the token format please see the relevant [documentation on submitting an authentication request for Open Source](../../apis/open-source/device-apis/device-authentication) or [Enterprise](../../apis/enterprise/device-apis/device-authentication).
+For details on the token format please see the relevant [documentation on submitting an authentication request for Open Source](../../200.APIs/01.Open-source/01.Device-APIs/01.Device-authentication/docs.md) or [Enterprise](../../200.APIs/02.Enterprise/01.Device-APIs/01.Device-authentication/docs.md).
 
 ## Viewing devices and auth sets
-To view available devices and their authentication sets, use the `GET /api/management/v2/authentication/devices` endpoint of the [Device Authentication Management API for Open Source](../../apis/open-source/management-apis/device-authentication) or [Enterprise](../../apis/enterprise/management-apis/device-authentication).
+To view available devices and their authentication sets, use the `GET /api/management/v2/authentication/devices` endpoint of the [Device Authentication Management API for Open Source](../../200.APIs/01.Open-source/02.Management-APIs/02.Device-authentication/docs.md) or [Enterprise](../../200.APIs/02.Enterprise/02.Management-APIs/02.Device-authentication/docs.md).

--- a/02.Architecture/03.Compatibility/docs.md
+++ b/02.Architecture/03.Compatibility/docs.md
@@ -10,9 +10,9 @@ This document outlines the compatibility between different versions of Mender co
 ## Backward compatibility policy
 
 <!--AUTOVERSION: "% to %"/ignore-->
-Mender always provides an [upgrade path](../../administration/upgrading) from the past patch (e.g. 1.2.0 to 1.2.1) and minor version (e.g. 1.1.1 to 1.2.0), and releases follow [Semantic Versioning](http://semver.org/?target=_blank). Note that according to Semantic Versioning, new functionality can be added in minor releases (e.g from 1.2.0 to 1.3.0) so be sure to upgrade components to support the newer functionality before starting to use it.
+Mender always provides an [upgrade path](../../07.Administration/06.Upgrading/docs.md) from the past patch (e.g. 1.2.0 to 1.2.1) and minor version (e.g. 1.1.1 to 1.2.0), and releases follow [Semantic Versioning](http://semver.org/?target=_blank). Note that according to Semantic Versioning, new functionality can be added in minor releases (e.g from 1.2.0 to 1.3.0) so be sure to upgrade components to support the newer functionality before starting to use it.
 
-For example, when a new [Artifact format](../mender-artifacts#the-mender-artifact-file-format) version is released, the *new* Mender client would support older versions of the Artifact format. However, the inverse is not true; the Mender client does not support *newer* versions of the Artifact format. So in this case you need to upgrade all Mender clients before starting to use new versions of the Artifact format (and the features it enables).
+For example, when a new [Artifact format](../04.Mender-Artifacts/docs.md#the-mender-artifact-file-format) version is released, the *new* Mender client would support older versions of the Artifact format. However, the inverse is not true; the Mender client does not support *newer* versions of the Artifact format. So in this case you need to upgrade all Mender clients before starting to use new versions of the Artifact format (and the features it enables).
 
 As another example, the Mender client supports one version of the server API, while the server can support several API versions. Therefore, the server should always be upgraded before the client.
 
@@ -54,7 +54,7 @@ the lists of specific criteria we use for our versioning policy.
 ## Mender client and Yocto Project version
 
 <!--AUTOVERSION: "% to %"/ignore-->
-In general the Mender client introduces new features in minor (e.g. 1.2.0 to 1.3.0) versions and the [meta-mender layer](https://github.com/mendersoftware/meta-mender?target=_blank) is updated accordingly to easily support these new features (e.g. by exposing new [MENDER_* variables](../../artifacts/yocto-project/variables)). The [meta-mender layer](https://github.com/mendersoftware/meta-mender?target=_blank) has branches corresponding to [versions of the Yocto Project](https://wiki.yoctoproject.org/wiki/Releases?target=_blank).
+In general the Mender client introduces new features in minor (e.g. 1.2.0 to 1.3.0) versions and the [meta-mender layer](https://github.com/mendersoftware/meta-mender?target=_blank) is updated accordingly to easily support these new features (e.g. by exposing new [MENDER_* variables](../../04.Artifacts/10.Yocto-project/99.Variables/docs.md)). The [meta-mender layer](https://github.com/mendersoftware/meta-mender?target=_blank) has branches corresponding to [versions of the Yocto Project](https://wiki.yoctoproject.org/wiki/Releases?target=_blank).
 
 <!--AUTOVERSION: "Mender client %"/ignore "| % ("/ignore-->
 | Client vs meta-mender version   | Older              | pyro (2.3) | rocko (2.4)           | sumo (2.5)            | thud (2.6)            | warrior (2.7)<sup>4</sup> |
@@ -76,17 +76,17 @@ In general the Mender client introduces new features in minor (e.g. 1.2.0 to 1.3
 !! <sup>2</sup> Rolling back to 1.x.x from a failed upgrade to 2.x.x is supported. However, it is not possible to downgrade to a Mender 1.x.x client from a 2.x.x client, once the update containing 2.x.x has been committed.
 
 <!--AUTOVERSION: "Yocto % branch and earlier"/ignore-->
-!!! <sup>3</sup> For compatibility reasons, the Yocto thud branch and earlier use Mender 1.7 by default. Please see [the section on configuring the build](../../artifacts/yocto-project/building#configuring-the-build) for how to force a later version.
+!!! <sup>3</sup> For compatibility reasons, the Yocto thud branch and earlier use Mender 1.7 by default. Please see [the section on configuring the build](../../04.Artifacts/10.Yocto-project/01.Building/docs.md#configuring-the-build) for how to force a later version.
 
 <!--AUTOVERSION: "from % to %"/ignore "from-%-to-%"/ignore-->
-! <sup>4</sup> If upgrading from thud to warrior, see also [known issues when upgrading from thud to warrior](../../troubleshooting/running-yocto-project-image#upgrading-from-thud-to-warrior-fails-with-dual-rootfs-configurat).
+! <sup>4</sup> If upgrading from thud to warrior, see also [known issues when upgrading from thud to warrior](../../201.Troubleshooting/02.Running-Yocto-Project-image/docs.md#upgrading-from-thud-to-warrior-fails-with-dual-rootfs-configuration-not-found).
 
 Leverage [Mender consulting services to support other versions of the Yocto Project](https://mender.io/product/board-support?target=_blank) for your board and environment.
 
 
 ## Mender client/server and Artifact format
 
-The [Mender Artifact format](../mender-artifacts) is managed by the [Mender Artifacts Library](https://github.com/mendersoftware/mender-artifact?target=_blank), which is included in the Mender client and server (for reading Artifacts) as well as in a standalone utility `mender-artifact` (for [writing Artifacts](../../artifacts/modifying-a-mender-artifact)).
+The [Mender Artifact format](../04.Mender-Artifacts/docs.md) is managed by the [Mender Artifacts Library](https://github.com/mendersoftware/mender-artifact?target=_blank), which is included in the Mender client and server (for reading Artifacts) as well as in a standalone utility `mender-artifact` (for [writing Artifacts](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md)).
 
 <!--AUTOVERSION: "Mender % / mender-artifact %"/ignore-->
 |                                      | Artifact v1 | Artifact v2 | Artifact v3 |
@@ -104,12 +104,12 @@ The [Mender Artifact format](../mender-artifacts) is managed by the [Mender Arti
 | Mender 2.2.x / mender-artifact 3.2.x | no          | yes         | yes         |
 | Mender 2.3.x / mender-artifact 3.3.x | no          | yes         | yes         |
 
-!! Older Mender clients do not support newer versions of the Artifact format; they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
+!! Older Mender clients do not support newer versions of the Artifact format; they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
 
 
 ## Mender server and client API
 
-The compatibility between the Mender server and client is managed by the Device API versions exposed by the server and used by the client. If the Mender server supports the API version of the Mender client, they are compatible.  However, please ensure that the client and server support the [Artifact format](#mender-clientserver-and-artifact-format) version you are using. Device API docs are available for both [Open Source](../../apis/open-source/device-apis) and [Mender Enterprise](../../apis/enterprise/device-apis).
+The compatibility between the Mender server and client is managed by the Device API versions exposed by the server and used by the client. If the Mender server supports the API version of the Mender client, they are compatible.  However, please ensure that the client and server support the [Artifact format](#mender-clientserver-and-artifact-format) version you are using. Device API docs are available for both [Open Source](../../200.APIs/01.Open-source/01.Device-APIs/docs.md) and [Mender Enterprise](../../200.APIs/02.Enterprise/01.Device-APIs/docs.md).
 
 <!--AUTOVERSION: "| %"/ignore-->
 |        | Mender server versions | Mender client versions |

--- a/02.Architecture/04.Mender-Artifacts/docs.md
+++ b/02.Architecture/04.Mender-Artifacts/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-As described in the [architecture overview](../overview) Mender uses the output
+As described in the [architecture overview](../01.Overview/docs.md) Mender uses the output
 from a build system and deploys this to remote devices.
 
 In order to ensure a robust update process, Mender needs *additional metadata*
@@ -45,7 +45,7 @@ More details about the exact format of the Mender Artifact can be found in the
 
 Mender is constantly evolving to adapt to the needs of its users. As new features are added, new versions of the 
 Mender Artifact format may be introduced as well, if the features require it.
-See the [compatibility documentation](../compatibility) for an overview of which versions of the Mender Artifact format is supported by Mender clients.
+See the [compatibility documentation](../03.Compatibility/docs.md) for an overview of which versions of the Mender Artifact format is supported by Mender clients.
 
 
 ## Streaming, resume and compression
@@ -72,14 +72,14 @@ by default.
 
 To verify that the Artifact comes from a known source, the Mender Artifact format supports 
 image signing and verification. In order to create a signed Artifact, which can be verified by the Mender Client
-during the update process, please follow the instructions at [Signing and verifying Mender Artifact](../../artifacts/signing-and-verification).
+during the update process, please follow the instructions at [Signing and verifying Mender Artifact](../../04.Artifacts/40.Signing-and-verification/docs.md).
 
 ## State scripts
 
 Starting with the Mender client version 1.2, support for state scripts is included. The most common use case is to do application data migration, 
 for example if application data like a user profile is stored in an SQLite database and a new column needs to be added before starting the new version of the application.
-There are a wide variety of other use cases that are covered by state scripts. For more use cases see [example use cases](../../artifacts/state-scripts#example-use-cases).
-For more information how to use state scripts see [Mender state scripts](../../artifacts/state-scripts).
+There are a wide variety of other use cases that are covered by state scripts. For more use cases see [example use cases](../../04.Artifacts/50.State-scripts/docs.md#example-use-cases).
+For more information how to use state scripts see [Mender state scripts](../../04.Artifacts/50.State-scripts/docs.md).
 
 
 ## Working with Mender Artifacts
@@ -87,7 +87,7 @@ For more information how to use state scripts see [Mender state scripts](../../a
 The easiest and most common way to generate Mender Artifacts is by
 adding the [meta-mender](https://github.com/mendersoftware/meta-mender?target=_blank)
 layer to your Yocto Project build environment. There is more information
-on how to do this as part of the tutorial [Building a Mender Yocto Project image](../../artifacts/yocto-project/building).
+on how to do this as part of the tutorial [Building a Mender Yocto Project image](../../04.Artifacts/10.Yocto-project/01.Building/docs.md).
 
 Although it is possible to use a tar utility to extract, modify and package
 Mender Artifacts, this is error-prone due to the amount of details
@@ -96,4 +96,4 @@ metadata and checksum computation.
 For this reason, it is recommended to use the Mender Artifact utility or Go library
 when you need to work with Mender Artifacts. The Mender Artifacts library and utility
 is available as open source in the [Mender Artifacts repository](https://github.com/mendersoftware/mender-artifact?target=_blank)
-and there is a tutorial using the utility at [Modifying a Mender Artifact](../../artifacts/modifying-a-mender-artifact).
+and there is a tutorial using the utility at [Modifying a Mender Artifact](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md).

--- a/02.Architecture/05.Deployments/docs.md
+++ b/02.Architecture/05.Deployments/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 A Deployment ensures delivery of a Release to one or more devices. A Release can contain one or more Mender Artifacts, one of the Artifacts is assigned when the device receives the update based on software and hardware compatibility.
 
-Deployments in Mender represent the explicit association of a release (Mender Artifact) and one or more devices running a client that implements the [Device APIs](../../apis/open-source/device-apis/device-authentication), e.g., the Mender client.
+Deployments in Mender represent the explicit association of a release (Mender Artifact) and one or more devices running a client that implements the [Device APIs](../../200.APIs/01.Open-source/01.Device-APIs/01.Device-authentication/docs.md), e.g., the Mender client.
 
 At its basics, the definition of a Deployment includes:
 

--- a/02.Architecture/06.Standalone-deployments/docs.md
+++ b/02.Architecture/06.Standalone-deployments/docs.md
@@ -11,9 +11,9 @@ to deploy updates to devices which do not have network connectivity or
 are updated through external storage like a USB stick.
 
 For an explanation of the difference between *managed* and *standalone* deployments, please see
-[Modes of operation](../overview#modes-of-operation).
+[Modes of operation](../01.Overview/docs.md#modes-of-operation).
 
-!!! Note that [state scripts](../../artifacts/state-scripts) work slightly differently in standalone mode, see [state scripts and standalone mode](../../artifacts/state-scripts#standalone-mode) for more information.
+!!! Note that [state scripts](../../04.Artifacts/50.State-scripts/docs.md) work slightly differently in standalone mode, see [state scripts and standalone mode](../../04.Artifacts/50.State-scripts/docs.md#standalone-mode) for more information.
 
 
 ## Setting Mender up for standalone mode
@@ -28,9 +28,9 @@ will entail disabling or removing any `systemd` unit that starts the Mender clie
 
 ## Building standalone images
 
-When [building a Mender Yocto Project image](../../artifacts/yocto-project/building),
+When [building a Mender Yocto Project image](../../04.Artifacts/10.Yocto-project/01.Building/docs.md),
 you can ensure Mender runs in standalone mode by following the
-[image configuration steps to make sure Mender does not run as a system service](../../artifacts/yocto-project/image-configuration#disabling-mender-as-a-system-service)
+[image configuration steps to make sure Mender does not run as a system service](../../04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md#disabling-mender-as-a-system-service)
 before building.
 
 From the Yocto Project build output configured as above you will get two
@@ -41,13 +41,13 @@ device, i.e. do the initial device storage provisioning.
 `meta-mender` creates these files with a `.sdimg`
 suffix, so they are easy to recognize. This file contains
 all the partitions of the given storage device, as
-described in [Partition layout](../../devices/general-system-requirements#partition-layout).
-Please see [Provisioning a new device](../../artifacts/provisioning-a-new-device)
+described in [Partition layout](../../03.Devices/01.General-system-requirements/docs.md#partition-layout).
+Please see [Provisioning a new device](../../04.Artifacts/20.Provisioning-a-new-device/docs.md)
 for steps how to provision the device storage using the `*.sdimg` image.
 
 Secondly, you will get an Artifact file that is used for deployments with Mender,
 and it is recognized by its `.mender` suffix.
-See [Mender Artifacts](../../architecture/mender-artifacts)
+See [Mender Artifacts](../../02.Architecture/04.Mender-Artifacts/docs.md)
 for a more detailed overview.
 
 
@@ -67,7 +67,7 @@ For example, if you are updating from a USB stick, you could use `/mnt/usb1/rele
 To use http, simply replace it with a URL like `https://fileserver.example.com/mender/release1.mender`.
 
 Mender will download the new Artifact, process its metadata information, extract the contents and write it to the inactive rootfs partition. It will configure the bootloader to boot into it on the next reboot. This will likely take several minutes to complete, depending on the performance of your device and the size of the Artifact.
-Note that Mender does not use any temporary space, it [streams the Artifact](../mender-artifacts#streaming-and-compression).
+Note that Mender does not use any temporary space, it [streams the Artifact](../04.Mender-Artifacts/docs.md#streaming-resume-and-compression).
 
 To run the newly deployed rootfs image, simply reboot your device:
 
@@ -88,4 +88,4 @@ mender -commit
 
 By running this command, Mender will configure the bootloader to persistently boot from this newly written deployment. To deploy another update, simply run `mender -install <URI>` again, then reboot and commit.
 
-!!! If we reboot the device again *without* running `mender -commit`, it will boot into the previous rootfs partition that is known to be working (where we deployed the update from). This ensures a robust update process in cases where the newly deployed rootfs does not boot or otherwise has issues that we want to roll back from. Also note that it is possible to automate deployments by [running the Mender client as a daemon](../../architecture/overview#modes-of-operation).
+!!! If we reboot the device again *without* running `mender -commit`, it will boot into the previous rootfs partition that is known to be working (where we deployed the update from). This ensures a robust update process in cases where the newly deployed rootfs does not boot or otherwise has issues that we want to roll back from. Also note that it is possible to automate deployments by [running the Mender client as a daemon](../01.Overview/docs.md#modes-of-operation).

--- a/03.Devices/01.General-system-requirements/docs.md
+++ b/03.Devices/01.General-system-requirements/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-##Device capacity
+## Device capacity
 The client binaries are about 7 MB in size, or about 4 MB when debug symbols are
 stripped (using the `strip` tool). This includes most of the dependencies for
 the client, such as the http, TLS, and JSON libraries.
@@ -13,15 +13,15 @@ The client depends on the LZMA library for Artifact compression, which is
 present in most Linux distributions, including those based on the Yocto Project
 and the Debian family.
 
-##Bootloader support
+## Bootloader support
 To support atomic rootfs rollback, Mender integrates with the bootloader of the device. Currently Mender supports [GRUB](https://www.gnu.org/software/grub/?target=_blank) and [U-Boot](http://www.denx.de/wiki/U-Boot?target=_blank). The bootloader installation, features and requirements vary depending on the target OS in use.  Please see the [Yocto bootloader support](../yocto-project/bootloader-support) or [Debian bootloader support](../debian-family#bootloader-support) for more information.
 
-##Kernel support
+## Kernel support
 While Mender itself does not have any specific kernel requirements beyond what a normal Linux kernel provides, it relies on systemd, which does have one such requirement: The `CONFIG_FHANDLE` feature must be enabled in the kernel. The symptom if this feature is unavailable is that systemd hangs during boot looking for device files.
 
 If you [run the Mender client in standalone mode](../../architecture/overview#modes-of-operation), you can avoid this dependency by [disabling Mender as a system service](../../artifacts/yocto-project/image-configuration#disabling-mender-as-a-system-service).
 
-##Partition layout
+## Partition layout
 In order to support robust rollback, Mender requires the device to have a certain partition layout.
 At least four different partitions are needed:
 * one boot partition, containing the U-Boot bootloader and its environment
@@ -38,7 +38,7 @@ A sample partition layout is shown below:
 
 ![Mender client partition layout](mender_client_partition_layout.png)
 
-##Correct clock
+## Correct clock
 Certificate verification requires the device clock to be running correctly at all times.
 Make sure to either have a reliable clock or use network time synchronization.
 Note that the default setup of systemd will use network time

--- a/03.Devices/01.General-system-requirements/docs.md
+++ b/03.Devices/01.General-system-requirements/docs.md
@@ -14,12 +14,13 @@ present in most Linux distributions, including those based on the Yocto Project
 and the Debian family.
 
 ## Bootloader support
-To support atomic rootfs rollback, Mender integrates with the bootloader of the device. Currently Mender supports [GRUB](https://www.gnu.org/software/grub/?target=_blank) and [U-Boot](http://www.denx.de/wiki/U-Boot?target=_blank). The bootloader installation, features and requirements vary depending on the target OS in use.  Please see the [Yocto bootloader support](../yocto-project/bootloader-support) or [Debian bootloader support](../debian-family#bootloader-support) for more information.
+
+To support atomic rootfs rollback, Mender integrates with the bootloader of the device. Currently Mender supports [GRUB](https://www.gnu.org/software/grub/?target=_blank) and [U-Boot](http://www.denx.de/wiki/U-Boot?target=_blank). The bootloader installation, features and requirements vary depending on the target OS in use.  Please see the [Yocto bootloader support](../02.Yocto-project/02.Bootloader-support/docs.md) or [Debian bootloader support](../02.Yocto-project/02.Bootloader-support/docs.md) for more information.
 
 ## Kernel support
 While Mender itself does not have any specific kernel requirements beyond what a normal Linux kernel provides, it relies on systemd, which does have one such requirement: The `CONFIG_FHANDLE` feature must be enabled in the kernel. The symptom if this feature is unavailable is that systemd hangs during boot looking for device files.
 
-If you [run the Mender client in standalone mode](../../architecture/overview#modes-of-operation), you can avoid this dependency by [disabling Mender as a system service](../../artifacts/yocto-project/image-configuration#disabling-mender-as-a-system-service).
+If you [run the Mender client in standalone mode](../../02.Architecture/01.Overview/docs.md#modes-of-operation), you can avoid this dependency by [disabling Mender as a system service](../../04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md#disabling-mender-as-a-system-service).
 
 ## Partition layout
 In order to support robust rollback, Mender requires the device to have a certain partition layout.
@@ -45,7 +46,7 @@ Note that the default setup of systemd will use network time
 synchronization to maintain the clock in a running system. This may
 take a few minutes to stabilize on system boot so it is possible
 to have a few connection rejections from the server until this process
-is complete and the time is correct. Please see [certificate troubleshooting](../../troubleshooting/mender-client#certificate-expired-or-not-yet-valid) for more information about the symptoms of this issue.
+is complete and the time is correct. Please see [certificate troubleshooting](../../201.Troubleshooting/03.Mender-Client/docs.md#certificate-expired-or-not-yet-valid) for more information about the symptoms of this issue.
 
 If your device does not have an active internet connection, then systemd
 will be unable to configure the system time as it will be unable to connect

--- a/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
+++ b/03.Devices/02.Yocto-project/01.Partition-configuration/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-##Flash memory types
+## Flash memory types
 
 Embedded devices almost universally use flash memory for storage.
 An important property of flash memory cells is that they can only
@@ -34,21 +34,21 @@ software*. In Linux, raw flash devices are exposed as a **Memory Technology
 Device (MTD)** file. Care must be taken when selecting a file system to ensure
 that it is MTD-aware and properly handles wear leveling and error correction.
 Popular file systems for MTD devices include UBIFS, JFFS2, and YAFFS.
-Consult the [raw flash](../raw-flash) section for details on setting up and
+Consult the [raw flash](../03.Raw-flash/docs.md) section for details on setting up and
 configuration.
 
 
-##File system types
+## File system types
 
-When [building a Mender Yocto Project image](../../../artifacts/yocto-project/building) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.mender` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
+When [building a Mender Yocto Project image](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md) the build output in `tmp/deploy/images/<MACHINE>` includes a binary rootfs file system image (e.g. with `.mender` extension), as well as a complete disk image (with `.sdimg` extension). The binary rootfs file system images are used when deploying updates to the device, while the `.sdimg` image is typically used just once during initial device provisioning to flash the entire storage, and includes the partition layout and all partitions.
 
 In general Mender does not have dependencies on a specific file system type as long as it is for a [block device](#flash-memory-types), but the version of U-Boot you are using must support the file system type used for rootfs because it needs to read the Linux kernel from the file system and start the Linux boot process.
 
-The standard Yocto Project `IMAGE_FSTYPES` variable will be used to determine the image types to create in Yocto deploy directory. The meta-mender layer will add the `mender` type to that variable, and usually `sdimg`, `uefiimg` or a different type ending with `img`, depending on which [image features](../../../artifacts/yocto-project/image-configuration/features#list-of-features)
+The standard Yocto Project `IMAGE_FSTYPES` variable will be used to determine the image types to create in Yocto deploy directory. The meta-mender layer will add the `mender` type to that variable, and usually `sdimg`, `uefiimg` or a different type ending with `img`, depending on which [image features](../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md#list-of-features)
  are enabled. The filesystem used for the individual partition files will be based on the `ARTIFACTIMG_FSTYPE` variable.  It is advised that you clean up the `IMAGE_FSTYPES` variable to avoid creating unnecessary image files.
 
 
-##Configuring storage
+## Configuring storage
 
 Two variables are required to configure storage correctly for Mender. The first is the storage device where the partitions are expected to be located on the device, `MENDER_STORAGE_DEVICE`. The second is the total size of this physical storage medium. The values should be for the raw device containing the entire storage, not any single partition. For example:
 
@@ -73,7 +73,7 @@ mtdinfo -a | sed -rne '/^Amount of eraseblocks:/{s/.*[^0-9]([0-9]+) *bytes.*/\1/
 
 The output will be in MiB, a number appropriate for `MENDER_STORAGE_TOTAL_SIZE_MB`.
 
-###More detailed storage configuration
+### More detailed storage configuration
 
 If you need more fine grained control over which partitions Mender will use, you can set one or more the following variables to specific partition strings, using `MENDER_STORAGE_DEVICE_BASE`:
 
@@ -94,9 +94,9 @@ MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}3"
 !! Note that the Mender image builder will not produce such images, so only set these variables if you're building partitioned images yourself, with a different layout than the default Mender layout (the example above reflects the default).
 
 
-##Configuring the partition sizes
+## Configuring the partition sizes
 
-When [building a Mender Yocto Project image](../../../artifacts/yocto-project/building) Mender defines and uses certain OpenEmbedded variables which are used to define the sizes of the partitions.
+When [building a Mender Yocto Project image](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md) Mender defines and uses certain OpenEmbedded variables which are used to define the sizes of the partitions.
 
 | Mount point  | Purpose                                                 | Default size | Variable to configure size     |
 |--------------|---------------------------------------------------------|--------------|--------------------------------|
@@ -104,25 +104,25 @@ When [building a Mender Yocto Project image](../../../artifacts/yocto-project/bu
 | &lt;BOOT&gt; | Store the bootloader.                                   | 16 MB        | `MENDER_BOOT_PART_SIZE_MB`     |
 | `/data`      | Store persistent data, preserved during Mender updates. | 128 MB       | `MENDER_DATA_PART_SIZE_MB`     |
 
-!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](../../../artifacts/yocto-project/image-configuration/features) for more information.
+!!! Even though the default size of `MENDER_DATA_PART_SIZE_MB` is `128 MB`, it will try to resize the partition and filesystem image on first boot to the full size of the underlying block device which is also resized to occupy remainder of available blocks on the storage medium. This functionality relies on [systemd-growfs](https://www.freedesktop.org/software/systemd/man/systemd-makefs@.service.html) and take note that only certain filesystem types are supported. See [mender-growfs-data feature](../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md) for more information.
 
 The value of &lt;BOOT&gt; depends on what features are enabled:
 * If `mender-uboot` is enabled: `/uboot`
 * If `mender-grub` and `mender-bios` are enabled: `/boot/grub`
 * If only `mender-grub` is enabled: `/boot/efi`
 
-You can override these default values in your `local.conf`. For details consult [Mender image variables](../../../artifacts/yocto-project/variables).
+You can override these default values in your `local.conf`. For details consult [Mender image variables](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md).
 
 
-##Preserving data and configuration across updates
+## Preserving data and configuration across updates
 
 As Mender does a full rootfs image update, care must be taken in where persistent data is stored. The contents of the partition mounted on `/data` is preserved across updates. In fact, the Mender client itself uses `/data/mender` as a backing to store data that needs to be kept across updates.
 
 If you have data or configuration that you need to preserve across updates, the recommended approach is to create a symlink from where it gets written to somewhere within `/data/`. For example, if you have an application that writes to `/etc/application1`, then you can create a symlink `/etc/application1` -> `/data/application1` to ensure the data it writes is not lost during a Mender rootfs update.
 
-##Deploying files to the persistent data partition
+## Deploying files to the persistent data partition
 
-When [building a Mender Yocto Project image](../../../artifacts/yocto-project/building), if you need to include files in the persistent data partition, all you have to do is add those files to the `/data` directory in the root filesystem, and the files will automatically be included on the data partition. For example:
+When [building a Mender Yocto Project image](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md), if you need to include files in the persistent data partition, all you have to do is add those files to the `/data` directory in the root filesystem, and the files will automatically be included on the data partition. For example:
 
 ```bash
 do_install() {
@@ -136,12 +136,12 @@ A sample recipe (`hello-mender`) is included in the `meta-mender-demo` layer whi
 ! Keep in mind that any files you add to the `/data` directory will not be included in `.mender` artifacts, since they don't contain a data partition. Only complete partitioned images (`.biosimg`, `.sdimg`, `.uefiimg`, etc) will contain the files.
 
 <!--AUTOVERSION: "In Yocto Project 2.4 % and earlier"/ignore-->
-!!! In Yocto Project 2.4 rocko and earlier, there was a different method for adding files to the data partition. Please see the [`MENDER_DATA_PART_DIR` variable](../../../artifacts/yocto-project/variables#mender_data_part_dir) for details on this now obsolete method.
+!!! In Yocto Project 2.4 rocko and earlier, there was a different method for adding files to the data partition. Please see the [`MENDER_DATA_PART_DIR` variable](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_data_part_dir) for details on this now obsolete method.
 
 
 ## Producing a standalone data partition image
 
-Although it is not needed for most work with Mender, for some flashing setups, it may be useful to have the sole data partition available as an image file. If this is needed, simply add `dataimg` to the Yocto Project `IMAGE_FSTYPES` variable, and the image file will be built and given the `.dataimg` suffix. Its filesystem type will be the value of [`ARTIFACTIMG_FSTYPE`](../../../artifacts/yocto-project/variables#artifactimg_fstype). For example:
+Although it is not needed for most work with Mender, for some flashing setups, it may be useful to have the sole data partition available as an image file. If this is needed, simply add `dataimg` to the Yocto Project `IMAGE_FSTYPES` variable, and the image file will be built and given the `.dataimg` suffix. Its filesystem type will be the value of [`ARTIFACTIMG_FSTYPE`](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#artifactimg_fstype). For example:
 
 ```bash
 IMAGE_FSTYPES_append = " dataimg"

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/01.GRUB/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/01.GRUB/docs.md
@@ -15,7 +15,7 @@ MENDER_FEATURES_ENABLE_append = " mender-grub mender-image-uefi"
 MENDER_FEATURES_DISABLE_append = " mender-uboot mender-image-sd"
 ```
 
-See [the documentation on features](../../../../artifacts/yocto-project/image-configuration/features) for more information.
+See [the documentation on features](../../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md) for more information.
 
 
 ## BIOS based systems

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/01.Providing-custom-u-boot-fw-utils/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/01.Providing-custom-u-boot-fw-utils/docs.md
@@ -49,7 +49,7 @@ this is the change:
 
 The first line changes a path inside the recipe, since the include file is not
 in the same directory anymore. The second adds Mender specific tweaks, as
-described in [this section](../..#forks-of-u-boot).
+described in [this section](../..//docs.md#forks-of-u-boot).
 
 ## Preparations
 
@@ -63,7 +63,7 @@ cp u-boot-my-fork_2016.03.bb u-boot-fw-utils-my-fork_2016.03.bb
 
 ## Using the fork
 
-Then, in accordance with [this section](../../manual-u-boot-integration#u-boot-fw-utils), we add the
+Then, in accordance with [this section](../../01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils), we add the
 following to our configuration:
 
 ```bash
@@ -136,7 +136,7 @@ will go through each line and explain why they are needed.
 
 2. We replace `u-boot-mender.inc` with `u-boot-fw-utils-mender.inc`. This is
    because the fw-utils tools requires different tweaks, as described in [this
-   section](../../manual-u-boot-integration#u-boot-fw-utils).
+   section](../../01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils).
 
 3. The next block of variable assignments (starting with `SUMMARY`) is added
    because this normally is provided by `u-boot.inc`, but since this file is not
@@ -192,7 +192,7 @@ will go through each line and explain why they are needed.
 
 12. The last two `PROVIDES_${PN}` and `RPROVIDES_${PN}` variables are added to
     describe to Bitbake that this recipe provides those packages, even though it
-    has a different name. This is described [here](../../manual-u-boot-integration#u-boot-fw-utils).
+    has a different name. This is described [here](../../01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils).
 
 And that's it! This provides a working recipe for u-boot-fw-utils.
 
@@ -203,5 +203,5 @@ case. Much of the inspiration was taken from there, and this is a good place to
 look if you hit problems and this guide doesn't provide the answer.
 
 After the adaptation is complete, you should go through the [Integration
-checklist](../../integration-checklist) to make sure that all functionality
+checklist](../../02.Integration-checklist/docs.md) to make sure that all functionality
 of the compiled tools is working.

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/02.U-Boot-versions-without-BOOTLIMIT-support/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/02.U-Boot-versions-without-BOOTLIMIT-support/docs.md
@@ -10,7 +10,7 @@ around this missing feature by using custom boot code to simulate the
 feature. It is equivalent in terms of functionality and robustness.
 
 This section assumes that you are using a [custom fork of
-U-Boot](../..#forks-of-u-boot).
+U-Boot](../../docs.md#forks-of-u-boot).
 
 ## The cross platform part
 

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md
@@ -96,7 +96,7 @@ these should be enabled in the board support headers in U-Boot, under
 
 3. `CONFIG_ENV_IS_IN_MMC`: This will store the U-Boot environment file on the
    memory card, before the first partition start. See
-   [`MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET`](../../../../../artifacts/yocto-project/variables#mender_uboot_env_storage_device_offset)
+   [`MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET`](../../../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_uboot_env_storage_device_offset)
    for more information. Other `CONFIG_ENV_IS_IN_` features should be turned
    off.
 
@@ -306,7 +306,7 @@ then make the necessary changes in the same fashion as done for the main
 
 An alternative approach is to port the forked U-Boot recipe,
 `u-boot-my-fork_*.bb` to a `u-boot-fw-utils-my-fork_*.bb` recipe. We have
-provided a [practical example for this](providing-custom-u-boot-fw-utils).
+provided a [practical example for this]().
 
 The two recipes should use identical source code (e.g. the same patches
 applied).

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/02.Integration-checklist/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/02.Integration-checklist/docs.md
@@ -23,7 +23,7 @@ This checklist will verify some key functionality aspects of the Mender integrat
 
 ## The steps
 
-!!! Steps 1-4 can be skipped when verifying [raw flash](../../../raw-flash) integration.
+!!! Steps 1-4 can be skipped when verifying [raw flash](../../../03.Raw-flash/docs.md) integration.
 
 1. As part of the test, we will need two different Linux kernels, in order to verify that both are booted correctly when they should. Therefore, before building the images you will test with, run the commands:
 

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 This section describes the steps needed to integrate with U-Boot for Yocto Project. Most steps are automated, but there are a few things that need to be in place for this to function.
 
-!!! Please consult [the bootloader support section](../../../general-system-requirements#bootloader-support) to find out if U-Boot is supported on your platform and build configuration, and whether it is enabled by default.
+!!! Please consult [the bootloader support section](../../../01.General-system-requirements/docs.md#bootloader-support) to find out if U-Boot is supported on your platform and build configuration, and whether it is enabled by default.
 
 
 ## Enabling U-Boot
@@ -18,14 +18,14 @@ MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
 MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 ```
 
-See [the documentation on features](../../../../artifacts/yocto-project/image-configuration/features) for more information.
+See [the documentation on features](../../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md) for more information.
 
 
 ## Boot counter
 
 As Mender relies on the `CONFIG_BOOTCOUNT_ENV` feature of U-Boot, which was [introduced in October 2013](http://lists.denx.de/pipermail/u-boot/2013-October/165484.html?target=_blank), Mender currently recommends **U-Boot v2014.07 or newer**.
 
-If you have an older version of U-Boot, it is possible to apply some extra patches to make this work. Please see the section about [U-Boot versions without BOOTLIMIT support](manual-u-boot-integration/u-boot-versions-without-bootlimit-support) for more information.
+If you have an older version of U-Boot, it is possible to apply some extra patches to make this work. Please see the section about [U-Boot versions without BOOTLIMIT support]() for more information.
 
 ## Forks of U-boot
 
@@ -83,7 +83,7 @@ Project you need to enable the `mender-uboot` feature using
 MENDER_FEATURES_ENABLE_append = " mender-uboot"
 ```
 
-!!! If the architecture is ARM, and the `mender-full` or `mender-full-ubi` class is inherited in a Bitbake `.conf` file, then the `mender-uboot` feature is already on by default. See [the documentation on features](../../../../artifacts/yocto-project/image-configuration/features) for more information.
+!!! If the architecture is ARM, and the `mender-full` or `mender-full-ubi` class is inherited in a Bitbake `.conf` file, then the `mender-uboot` feature is already on by default. See [the documentation on features](../../../../04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md) for more information.
 
 This enables U-Boot integration, and also enables full automatic patching of
 U-Boot.
@@ -108,5 +108,5 @@ using the modified boot loader. If this happens, or if you are using an older
 Yocto Project branch, there will be some manual work required in order to
 produce a working integration patch.
 
-Please see [Manual U-Boot integration](manual-u-boot-integration) for more
+Please see [Manual U-Boot integration]() for more
 information.

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-This section describes the support level of the two bootloaders that Mender supports, [GRUB](https://www.gnu.org/software/grub/?target=_blank) and [U-Boot](http://www.denx.de/wiki/U-Boot?target=_blank). It is assumed that Yocto is the build system used to build the device images.
+This section describes the support level of the two bootloaders that Mender supports, [GRUB](https://www.gnu.org/software//?target=_blank) and [U-Boot](http://www.denx.de/wiki/U-Boot?target=_blank). It is assumed that Yocto is the build system used to build the device images.
 
 Below is a table listing the bootloader support using various device types and Yocto Project releases. All versions of the Mender client software will work with either of the two bootloaders.
 
@@ -23,6 +23,6 @@ Below is a table listing the bootloader support using various device types and Y
 
 ## Which one to pick
 
-If you are just starting out, we recommend trying [GRUB integration](grub) first, if possible. We recommend moving to [U-Boot integration](u-boot) only if integration with GRUB is not possible or unsuccessful.
+If you are just starting out, we recommend trying [GRUB integration]() first, if possible. We recommend moving to [U-Boot integration]() only if integration with GRUB is not possible or unsuccessful.
 
 The main technical reason for using GRUB rather than U-Boot is that GRUB requires no patching to work with Mender, whereas U-Boot does. For most users this will be the path of least resistance.

--- a/03.Devices/02.Yocto-project/03.Raw-flash/docs.md
+++ b/03.Devices/02.Yocto-project/03.Raw-flash/docs.md
@@ -24,7 +24,7 @@ machine.
 
 As an example, to illustrate potential pain points we will use a Versatile
 Express CortexA9x4 board, emulated under QEMU (`vexpress-a9` target). See [the
-next example section](example-qemu).
+next example section]().
 
 
 ### Raw flash storage
@@ -35,7 +35,7 @@ bootloader. Some configuration values need to be set, however, and they are
 described below.
 
 For more information about these or other variables that affect a Flash build,
-see [the Variables section](../../../artifacts/yocto-project/variables).
+see [the Variables section](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md).
 
 
 #### MENDER_MTDIDS
@@ -149,11 +149,11 @@ filesystem volumes and one data volume. It will also normally contain two
 volumes to store two redundant copies of U-Boot's environment data.
 
 This image can be flashed to an MTD device into its "ubi" partition, as
-identified from its ["mtdparts" string (`MENDER_MTDPARTS`)](#mender-mtdparts).
+identified from its ["mtdparts" string (`MENDER_MTDPARTS`)](#mender_mtdparts).
 
 #### mtdimg
 
 A raw flash image for MTD devices that contains the `ubimg` as well as other
-components specified in the [`MENDER_MTDPARTS` variable](#mender-mtdparts).
+components specified in the [`MENDER_MTDPARTS` variable](#mender_mtdparts).
 
 This image can be flashed directly to a raw Flash device.

--- a/03.Devices/03.Debian-family/docs.md
+++ b/03.Devices/03.Debian-family/docs.md
@@ -48,7 +48,7 @@ all that you need to integrate a new device with an unsupported OS.
 ### Common customizations
 
 In many cases it will be required to provide a [custom configuration
-file](../../artifacts/debian-family/image-configuration#configuration-files)
+file](../../04.Artifacts/15.Debian-family/02.image-configuration/docs.md#configuration-files)
 to provide details that cannot be determined at probe time. Common configuration
 variables are:
 
@@ -84,8 +84,8 @@ The above would translate to `MENDER_STORAGE_DEVICE = "/dev/mmcblk1p"`.
 ## Other Mender customizations
 
 Note that configuring features such as
-[identity](../../client-configuration/identity) and
-[inventory]((../../client-configuration/identity) rely on placing
+[identity](../../05.Client-configuration/03.Identity/docs.md) and
+[inventory]((../../05.Client-configuration/03.Identity/docs.md) rely on placing
 additional files into the target filesystem.  With `mender-convert`,
 these modifications should _not_ be done in the input images since
 they will be overwritten by `mender-convert`.  The proper mechanism to
@@ -93,7 +93,7 @@ support updates like these, is to add them as files in your rootfs
 overlay.
 
 Similarly adding
-[root file system state scripts](../../artifacts/state-scripts#root-file-system-and-artifact-scripts)
+[root file system state scripts](../../04.Artifacts/50.State-scripts/docs.md#root-file-system-and-artifact-scripts)
 should be done using the `mender-convert` rootfs overlay.
 
 ## Fall back to U-Boot integration on ARM

--- a/03.Devices/10.Update-Modules/docs.md
+++ b/03.Devices/10.Update-Modules/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 ## Introduction
 
-The built-in update mechanism in Mender is [dual rootfs updates](../../architecture/overview#robust-updates). To do other types of updates, you will need an _Update module_ for your device.
+The built-in update mechanism in Mender is [dual rootfs updates](../../02.Architecture/01.Overview/docs.md#robust-updates). To do other types of updates, you will need an _Update module_ for your device.
 
 An _Update Module_ is an extension to the Mender client for supporting a new type of software update, such as a package manager, container, bootloader or even updates of nearby microcontrollers. An Update Module can be tailored to a specific device or environment (e.g. update a proprietary bootloader), or be more general-purpose (e.g. install a set of `.deb` packages.).
 
@@ -18,7 +18,7 @@ An Update Module implements one or more of the actions that the Mender client ca
 
 ### The state machine workflow
 
-Update Modules are modeled after the same execution flow as [state scripts](../../artifacts/state-scripts). For the development of Update Modules it is important to have a basic understanding of the workflow.
+Update Modules are modeled after the same execution flow as [state scripts](../../04.Artifacts/50.State-scripts/docs.md). For the development of Update Modules it is important to have a basic understanding of the workflow.
 
 ![Update Modules state machine](update-modules-state-machine.png)
 
@@ -41,22 +41,22 @@ Refer to [further reading](#further-reading) for more details.
 
 ### Mender server
 
-You will need a Mender server if you are using [managed mode](../../architecture/overview#modes-of-operation).
+You will need a Mender server if you are using [managed mode](../../02.Architecture/01.Overview/docs.md#modes-of-operation).
 
-For easy setup, use [hosted Mender](https://hosted.mender.io?target=_blank) or the [on-premise demo server](../../getting-started/on-premise-installation).
+For easy setup, use [hosted Mender](https://hosted.mender.io?target=_blank) or the [on-premise demo server](../../01.Getting-started/02.On-premise-installation/docs.md).
 
 ### Device with Mender client
 
 You will need a device with a Mender client installed. For development purposes you also need shell access to the device (e.g. via SSH).
 
-To install the Mender client on your device, follow the instructions in the [Installing](../../client-configuration/installing) documentation.
+To install the Mender client on your device, follow the instructions in the [Installing](../../05.Client-configuration/06.Installing/docs.md) documentation.
 
 ### Workstation with mender-artifact
 
 We will use the `mender-artifact` tool to create the payloads required for Update Modules to work.
 
 Download the prebuilt `mender-artifact` binary for your platform following the links
-in [Downloads section](../../downloads#mender-artifact-tool).
+in [Downloads section](../../08.Downloads/docs.md#mender-artifact).
 
 ## Basic example: File copy Update Module
 

--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -9,7 +9,7 @@ The build output will most notably include:
 * a disk image that can be flashed to the device storage during initial provisioning
 * an Artifact containing rootfs filesystem image file that Mender can deploy to your provisioned device, it has suffix `.mender`
 
-!!! If you do not want to build your own images for testing purposes, the [Getting started](../../../getting-started) tutorials provide links to several [prebuilt images](../../../downloads#disk-images).
+!!! If you do not want to build your own images for testing purposes, the [Getting started](../../../01.Getting-started/chapter.md) tutorials provide links to several [prebuilt images](../../../08.Downloads/docs.md#disk-images).
 
 ## What is *meta-mender*?
 
@@ -18,8 +18,8 @@ The build output will most notably include:
 Inside *meta-mender* there are several layers. The most important one is *meta-mender-core*, which is required by all builds that use Mender. *meta-mender-core* takes care of:
 
 * Cross-compiling Mender for ARM devices
-* [Partitioning the image correctly](../../../devices/yocto-project/partition-configuration)
-* [Setting up the U-Boot bootloader to support Mender](../../../devices/yocto-project/bootloader-support/u-boot)
+* [Partitioning the image correctly](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md)
+* [Setting up the U-Boot bootloader to support Mender](../../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md)
 
 Each one of these steps can be configured further, see the linked sections for more details.
 
@@ -38,7 +38,7 @@ The other layers in *meta-mender* provide support for specific boards used in Me
 
 Mender needs to integrate with your board, most notably with the boot process.
 Although the integration is automated for most boards, please see
-[Board integration](../../../devices) for general requirements and
+[Board integration](../../../03.Devices/chapter.md) for general requirements and
 adjustment you might need to make before building.
 
 Check out the board integrations at [Mender Hub](https://hub.mender.io?target=_blank) to see if your board is
@@ -51,7 +51,7 @@ the [Mender Consulting services to integrate your board](https://mender.io/suppo
 
 Make sure that the clock is set correctly on your devices. Otherwise certificate verification will become unreliable
 and **the Mender client can likely not connect to the Mender server**.
-See [certificate troubleshooting](../../../troubleshooting/mender-client#certificate-expired-or-not-yet-valid) for more information.
+See [certificate troubleshooting](../../../201.Troubleshooting/03.Mender-Client/docs.md#certificate-expired-or-not-yet-valid) for more information.
 
 
 ## Yocto Project
@@ -66,15 +66,15 @@ Full details for building the Yocto project for your board are available at Mend
 
 !!! Note that the Yocto Project also depends on some [development tools to be in place](http://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html?target=_blank#packages).
 
-! The `meta-mender-demo` layer, which is included in the integrations available at [Mender Hub](https://hub.mender.io?target=_blank), is not appropriate if you are building for production devices. Please go to the section about [building for production](../building-for-production) to see the difference between demo builds and production builds.
+! The `meta-mender-demo` layer, which is included in the integrations available at [Mender Hub](https://hub.mender.io?target=_blank), is not appropriate if you are building for production devices. Please go to the section about [building for production](../03.Building-for-production/docs.md) to see the difference between demo builds and production builds.
 
-If you encounter any issues, please see [Board integration](../../../devices)
+If you encounter any issues, please see [Board integration](../../../03.Devices/chapter.md)
 for general requirements and adjustments you might need to enable your board to
 support Mender.
 
 #### Configuring the build
 
-!!! The configuration from [Mender Hub](https://hub.mender.io?target=_blank) will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../../architecture/overview#modes-of-operation). See the [section on customizations](../image-configuration#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
+!!! The configuration from [Mender Hub](https://hub.mender.io?target=_blank) will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../../02.Architecture/01.Overview/docs.md#modes-of-operation). See the [section on customizations](../02.Image-configuration/docs.md#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
 
 The following settings will be present in the default `conf/local.conf` after running the steps from [Mender Hub](https://hub.mender.io?target=_blank). These are likely to need customization for your setup.
 
@@ -124,7 +124,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 # Build for Mender production setup (on-prem)
 #
-# https://docs.mender.io/artifacts/building-for-production
+# https://docs.mender.io/artifac../03.Building-for-production/docs.md
 #
 # Uncomment below and update the URL to match your configured domain
 # name and provide the path to the generated server.crt file.
@@ -140,11 +140,11 @@ ARTIFACTIMG_FSTYPE = "ext4"
 #SRC_URI_append_pn-mender = " file://server.crt"
 ```
 
-!!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
+!!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../99.Variables/docs.md#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#file-system-types) for more information.
 
 !!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
-!!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
+!!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../10.Yocto-project/02.Image-configuration/docs.md#configuring-the-image-for-read-only-rootfs).
 
 ### Adding meta-mender to existing Yocto Project environment
 
@@ -177,7 +177,7 @@ Then, add the Mender layers into your project:
 bitbake-layers add-layer ../meta-mender/meta-mender-core
 ```
 
-! The `meta-mender-demo` layer (below) is not appropriate if you are building for production devices. Please go to the section about [building for production](../building-for-production) to see the difference between demo builds and production builds.
+! The `meta-mender-demo` layer (below) is not appropriate if you are building for production devices. Please go to the section about [building for production](../03.Building-for-production/docs.md) to see the difference between demo builds and production builds.
 
 ```bash
 bitbake-layers add-layer ../meta-mender/meta-mender-demo
@@ -185,7 +185,7 @@ bitbake-layers add-layer ../meta-mender/meta-mender-demo
 
 #### Configuring the build
 
-!!! The configuration in `conf/local.conf` below will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../../architecture/overview#modes-of-operation). See the [section on customizations](../../yocto-project/image-configuration#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
+!!! The configuration in `conf/local.conf` below will create a build that runs the Mender client in managed mode, as a `systemd` service. It is also possible to [run Mender standalone from the command-line or a custom script](../../../02.Architecture/01.Overview/docs.md#modes-of-operation). See the [section on customizations](../02.Image-configuration/docs.md#disabling-mender-as-a-system-service) for steps to disable the `systemd` integration.
 
 Add these lines to the start of your `conf/local.conf`:
 
@@ -249,7 +249,7 @@ ARTIFACTIMG_FSTYPE = "ext4"
 
 # Build for Mender production setup (on-prem)
 #
-# https://docs.mender.io/artifacts/building-for-production
+# https://docs.mender.io/artifac../03.Building-for-production/docs.md
 #
 # Uncomment below and update the URL to match your configured domain
 # name and provide the path to the generated server.crt file.
@@ -265,11 +265,11 @@ ARTIFACTIMG_FSTYPE = "ext4"
 #SRC_URI_append_pn-mender = " file://server.crt"
 ```
 
-!!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../variables#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../devices/yocto-project/partition-configuration#file-system-types) for more information.
+!!! The size of the disk image (`.sdimg`) should match the total size of your storage so you do not leave unused space; see [the variable MENDER_STORAGE_TOTAL_SIZE_MB](../99.Variables/docs.md#mender_storage_total_size_mb) for more information. Mender selects the file system type it builds into the disk image, which is used for initial flash provisioning, based on the `ARTIFACTIMG_FSTYPE` variable. See the [section on file system types](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#file-system-types) for more information.
 
 !!! If you are building for **[hosted Mender](https://hosted.mender.io?target=_blank)**, make sure to set `MENDER_SERVER_URL` and `MENDER_TENANT_TOKEN` (see the comments above).
 
-!!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../yocto-project/image-configuration#configuring-the-image-for-read-only-rootfs).
+!!! If you would like to use a read-only root file system, please see the section on [configuring the image for read-only rootfs](../../10.Yocto-project/02.Image-configuration/docs.md#configuring-the-image-for-read-only-rootfs).
 
 #### Building the image
 
@@ -294,14 +294,14 @@ There is one Mender disk image, which will have one of the following suffixes:
   * `.sdimg` if the system is an ARM system and boots using U-Boot (without UEFI emulation)
   * `.biosimg` if the system is an x86 system and boots using the traditional BIOS and GRUB bootloader
 
-!!! Please consult the [bootloader support section](../../../devices/yocto-project/bootloader-support) for information on which boot method is typically used in each build configuration.
+!!! Please consult the [bootloader support section](../../../03.Devices/chapter.md/yocto-project/bootloader-support) for information on which boot method is typically used in each build configuration.
 
 This disk image is used to provision the device storage for devices without
-Mender running already. Please proceed to [Provisioning a new device](../../provisioning-a-new-device)
+Mender running already. Please proceed to [Provisioning a new device](../../20.Provisioning-a-new-device/docs.md)
 for steps to do this.
 
 On the other hand, if you already have Mender running on your device and want to deploy a rootfs update
-using this build, you should use the [Mender Artifact](../../../architecture/mender-artifacts) files,
+using this build, you should use the [Mender Artifact](../../../02.Architecture/04.Mender-Artifacts/docs.md) files,
 which have `.mender` suffix.
 
 !!! If you built for one of the virtual Mender reference boards (`qemux86-64` or `vexpress-qemu`), you can start up your newly built image with the script in `../meta-mender/meta-mender-qemu/scripts/mender-qemu` and log in as *root* without password.

--- a/04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md
+++ b/04.Artifacts/10.Yocto-project/02.Image-configuration/01.Features/docs.md
@@ -63,7 +63,7 @@ Below is a list of the features that Mender provides, with descriptions:
 
 * `mender-systemd` - Enables a Mender build that uses systemd. See also the
   section about [disabling Mender as a system
-  service](..#disabling-mender-as-a-system-service).
+  service](../docs.md#disabling-mender-as-a-system-service).
 
 * `mender-uboot` - Enables integration with the U-Boot bootloader.
 

--- a/04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md
+++ b/04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md
@@ -32,15 +32,15 @@ In this case it is also possible to avoid Mender's current dependency on systemd
 MENDER_FEATURES_DISABLE_append = " mender-systemd"
 ```
 
-Also, you do not need any daemon-related configuration items in your `local.conf` as outlined in [the section on configuring the Yocto Project build](../../../artifacts/yocto-project/building#configuring-the-build).
+Also, you do not need any daemon-related configuration items in your `local.conf` as outlined in [the section on configuring the Yocto Project build](../../../04.Artifacts/10.Yocto-project/01.Building/docs.md#configuring-the-build).
 
-! If you disable Mender running as a daemon under `systemd`, you must run all required Mender commands from the CLI or scripts. Most notably, you need to run `mender -commit` after booting into and verifying a successful deployment. When running in managed mode, any pending `mender -commit` will automatically be run by the Mender daemon after it starts. See [Modes of operation](../../../architecture/overview#modes-of-operation) for more information about the difference.
+! If you disable Mender running as a daemon under `systemd`, you must run all required Mender commands from the CLI or scripts. Most notably, you need to run `mender -commit` after booting into and verifying a successful deployment. When running in managed mode, any pending `mender -commit` will automatically be run by the Mender daemon after it starts. See [Modes of operation](../../../02.Architecture/01.Overview/docs.md#modes-of-operation) for more information about the difference.
 
 
 ## Configuring polling intervals
 
 You can configure how frequently the Mender client will make requests to the Mender server
-as described in [Polling intervals](../../../client-configuration/configuration-file/polling-intervals) before
+as described in [Polling intervals](../../../05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md) before
 starting the build process.
 
 In order to do this, change the following in the file

--- a/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
+++ b/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-This section describes the steps that are specific to production builds for Yocto Project. If you are using Debian converted images please refer to [setting parameters for mender-convert](../../debian-family)
+This section describes the steps that are specific to production builds for Yocto Project. If you are using Debian converted images please refer to [setting parameters for mender-convert](../../15.Debian-family/docs.md)
 These steps are not necessary if you are just trying out Mender, but must be done before deploying to production.
 
 
@@ -29,18 +29,18 @@ bitbake-layers remove-layer meta-mender-demo
 
 For security reasons, the Mender client does not require any open ports at the embedded device. Therefore, all communication between the Mender client and the server is always initiated by the client and it is important to configure the client so that the frequency of sending various requests to the server is reasonable for a given setup.
 
-Please refer to [polling intervals](../../../client-configuration/configuration-file/polling-intervals), for information on how to choose and how to set polling intervals.
+Please refer to [polling intervals](../../../05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md), for information on how to choose and how to set polling intervals.
 
 ## Certificates
 
 Certificates are used to ensure the communication between the client and the server is secure, so that it is not possible for an adversary to pose as a legitimate server.
 
-!! Please make sure that the clock is set correctly on your devices. Otherwise certificate verification will become unreliable. See [certificate troubleshooting](../../../troubleshooting/mender-client#certificate-expired-or-not-yet-valid) for more information.
+!! Please make sure that the clock is set correctly on your devices. Otherwise certificate verification will become unreliable. See [certificate troubleshooting](../../../201.Troubleshooting/03.Mender-Client/docs.md#certificate-expired-or-not-yet-valid) for more information.
 
 
 ### Preparing the client certificates
 
-You can either generate new certificates by following the guide for [generating certificates](../../../administration/certificates-and-keys#generating-new-keys-and-certificates), or obtain the certificates in a different way - for example from your existing Certificate Authority. In either case the certificates on the client and server must be the same.
+You can either generate new certificates by following the guide for [generating certificates](../../../07.Administration/03.Certificates-and-keys/docs.md#generating-new-keys-and-certificates), or obtain the certificates in a different way - for example from your existing Certificate Authority. In either case the certificates on the client and server must be the same.
 
 ### Including the client certificates
 
@@ -78,9 +78,9 @@ Note in particular the `:` after the directory; this is mandatory.
 
 ### Updating MENDER_SERVER_URL
 
-Please note that setting up for production will require that you explicitly set the [MENDER_SERVER_URL variable](../variables#mender_server_url) to the proper value for your server.
+Please note that setting up for production will require that you explicitly set the [MENDER_SERVER_URL variable](../99.Variables/docs.md#mender_server_url) to the proper value for your server.
 
-!!! Note that, this step is not required for the [standalone mode](../../../architecture/standalone-deployments).
+!!! Note that, this step is not required for the [standalone mode](../../../02.Architecture/06.Standalone-deployments/docs.md).
 
 ## Artifact signing and verification keys
 
@@ -98,4 +98,4 @@ SRC_URI_append = " file://artifact-verify-key.pem"
 
 Note that it is also possible (but not recommended) to use `local.conf`, by using [the same method as for client certificates](#using-localconf), adding `pn-mender` to the variable names.
 
-For more information about some alternate approaches please follow the [MENDER_ARTIFACT_VERIFY_KEY documentation](../variables#mender_artifact_verify_key).
+For more information about some alternate approaches please follow the [MENDER_ARTIFACT_VERIFY_KEY documentation](../99.Variables/docs.md#mender_artifact_verify_key).

--- a/04.Artifacts/10.Yocto-project/99.Variables/docs.md
+++ b/04.Artifacts/10.Yocto-project/99.Variables/docs.md
@@ -17,7 +17,7 @@ and used by Mender.
 
 Defines which file system type Mender will build for the rootfs partitions in
 the `.biosimg`, `.sdimg`, `.uefiimg` and the `.mender` file. See [File system
-types](../../../devices/yocto-project/partition-configuration#file-system-types)
+types](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#file-system-types)
 for more information.
 
 
@@ -82,7 +82,7 @@ default is empty, which means the artifact won't be signed.
 
 The signature can also be added or changed outside the build process, by using
 the `mender-artifact` tool's `-k` option. For more information, see [signing
-Mender Artifacts](../../signing-and-verification#signing).
+Mender Artifacts](../../40.Signing-and-verification/docs.md#signing).
 
 
 #### MENDER_ARTIFACT_VERIFY_KEY
@@ -92,7 +92,7 @@ Mender Artifacts](../../signing-and-verification#signing).
 If set, this will add the given public verification key to the client
 configuration, which means that the client will reject updates which are not
 signed by the corresponding private key (see
-[MENDER_ARTIFACT_SIGNING_KEY](#mender-artifact-signing-key)).
+[MENDER_ARTIFACT_SIGNING_KEY](#mender_artifact_signing_key)).
 
 More specifically, it will add the key to the root filesystem under
 `/etc/mender/artifact-verify-key.pem`, and add a `ArtifactVerifyKey` entry to
@@ -115,7 +115,7 @@ Note that you cannot both use `MENDER_ARTIFACT_VERIFY_KEY` and have
 > Value: <block device> (default: 1st partition on `MENDER_STORAGE_DEVICE`)
 
 The partition Mender uses as the boot partition. See [More detailed storage
-configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
+configuration](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md)
 for more information.
 
 
@@ -134,7 +134,7 @@ exists to override the auto detection.
 
 The size of the boot partition in the generated `.biosimg`, `.sdimg` or
 `.uefiimg` file. See [Configuring the partition
-sizes](../../../devices/yocto-project/partition-configuration#configuring-the-partition-sizes)
+sizes](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md)
 for more information.
 
 
@@ -144,7 +144,7 @@ for more information.
 
 The partition Mender uses as the persistent data partition. See [More detailed
 storage
-configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
+configuration](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#more-detailed-storage-configuration)
 for more information.
 
 
@@ -154,7 +154,7 @@ for more information.
 
 <!--AUTOVERSION: "Yocto Project 2.5 % and later"/ignore-->
 !!! This variable and the associated method is obsolete in Yocto Project 2.5 sumo and later.
-Simply [using recipes](../../../devices/yocto-project/partition-configuration#deploying-files-to-the-persistent-data-partition)
+Simply [using recipes](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#deploying-files-to-the-persistent-data-partition)
 to put files in the `/data` partition is enough.
 
 This variable is used to add files to the data partition of the Mender
@@ -201,7 +201,7 @@ exists to override the auto detection.
 
 The size of the persistent data partition in the generated `.biosimg`, `.sdimg`
 or `.uefiimg` file. See [Configuring the partition
-sizes](../../../devices/yocto-project/partition-configuration#configuring-the-partition-sizes)
+sizes](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#configuring-the-partition-sizes)
 for more information.
 
 
@@ -259,7 +259,7 @@ tool](https://www.yoctoproject.org/docs/latest/dev-manual/dev-manual.html#creati
 > Value: <mender features> (default: empty)
 
 Features appended to this variable will be disabled in the build. See [the
-section on features](../image-configuration/features) for more information.
+section on features](../02.Image-configuration/01.Features/docs.md) for more information.
 
 
 #### MENDER_FEATURES_ENABLE
@@ -267,7 +267,7 @@ section on features](../image-configuration/features) for more information.
 > Value: <mender features> (default: platform dependent)
 
 Features appended to this variable will be enabled in the build. See [the
-section on features](../image-configuration/features) for more information.
+section on features](../02.Image-configuration/01.Features/docs.md) for more information.
 
 
 #### MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET
@@ -294,7 +294,7 @@ space between the partition table and the first partition.
 > Value: <MTD ID> (default: first MTD ID in `MENDER_MTDIDS`)
 
 This variable is only relevant if the [the `mender-ubi`
-feature](../image-configuration/features#list-of-features) is enabled. The
+feature](../02.Image-configuration/01.Features/docs.md#list-of-features) is enabled. The
 variable should be set to the MTDID of the device that mender, and the root
 filesystem in particular, resides on. This is set automatically in cases where
 it's possible, but in some cases it must be set manually.
@@ -306,7 +306,7 @@ MENDER_MTDIDS = "nand0=20000000.flash"
 MENDER_IS_ON_MTDID = "20000000.flash"
 ```
 
-See also [`MENDER_MTDIDS`](#mender-mtdids).
+See also [`MENDER_MTDIDS`](#mender_mtdids).
 
 
 #### MENDER_KERNEL_IMAGETYPE_FORCE
@@ -361,7 +361,7 @@ otherwise the default is empty.
 > Value: <mtdids string> (no default, must be set if using UBI)
 
 This variable is only relevant if the [the `mender-ubi`
-feature](../image-configuration/features#list-of-features) is enabled, in which
+feature](../02.Image-configuration/01.Features/docs.md#list-of-features) is enabled, in which
 case it is mandatory. It lists the MTDID assignments on the system, separated by
 comma. For example:
 
@@ -369,7 +369,7 @@ comma. For example:
 MENDER_MTDIDS = "nand0=20000000.flash,nand1=30000000.flash"
 ```
 
-If it has more than one entry, then [`MENDER_IS_ON_MTDID`](#mender-is-on-mtdid)
+If it has more than one entry, then [`MENDER_IS_ON_MTDID`](#mender_is_on_mtdid)
 must be set too.
 
 
@@ -378,7 +378,7 @@ must be set too.
 > Value: <mtdparts string> (default calculated from several factors)
 
 This variable is only relevant if the [the `mender-ubi`
-feature](../image-configuration/features#list-of-features) is enabled. The
+feature](../02.Image-configuration/01.Features/docs.md#list-of-features) is enabled. The
 variable holds the MTDPARTS string for the Flash based device. This is set
 automatically in cases where it's possible, but in some cases it must be set
 manually. For example:
@@ -394,7 +394,7 @@ Two volume names have special meaning to the Mender `mtdimg` image builder:
 * `ubi` - The `ubimg` image (UBI image) will be put into this volume. The `ubi`
   volume should virtually always be present.
 
-See also [`MENDER_MTDIDS`](#mender-mtdids).
+See also [`MENDER_MTDIDS`](#mender_mtdids).
 
 
 #### MENDER_NAND_FLASH_PAGE_SIZE
@@ -431,7 +431,7 @@ storage device is a UBI volume.
 
 The partition Mender uses as the first (A) rootfs partition. See [More detailed
 storage
-configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
+configuration](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#more-detailed-storage-configuration)
 for more information.
 
 
@@ -460,7 +460,7 @@ Defaults to `${MENDER_STORAGE_DEVICE}:rootfsa` when building `.ubimg`.
 
 The partition Mender uses as the second (B) rootfs partition. See [More detailed
 storage
-configuration](../../../devices/yocto-project/partition-configuration#more-detailed-storage-configuration)
+configuration](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#more-detailed-storage-configuration)
 for more information.
 
 
@@ -488,7 +488,7 @@ Variable to override the URL of the server for the client to connect to.
 > Value: `${S}/mender-state-scripts ${MENDER_STATE_SCRIPTS_DIR}` (default)
 
 Variable to override the location of state scripts. See
-[MENDER_STATE_SCRIPTS_DIR](#mender-state-scripts-dir) for more information.
+[MENDER_STATE_SCRIPTS_DIR](#mender_state_scripts_dir) for more information.
 
 
 #### MENDER_STATE_SCRIPTS_DIR
@@ -518,7 +518,7 @@ The three methods should not be mixed.
 
 The storage device holding all partitions (rootfs, boot, data) used by Mender.
 See [Configuring
-storage](../../../devices/yocto-project/partition-configuration#configuring-storage)
+storage](../../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#configuring-storage)
 for more information.
 
 
@@ -540,7 +540,7 @@ automatically by subtracting the sizes of boot (see
 [MENDER_BOOT_PART_SIZE_MB](#mender_boot_part_size_mb)) and data partitions (see
 [MENDER_DATA_PART_SIZE_MB](#mender_data_part_size_mb)) along with some
 predefined overhead (see
-[MENDER_PARTITIONING_OVERHEAD_MB](#mender_partitioning_overhead_mb))). Default
+[MENDER_PARTITIONING_OVERHEAD_KB](#mender_partitioning_overhead_kb))). Default
 value is `1024`.
 
 
@@ -630,7 +630,7 @@ The storage device, as referred to by U-Boot (e.g. `1`). This variable can be
 used in cases where the Linux kernel and U-Boot refer to the same device with
 different names. See [The bootloader and the Linux kernel do not agree about the
 indexes of storage
-devices](../../../troubleshooting/yocto-project-build#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-index)
+devices](../../../201.Troubleshooting/01.Yocto-project-build/docs.md#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-indexes-of-storage-devices)
 for more information.
 
 If the variable is empty, it is automatically deduced from
@@ -645,7 +645,7 @@ The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can
 be used in cases where the Linux kernel and U-Boot refer to the same device with
 different names. See [The bootloader and the Linux kernel do not agree about the
 indexes of storage
-devices](../../../troubleshooting/yocto-project-build#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-index)
+devices](../../../201.Troubleshooting/01.Yocto-project-build/docs.md#the-bootloader-and-the-linux-kernel-do-not-agree-about-the-indexes-of-storage-devices)
 for more information.
 
 If the variable is empty, it is automatically deduced from
@@ -657,5 +657,5 @@ If the variable is empty, it is automatically deduced from
 > Value: `enable` (default)
 
 Controls whether to run Mender as a systemd service. See [Modes of
-operations](../../../architecture/overview#modes-of-operation) and [Image
-configuration](../image-configuration) for more information.
+operations](../../../02.Architecture/01.Overview/docs.md#modes-of-operation) and [Image
+configuration](../02.Image-configuration/docs.md) for more information.

--- a/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
+++ b/04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md
@@ -159,8 +159,8 @@ host machine.
 
 Learning to configure the converted image:
 
-[Image configuration](../image-configuration)
+[Image configuration](../02.image-configuration/docs.md)
 
 Learning about the configuration variables available:
 
-[Configuration variables](../variables)
+[Configuration variables](../03.variables/docs.md)

--- a/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
+++ b/04.Artifacts/15.Debian-family/02.image-configuration/docs.md
@@ -40,7 +40,7 @@ MENDER_ARTIFACT_NAME=release-1 ./mender-convert \
 
 Configuration files are also a means to add customization that might be
 necessary for specific devices or distributions. For more information please
-visit the [Board-integration](../../../devices/debian-family)
+visit the [Board-integration](../../../03.Devices/03.Debian-family/docs.md)
 section.
 
 
@@ -109,7 +109,7 @@ customize the files that are included in the output images.
 
 One example of a overlay-rootfs addition can be found in the
 `rootfs-overlay-demo` directory, which, after running the server setup script
-(see [Using hosted Mender](../building-a-mender-debian-image#using-mender-professional))
+(see [Using hosted Mender](../01.building-a-mender-debian-image/docs.md))
 contains:
 
 ```bash
@@ -133,4 +133,4 @@ recommended way of doing it.
 
 Learning about the configuration variables available:
 
-[Configuration variables](../variables)
+[Configuration variables](../03.variables/docs.md)

--- a/04.Artifacts/15.Debian-family/03.variables/docs.md
+++ b/04.Artifacts/15.Debian-family/03.variables/docs.md
@@ -52,7 +52,7 @@ if the result is larger than `IMAGE_ROOTFS_SIZE + IMAGE_ROOTFS_EXTRA_SPACE`, it
 will be used as the size of the rootfs instead of the other two variables.
 
 The actual free space will usually be lower than requested. See comment for
-[`IMAGE_ROOTFS_EXTRA_SPACE`](#image-rootfs-extra-space).
+[`IMAGE_ROOTFS_EXTRA_SPACE`](#image_rootfs_extra_space).
 
 This variable directly mirrors the variable from the Yocto Project, which is
 why it is missing a "MENDER_" prefix.

--- a/04.Artifacts/20.Provisioning-a-new-device/docs.md
+++ b/04.Artifacts/20.Provisioning-a-new-device/docs.md
@@ -5,7 +5,7 @@ taxonomy:
 ---
 
 After downloading one of the Mender demo images,
-[building a Mender Yocto Project image](../yocto-project/building) or [converting existing debian images](../debian-family)
+[building a Mender Yocto Project image](../10.Yocto-project/01.Building/docs.md) or [converting existing debian images](../15.Debian-family/docs.md)
 for the first time, you need to write the storage image to
 the flash of the device.
 
@@ -19,7 +19,7 @@ You need an image file to flash to the entire storage of the
 device. `meta-mender-core` creates these files with a `.sdimg`
 suffix, so they are easy to recognize. This file contains
 all the partitions of the given storage device, as
-described in [Partition layout](../../devices/general-system-requirements#partition-layout).
+described in [Partition layout](../../03.Devices/01.General-system-requirements/docs.md#partition-layout).
 
 
 ### A physical device to provision that uses SD cards
@@ -31,7 +31,7 @@ There are several methods to flash storage, and the simplest
 case is if your device uses a SD card. Currently, this is the approach
 we assume you take here, but the same `.sdimg` file can be used
 to flash any block device. See
-[Flash memory types](../../devices/yocto-project/partition-configuration#flash-memory-types)
+[Flash memory types](../../03.Devices/02.Yocto-project/01.Partition-configuration/docs.md#flash-memory-types)
 for a clarification of what is meant by block device in this context.
 
 

--- a/04.Artifacts/22.Snapshots/docs.md
+++ b/04.Artifacts/22.Snapshots/docs.md
@@ -57,7 +57,7 @@ mender snapshot dump --compression gzip > /mnt/root-part.ext4.gz
 !!! Don't forget the `.gz` extension in the target filename.
 
 In this case, passing `root-part.ext4` (or `root-part.ext4.gz`) as the 
-file-parameter to [mender-artifact](../../downloads#mender-artifact)
+file-parameter to [mender-artifact](../../08.Downloads/docs.md#mender-artifact)
 produces a deployment ready Mender Artifact:
 ```bash
 mender-artifact write rootfs-image -f /mnt/root-part.ext4 \

--- a/04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md
+++ b/04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md
@@ -5,7 +5,7 @@ taxonomy:
 ---
 
 A Mender Artifact is a file Mender uses to deploy updates. Please see
-[Mender Artifacts](../../architecture/mender-artifacts) for a more detailed
+[Mender Artifacts](../../02.Architecture/04.Mender-Artifacts/docs.md) for a more detailed
 description.
 
 When testing deployments, it is useful that the Artifact you are deploying
@@ -23,7 +23,7 @@ In this tutorial we will highlight some key use cases covered by the `mender-art
 The `mender-artifact` utility is used to create and inspect Mender Artifacts.
 
 Download the prebuilt `mender-artifact` binary for your platform following the links
-in [Downloads section](../../downloads#mender-artifact-tool).
+in [Downloads section](../../08.Downloads/docs.md#mender-artifact).
 
 
 ## Changing the Mender server
@@ -100,7 +100,7 @@ version of the Artifact format, you can build an older Artifact version with the
 `mender-artifact write rootfs-image -v 2 -t beaglebone -n release-1 -f
 rootfs.ext4 -o artifact.mender`. The default Artifact version is the latest one.
 Also see the build variable
-[MENDER_ARTIFACT_EXTRA_ARGS](../yocto-project/variables#mender_artifact_extra_args).
+[MENDER_ARTIFACT_EXTRA_ARGS](../10.Yocto-project/99.Variables/docs.md#mender_artifact_extra_args).
 
 !!! If you would like to generate a *signed Artifact*, simply add the `-k` option with the path to your *private key*. In our example above, the full command would be `mender-artifact write rootfs-image -t beaglebone -n release-1 -f rootfs.ext4 -o artifact-signed.mender -k private.key`.
 
@@ -122,7 +122,7 @@ Use `mender-artifact --help` to list all available compression options.
 ## Signing after modification
 
 If you are signing Artifacts, the signature will become invalid whenever
-you make modifications to them. See the section on [signing and verification](../signing-and-verification#an-existing-mender-artifact)
+you make modifications to them. See the section on [signing and verification](../40.Signing-and-verification/docs.md#an-existing-mender-artifact)
 for more information.
 
 

--- a/04.Artifacts/30.Modifying-a-disk-image/docs.md
+++ b/04.Artifacts/30.Modifying-a-disk-image/docs.md
@@ -38,7 +38,7 @@ mender-beaglebone.sdimg5      524288 786431  262144  128M 83 Linux
 ```
 
 In this example there are four partitions (plus an extended partition). Please see
-[Partition layout](../../devices/general-system-requirements#partition-layout) for a description of the
+[Partition layout](../../03.Devices/01.General-system-requirements/docs.md#partition-layout) for a description of the
 partitions Mender uses. The two Linux partitions in the middle, at device
 `.sdimg2` and `.sdimg3`, are the two rootfs partitions.
 

--- a/04.Artifacts/40.Signing-and-verification/docs.md
+++ b/04.Artifacts/40.Signing-and-verification/docs.md
@@ -44,7 +44,7 @@ In order to sign and later on verify the signature of the Mender Artifact we nee
 Please follow the respective section below, depending on the signature algorithm you want to use.
 
 After generating the keys you will have a file `private.key`, which is only used by the Signing system, as well as
-`public.key` which you [provision all the devices with](../yocto-project/building-for-production#artifact-signing-and-verification-keys).
+`public.key` which you [provision all the devices with](../10.Yocto-project/03.Building-for-production/docs.md#artifact-signing-and-verification-keys).
 
 !!! The file `public.key` is referred to as `artifact-verify-key.pem` when placed on the devices to avoid ambiguity with other keys.
 
@@ -81,7 +81,7 @@ The resulting `private.key` and `public.key` files are the private and public ke
 
 We use the `mender-artifact` tool to create a signed Artifact. Download the
 prebuilt `mender-artifact` binary for your platform following the links in
-[Downloads section](../../downloads#mender-artifact-tool).
+[Downloads section](../../08.Downloads/docs.md#mender-artifact).
 
 There are two ways to sign an Artifact: while creating it with the `write`
 command or once already created using the `sign` command. We add the `-k`
@@ -120,6 +120,6 @@ mender-artifact validate artifact-signed.mender -k public.key
 ## Enable Mender Client signature verification
 
 To make it easier to provision your devices with the public verification key and corresponding Mender Client configuration,
-Mender has integration with the Yocto Project. Please refer to the documentation for [Artifact signing and verification keys](../yocto-project/building-for-production#artifact-signing-and-verification-keys) to see how to include them.
+Mender has integration with the Yocto Project. Please refer to the documentation for [Artifact signing and verification keys](../10.Yocto-project/03.Building-for-production/docs.md#artifact-signing-and-verification-keys) to see how to include them.
 
 !!! The public verification key should be stored on *persistent storage* on the device where the Mender client runs, as the key should not change across deployments (except when doing key rotation). By default it is stored on the data partition.

--- a/04.Artifacts/50.State-scripts/docs.md
+++ b/04.Artifacts/50.State-scripts/docs.md
@@ -69,13 +69,13 @@ All other return codes are reserved for future use by Mender and should not be u
 
 ### Retry-later
 
-State scripts are allowed to return a specific error code (`21`), in which case the client will sleep for a time configured by [StateScriptRetryIntervalSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretryintervalseconds) before the state script is called again. Note that scripts are not allowed to retry for infinitely long. Please see description of [StateScriptRetryTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretrytimeoutseconds) for more information.
+State scripts are allowed to return a specific error code (`21`), in which case the client will sleep for a time configured by [StateScriptRetryIntervalSeconds](../../05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md#statescriptretryintervalseconds) before the state script is called again. Note that scripts are not allowed to retry for infinitely long. Please see description of [StateScriptRetryTimeoutSeconds](../../05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md#statescriptretrytimeoutseconds) for more information.
 
-This feature is useful e.g when you want user confirmation before proceeding with the update as is described in the [Update confirmation by end user](./#update-confirmation-by-end-user) section on this page.
+This feature is useful e.g when you want user confirmation before proceeding with the update as is described in the [Update confirmation by end user](.///docs.md#update-confirmation-by-end-user) section on this page.
 
 ## Script timeout
 
-Each script has a maximum execution time defined by [StateScriptTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescripttimeoutseconds). If a script exceeds this running time, its process group will be killed and the Mender client will treat the script and the update as failed.
+Each script has a maximum execution time defined by [StateScriptTimeoutSeconds](../../05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md#statescripttimeoutseconds). If a script exceeds this running time, its process group will be killed and the Mender client will treat the script and the update as failed.
 
 ## Power loss
 
@@ -90,7 +90,7 @@ Because of the possible re-execution described above, state scripts should be wr
 Mender captures the standard error (but not standard out) stream from
 state scripts. The standard error stream from state scripts is stored
 as part of the Mender deployment log, so it becomes available
-[locally on the client](../../troubleshooting/mender-client#deployment-log-files)
+[locally on the client](../../201.Troubleshooting/03.Mender-Client/docs.md#deployment-log-files)
 as well as reported to the server (if the deployment fails) to ease diagnostics.
 
 Thus the state scripts should be written so they output diagnostics
@@ -116,7 +116,7 @@ For many devices with a display that interacts with an end user, it is desirable
 
 Mender state scripts enable this use case with a script written to create the dialog box on the UI framework used. The script will simply wait for user input, and Mender will wait with the update process while waiting for the script to finish. Depending on what the user selects, the script can return `0` (proceed) or `21` ([retry later](#retry-later)). For example, this script can be run in the `Download_Enter` state, and the user will be asked before the download begins. Alternatively, the script can also be run in the `Download_Leave` state, if you want the download to finish first, and the user only to accept installing the update and rebooting.
 
-Make sure to adjust [StateScriptRetryTimeoutSeconds](../../client-configuration/configuration-file/configuration-options/#statescriptretrytimeoutseconds), to enable this use case.
+Make sure to adjust [StateScriptRetryTimeoutSeconds](../../05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md#statescriptretrytimeoutseconds), to enable this use case.
 
 ![End user update confirmation state scripts](mender-state-machine-user-confirmation.png)
 
@@ -136,7 +136,7 @@ In order to save power and bandwidth, network connectivity may not be enabled by
 
 A state script in `Sync_Enter` can enable network connectivity. You could also enable more powerful network connectivity, such as Wi-Fi, with a state script in `Download_Enter`. If the network is not brought up by default on reboot, you should also enable network in `Reboot_Leave`.
 
-!!! Note that the `Sync_Enter` transition can be reached quite frequently, depending on the [polling intervals](../../client-configuration/configuration-file/polling-intervals). The Mender Client also requires network in several following states of the update process to report progress to the Mender Server.
+!!! Note that the `Sync_Enter` transition can be reached quite frequently, depending on the [polling intervals](../../05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md). The Mender Client also requires network in several following states of the update process to report progress to the Mender Server.
 
 If you want to explicitly disable network again after Mender has finished the deployment, the only safe place to do this is in `Idle_Enter`.
 
@@ -145,7 +145,7 @@ If you want to explicitly disable network again after Mender has finished the de
 
 ## Including state scripts in Artifacts and disk images
 
-The easiest way to have Mender run the state scripts is to create a new OpenEmbedded recipe that inherits `mender-state-scripts` and copies them into place in `do_compile`, using the [${MENDER_STATE_SCRIPTS_DIR}](../../artifacts/yocto-project/variables#mender_state_scripts_dir) variable.
+The easiest way to have Mender run the state scripts is to create a new OpenEmbedded recipe that inherits `mender-state-scripts` and copies them into place in `do_compile`, using the [${MENDER_STATE_SCRIPTS_DIR}](../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_state_scripts_dir) variable.
 
 <!--AUTOVERSION: "meta-mender/tree/%"/ignore-->
 Take a look at the [example-state-scripts](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-demo/recipes-mender/example-state-scripts?target=_blank) recipe to get started.

--- a/05.Client-configuration/01.Overview/docs.md
+++ b/05.Client-configuration/01.Overview/docs.md
@@ -7,9 +7,9 @@ taxonomy:
 The main purpose of the Mender updater client is to install software updates to the device it is running on.
 However, it also includes functionality to work with a Mender server, such as authenticate, report inventory
 and the outcome of deployments. The Mender client runs in user space on top of an embedded Linux operating system.
-It can be run in standalone or managed mode, as described in [Modes of operation](../../architecture/overview#modes-of-operation).
+It can be run in standalone or managed mode, as described in [Modes of operation](../../02.Architecture/01.Overview/docs.md#modes-of-operation).
 For a more general overview of where the Mender client fits in as part of the deployment process,
-please see the [Architecture overview](../../architecture/overview).
+please see the [Architecture overview](../../02.Architecture/01.Overview/docs.md).
 
 In order to enable the client to work in as many environments as possible, it is built to be generic and extensible,
 while providing default setup and configuration that should work with most environments. Especially when running

--- a/05.Client-configuration/02.Cross-compiling/docs.md
+++ b/05.Client-configuration/02.Cross-compiling/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 By using Golang tools the Mender client can easily be cross-compiled to target
 a number of different architectures.
 
-! The Mender client must also be [integrated with your board](../../devices), cross-compiling it is often one step in the board integration process.
+! The Mender client must also be [integrated with your board](../../03.Devices/chapter.md), cross-compiling it is often one step in the board integration process.
 
 This example is targeting the `armhf` architecture but is applicable to other
 architectures with minor adjustments.

--- a/05.Client-configuration/04.Inventory/docs.md
+++ b/05.Client-configuration/04.Inventory/docs.md
@@ -5,7 +5,7 @@ taxonomy:
 ---
 
 Inventory is a set of simple key-value attributes that are useful know about a device,
-similar to the [device identity attributes](../identity). However, the device
+similar to the [device identity attributes](../03.Identity/docs.md). However, the device
 inventory attributes are not used to uniquely identify over time, they are just
 informational. As such, they do not need to be unique for each device like the
 device identity attributes.

--- a/05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md
+++ b/05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md
@@ -1,53 +1,53 @@
----
-title: Polling intervals
-taxonomy:
-    category: docs
----
+../docs.md-
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md:
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md-
 
-For security reasons, the Mender client does not require any open ports at the embedded device.
-Therefore, all communication between the Mender client and the server is always initiated by the client and
-it is important to configure the client so that the frequency of sending various requests to the server is
-reasonable for a given setup.
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdd
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
 
-There are two client configuration parameters that allow controlling the frequency of communication between
-the client and the server:
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdn
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
 
-* `UpdatePollIntervalSeconds` sets the frequency the client will send an update check request to the server.
-Default value: 1800 seconds (30 minutes).
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
 
-* `InventoryPollIntervalSeconds` sets the frequency for periodically sending [inventory data](../../inventory).
-Inventory data is always sent after each boot of the device, and after a new update has been
-correctly applied and committed by the device in addition to this periodic interval.
-Default value: 28800 seconds (8 hours).
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
 
-## How to choose right intervals
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
 
-The higher the frequency is (i.e. the lower the configuration value), the sooner the server will
-be updated with the client inventory data and the client will poll the update install request faster
-so updates can be deployed more quickly.
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
 
-But there is a trade-off, as the higher frequency is, the more load server will receive.
-If many clients are connected to one server, a high frequency
-will require more resources server-side to keep the environment responsive.
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdy
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
 
-!!! If you are using the Mender client in demo mode, either by selecting it when running `mender setup`, or by using one of the [prebuilt Yocto images](../../../downloads#disk-images) and set up with the [demo layer](../../../artifacts/yocto-project/building#adding-the-meta-layers), the Mender client has more aggressive polling intervals to simplify testing. The defaults noted above does not apply to demo mode and you will see extra network traffic in demo mode.
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
 
 
-## Changing the parameters
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
 
-Both parameters are stored in the configuration file `/etc/mender/mender.conf`:
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md:
 
-```
+../docs.md`
 {
-  "UpdatePollIntervalSeconds": 1800,
-  "InventoryPollIntervalSeconds": 28800,
-...
-```
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md
+../docs.md.
+../docs.md`
 
-Before building an image as described in [Building Mender Yocto
-image](../../../artifacts/yocto-project/building), you can adjust these configuration settings
-either [using a custom configuration file](..), or [using Yocto
-variables](../../../artifacts/yocto-project/image-configuration#configuring-polling-intervals).
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdo
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mds
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdo
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md.
 
-If you have already built an Artifact containing the rootfs, have a look at
-[modifying a configuration in a Mender Artifact](../../../artifacts/modifying-a-mender-artifact#modifying-a-configuration-file).
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.mdt
+../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md../docs.md

--- a/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
+++ b/05.Client-configuration/05.Configuration-file/50.Configuration-options/docs.md
@@ -12,21 +12,21 @@ these options can also be modified using Yocto variables.
 Specifies the location of the public key used to verify signed updates, and also
 enables signed-updates-only mode when it is set. If set the client will reject
 incorrectly signed updates, or updates without a signature. See also the section
-about [signing and verification](../../../artifacts/signing-and-verification).
+about [signing and verification](../../../04.Artifacts/40.Signing-and-verification/docs.md).
 
 #### InventoryPollIntervalSeconds
 
 An integer that sets the number of seconds to wait between each inventory
 update. Note that the client may occasionally post its inventory more often if
 there has been recent activity on the device. See also the section about
-[polling intervals](../polling-intervals).
+[polling intervals](../01.Polling-intervals/docs.md).
 
 #### UpdatePollIntervalSeconds
 
 An integer that sets the number of seconds to wait between each check for a new
 update. Note that the client may occasionally check more often if there has been
 recent activity on the device. See also the section about [polling
-intervals](../polling-intervals).
+intervals](../01.Polling-intervals/docs.md).
 
 #### ModuleTimeoutSeconds
 
@@ -41,7 +41,7 @@ An integer that sets the number of seconds to wait between each attempt to
 communicate with the server. Note that the client may attempt more often
 initially to enable rapid upgrades, but will gradually fall back to this value
 if the server is busy. See also the section about [polling
-intervals](../polling-intervals).
+intervals](../01.Polling-intervals/docs.md).
 
 #### RootfsPartA
 
@@ -96,7 +96,7 @@ it is returning `retry-later`.
 
 Default value is: `60`
 
-See also the section about [state scripts](../../../artifacts/state-scripts).
+See also the section about [state scripts](../../../04.Artifacts/50.State-scripts/docs.md).
 
 <!--AUTOVERSION: "mender v%"/ignore-->
 *Note*: Before mender v2.0.0 release, this option used to be called
@@ -125,7 +125,7 @@ aborting and marking the update as failed.
 
 Default value is: `1800` (30 min)
 
-See also the section about [state scripts](../../../artifacts/state-scripts).
+See also the section about [state scripts](../../../04.Artifacts/50.State-scripts/docs.md).
 
 <!--AUTOVERSION: "mender v%"/ignore-->
 *Note*: Before mender v2.0.0 release, this option used to be called
@@ -144,7 +144,7 @@ set it based on the expected execution time of your scripts.
 
 Default value is: `3600` (60 min)
 
-See also the section about [state scripts](../../../artifacts/state-scripts).
+See also the section about [state scripts](../../../04.Artifacts/50.State-scripts/docs.md).
 
 #### TenantToken
 

--- a/05.Client-configuration/05.Configuration-file/docs.md
+++ b/05.Client-configuration/05.Configuration-file/docs.md
@@ -8,7 +8,7 @@ Much of the Mender client's configuration resides in `/etc/mender/mender.conf`
 on the root filesystem. This file is JSON structured and defines various
 parameters for Mender's operation. Some of the most common settings are tunable
 using [Yocto
-variables](../../artifacts/yocto-project/image-configuration#configuring-polling-intervals). The
+variables](../../04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md#configuring-polling-intervals). The
 remaining parameters can only be changed by providing your own `mender.conf`.
 
 On systems where it is desired for one or more of the configuration options

--- a/05.Client-configuration/06.Installing/docs.md
+++ b/05.Client-configuration/06.Installing/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 This page describes how to install the Mender client in an existing Linux system. Installing this way does not offer a full Mender integration. However, it is possible to use Update Modules and update parts of the system.
 
-If full board integration is desired, follow the device documentation on [Yocto Project](../../devices/yocto-project) or [Debian family](../../devices/debian-family).
+If full board integration is desired, follow the device documentation on [Yocto Project](../../03.Devices/02.Yocto-project/docs.md) or [Debian family](../../03.Devices/03.Debian-family/docs.md).
 
 
 ## Install Mender using the Debian package
@@ -17,7 +17,7 @@ A Debian package (`.deb`) is provided for convenience to install on e.g Debian, 
 - arm64: (ARM-v8): ARM 64bit processors, for example Debian for Asus Tinker Board
 - amd64: Generic 64-bit x86 processors, the most popular among workstations
 
-See [the downloads page](../../downloads) for links to download all package architectures. We will assume *armhf* in the following, which is the most common.
+See [the downloads page](../../08.Downloads/docs.md) for links to download all package architectures. We will assume *armhf* in the following, which is the most common.
 
 
 ### Download the package
@@ -27,7 +27,7 @@ See [the downloads page](../../downloads) for links to download all package arch
 wget https://d1b0l86ne08fsf.cloudfront.net/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
 ```
 
-!!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../downloads) for other architectures, and also make sure to modify the references to the package in commands below.
+!!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../08.Downloads/docs.md) for other architectures, and also make sure to modify the references to the package in commands below.
 
 
 ### Option 1: Attended installation with a wizard
@@ -44,7 +44,7 @@ sudo dpkg -i mender-client_master-1_armhf.deb
 
 After the installation wizard is completed, Mender is correctly setup on your
 device and will automatically start in [managed
-mode](../../architecture/overview#modes-of-operation). Your device is now ready
+mode](../../02.Architecture/01.Overview/docs.md#modes-of-operation). Your device is now ready
 to authenticate with the server and start receiving updates.
 
 

--- a/06.Server-integration/01.Using-the-apis/docs.md
+++ b/06.Server-integration/01.Using-the-apis/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-The Mender server microservices are all accessible using an HTTPS API. These APIs can be used to configure the server (for example, pre-authorizing devices) or implementing custom workflows (for example, integrating the Mender server into an existing device management system.) There are separate APIs for [Open Source](../../apis/open-source) and [Enterprise](../../apis/enterprise).
+The Mender server microservices are all accessible using an HTTPS API. These APIs can be used to configure the server (for example, pre-authorizing devices) or implementing custom workflows (for example, integrating the Mender server into an existing device management system.) There are separate APIs for [Open Source](../../200.APIs/01.Open-source/docs.md) and [Enterprise](../../200.APIs/02.Enterprise/docs.md).
 
 There are many ways to interact with Mender's REST APIs and the most common ones are shown below.
 
@@ -21,7 +21,7 @@ Over time the functionality of `mender-cli` will be extended to simplify the mos
 
 First download the [prebuilt mender-cli Linux binary here][x.x.x_mender-cli].
 
-!!! If you need to build `mender-cli` from source, the general steps are the same as for [compiling mender-artifact from source](../../artifacts/modifying-a-mender-artifact#compiling-mender-artifact). Just use the [mender-cli repository](https://github.com/mendersoftware/mender-cli?target=_blank) instead of the mender-artifact repository.
+!!! If you need to build `mender-cli` from source, the general steps are the same as for [compiling mender-artifact from source](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#compiling-mender-artifact). Just use the [mender-cli repository](https://github.com/mendersoftware/mender-cli?target=_blank) instead of the mender-artifact repository.
 
 Then open a terminal in the directory you downloaded `mender-cli` and run the following commands to log in to your Mender server.
 
@@ -68,7 +68,7 @@ Next, set a variable with your user email on the Mender server (replace its cont
 MENDER_SERVER_USER='myusername@example.com'
 ```
 
-Now obtain a management API JSON Web Token by using the [Open Source](../../apis/open-source/management-apis/user-administration-and-authentication#log-in-to-mender) or [Enterprise](../../apis/enterprise/management-apis/user-administration-and-authentication#log-in-to-mender) login API:
+Now obtain a management API JSON Web Token by using the [Open Source](../../200.APIs/01.Open-source/02.Management-APIs/06.User-administration-and-authentication/docs.md#log-in-to-mender) or [Enterprise](../../200.APIs/02.Enterprise/02.Management-APIs/06.User-administration-and-authentication/docs.md#log-in-to-mender) login API:
 
 ```bash
 JWT=$(curl -X POST -u $MENDER_SERVER_USER $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
@@ -76,7 +76,7 @@ JWT=$(curl -X POST -u $MENDER_SERVER_USER $MENDER_SERVER_URI/api/management/v1/u
 
 !!! If you are using self-signed certificates in a demo setup you may want to skip validation with the `-k` option of `curl` (this is insecure).
 
-You should now have an API token you can use to call any of the [Mender server management APIs](../../apis/open-source/management-apis) in the `JWT` shell variable.
+You should now have an API token you can use to call any of the [Mender server management APIs](../../200.APIs/01.Open-source/02.Management-APIs/docs.md) in the `JWT` shell variable.
 
 !!! The `MENDER_SERVER_URI` and `JWT` shell variables will only exist in the current shell invocation by default, so make sure you use this same shell environment for any interactions with the API.
 

--- a/06.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/06.Server-integration/02.Preauthorizing-devices/docs.md
@@ -4,9 +4,9 @@ taxonomy:
     category: docs
 ---
 
-The Mender server supports [preauthorizing devices](../../architecture/device-authentication#preauthorization-flow), where you add the [identity](../../client-configuration/identity) and public key of the device to the Mender server before the device connects for the first time. This way the device is automatically authorized to join the Mender server when it first connects. This is in particular useful in a mass production setting because you can preauthorize devices when they are manufactured so they automatically get accepted into the Mender server when your customer turns them on, which might happen several months after manufacturing.
+The Mender server supports [preauthorizing devices](../../02.Architecture/02.Device-authentication/docs.md#preauthorization-flow), where you add the [identity](../../05.Client-configuration/03.Identity/docs.md) and public key of the device to the Mender server before the device connects for the first time. This way the device is automatically authorized to join the Mender server when it first connects. This is in particular useful in a mass production setting because you can preauthorize devices when they are manufactured so they automatically get accepted into the Mender server when your customer turns them on, which might happen several months after manufacturing.
 
-See [Device authentication](../../architecture/device-authentication) for a general overview of how device authentication works in Mender.
+See [Device authentication](../../02.Architecture/02.Device-authentication/docs.md) for a general overview of how device authentication works in Mender.
 
 
 ## Prerequisites
@@ -14,19 +14,19 @@ See [Device authentication](../../architecture/device-authentication) for a gene
 
 ### A board integrated with Mender
 
-You need a physical board that has already been [integrated with Mender](../). For example, you may use one of the reference boards BeagleBone Black, Raspberry Pi 3 or Raspberry Pi 4.
+You need a physical board that has already been [integrated with Mender](). For example, you may use one of the reference boards BeagleBone Black, Raspberry Pi 3 or Raspberry Pi 4.
 
 
 ### A block-based disk image for your board
 
-We assume you have either [built a disk image for your board](../../artifacts/yocto-project/building) or base it off one of the [pre-built images](../../downloads#disk-images). Note that a disk image is used to provision the entire storage of the board (it contains *all* the partitions) and typically has the `.sdimg` suffix.
+We assume you have either [built a disk image for your board](../../04.Artifacts/10.Yocto-project/01.Building/docs.md) or base it off one of the [pre-built images](../../08.Downloads/docs.md#disk-images). Note that a disk image is used to provision the entire storage of the board (it contains *all* the partitions) and typically has the `.sdimg` suffix.
 
 !!! Raw flash or raw filesystem images are not covered by this tutorial; however the steps are conceptually the same in these cases.
 
 
 ### The identity of your device
 
-When preauthorizing a device you need to know its [identity](../../client-configuration/identity). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI (note it is *not* the ID of the device, but the key-value attributes under Identity that are used for preauthorization).
+When preauthorizing a device you need to know its [identity](../../05.Client-configuration/03.Identity/docs.md). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI (note it is *not* the ID of the device, but the key-value attributes under Identity that are used for preauthorization).
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
 By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/master/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
@@ -38,17 +38,17 @@ Once your device boots with a newly provisioned disk image, it should already be
 
 ![Mender UI - device pending authorization](device-pending-authorization.png)
 
-If your device does not show as pending authorization in the Mender server once it is booted with the disk image, you need to diagnose this issue before continuing. See the [troubleshooting section on connecting devices](../../troubleshooting/device-runtime#mender-server-connection-issues) in this case.
+If your device does not show as pending authorization in the Mender server once it is booted with the disk image, you need to diagnose this issue before continuing. See the [troubleshooting section on connecting devices](../../201.Troubleshooting/05.Device-Runtime/docs.md#mender-server-connection-issues) in this case.
 
 
 ### A CLI environment for your server
 
 In order to access the the Mender server API with the commands below, you need to set up some shell variables in the terminal you will be using.
 
-Follow the steps in [set up shell variables for cURL](../using-the-apis#set-up-shell-variables-for-curl).
+Follow the steps in [set up shell variables for cURL](../01.Using-the-apis/docs.md#set-up-shell-variables-for-curl).
 
 ### Mender-Artifact tool
-Please follow [the documentation on mender-artifact](../../artifacts/modifying-a-mender-artifact#mender-artifact) and install it.
+Please follow [the documentation on mender-artifact](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#mender-artifact) and install it.
 
 
 ## Generate a client keypair
@@ -94,7 +94,7 @@ keys-client-generated/
 
 ## Preauthorize your device
 
-Now that we have the device's identity and public key, we will use the Mender server management REST APIs to preauthorize it. The APIs are documented for both [Open Source](../../apis/open-source/management-apis) and [Enterprise](../../apis/enterprise/management-apis).
+Now that we have the device's identity and public key, we will use the Mender server management REST APIs to preauthorize it. The APIs are documented for both [Open Source](../../200.APIs/01.Open-source/02.Management-APIs/docs.md) and [Enterprise](../../200.APIs/02.Enterprise/02.Management-APIs/docs.md).
 
 
 ### Make sure there are no existing authentication sets for your device
@@ -125,7 +125,7 @@ curl -H "Authorization: Bearer $JWT" -X DELETE $MENDER_SERVER_URI/api/management
 
 Once this is done, re-run the command above to generate the `devauth.json` file again and verify that your device identity does not exist anywhere.
 
-In the event that the decommissioning operation fails, perform a [manual database cleanup via the provided CLI command](../../troubleshooting/mender-server#cleaning-up-the-deviceauth-database-after-device-decommissioning).
+In the event that the decommissioning operation fails, perform a [manual database cleanup via the provided CLI command](../../201.Troubleshooting/04.Mender-Server/docs.md#cleaning-up-the-deviceauth-database-after-device-decommissioning).
 
 ### Call the preauthorize API
 
@@ -143,7 +143,7 @@ Secondly, set the contents of the device public key you generated above in a sec
 DEVICE_PUBLIC_KEY="$(cat keys-client-generated/public.key | sed -e :a  -e 'N;s/\n/\\n/;ta')"
 ```
 
-Then simply call the [API to preauthorize a device](../../apis/open-source/management-apis/device-authentication#devices-post):
+Then simply call the [API to preauthorize a device](../../200.APIs/01.Open-source/02.Management-APIs/02.Device-authentication/docs.md#devices-post):
 
 ```bash
 curl -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -X POST -d "{ \"identity_data\" : $DEVICE_IDENTITY_JSON_OBJECT_STRING, \"pubkey\" : \"$DEVICE_PUBLIC_KEY\" }" $MENDER_SERVER_URI/api/management/v2/devauth/devices
@@ -188,6 +188,6 @@ Then insert the SD card back into your device and boot it.
 
 If everything went as intended, your device will get the `accepted` status in the Mender server. You can log in to the Mender UI to ensure your device is listed and reports inventory.
 
-If your device shows as `pending`, see the troubleshooting on [a device shows up as pending after preauthorizing it](../../troubleshooting/mender-server#a-device-shows-up-as-pending-after-preauthorizing-it).
+If your device shows as `pending`, see the troubleshooting on [a device shows up as pending after preauthorizing it](../../201.Troubleshooting/04.Mender-Server/docs.md#a-device-shows-up-as-pending-after-preauthorizing-it).
 
-If you do not see your device at all, verify it booted correctly and it is able to connect to the Mender server. You can check [the Mender client logs on the device](../../troubleshooting/mender-client#obtaining-client-logs) for more diagnostics information.
+If you do not see your device at all, verify it booted correctly and it is able to connect to the Mender server. You can check [the Mender client logs on the device](../../201.Troubleshooting/03.Mender-Client/docs.md#obtaining-client-logs) for more diagnostics information.

--- a/07.Administration/01.Overview/docs.md
+++ b/07.Administration/01.Overview/docs.md
@@ -8,7 +8,7 @@ Mender backend is composed of a number of microservices, each implementing a
 small, well defined piece of functionality.
 
 The integration environment, previously used
-in [Create a test environment](../../getting-started/on-premise-installation/create-a-test-environment)
+in [Create a test environment](../../01.Getting-started/02.On-premise-installation/02.Create-a-test-environment/docs.md)
 chapter, brings together the following services:
 
 - [Mender Device Authentication Service](https://github.com/mendersoftware/deviceauth?target=_blank)

--- a/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -35,7 +35,7 @@ taxonomy:
 This section describes how to upgrade from the Mender Open Source server, to the
 Mender Enterprise server. If you have any questions or would like assistance
 with upgrading to Mender Enterprise, please email
-[contact@mender.io](mailto:contact@mender.io).
+[contact@mender.io]().
 
 !! In this version of Mender, there is no support for migrating data between the
 !! Open Source and Enterprise servers. Hence you will **lose all data** on the
@@ -92,7 +92,7 @@ docker volume create --name=mender-db
 ```
 
 After deleting the volumes, you need to follow [the main guide for installing
-the Enterprise server](..#enterprise). You will be directed back to this guide
+the Enterprise server](../docs.md#enterprise). You will be directed back to this guide
 when it is time to migrate the clients.
 
 <!-- AUTOMATION: execute=cp config/enterprise.yml.template config/enterprise.yml -->
@@ -110,7 +110,7 @@ connect without a tenant token.
 
 1. Fetch the tenant token using the **tenant ID** that you obtained while
    [creating the first organization and
-   user](..#creating-the-first-organization-and-user) (replace `$TENANT_ID`
+   user](../docs.md#creating-the-first-organization-and-user) (replace `$TENANT_ID`
    accordingly):
 
    <!-- AUTOMATION: execute=TENANT_ID=$( ( ./run exec mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword ) | tr -d '\r' ) -->
@@ -150,7 +150,7 @@ connect without a tenant token.
 
 5. To finalize the upgrade follow the steps in [the Enterprise installation
    tutorial from saving the enterprise
-   configuration](..#saving-the-enterprise-configuration).
+   configuration](../docs.md#saving-the-enterprise-configuration).
 
 <!-- Verification -->
 
@@ -176,13 +176,13 @@ organization. See one of these sections for details on how to include tenant
 tokens using various client integration methods:
 
 * [Mender installed on device using a deb
-  package](../../../client-configuration/installing#configuration-for-hosted-mender-server)
+  package](../../../05.Client-configuration/06.Installing/docs.md)
 * [Device integration using Yocto
-  Project](../../../artifacts/yocto-project/variables#mender_tenant_token)
+  Project](../../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_tenant_token)
 * [Device integration with Debian
-  Family](../../../artifacts/debian-family#convert-a-raw-disk-image)
+  Family](../../../04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md#convert-a-raw-disk-image)
 * [Modifying an existing prebuilt
-  image](../../../artifacts/modifying-a-mender-artifact#changing-the-mender-server)
+  image](../../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#changing-the-mender-server)
 
 Once all devices have been migrated, the `DEVICEAUTH_DEFAULT_TENANT_TOKEN`
 should be configured empty.

--- a/07.Administration/02.Production-installation/docs.md
+++ b/07.Administration/02.Production-installation/docs.md
@@ -24,7 +24,7 @@ steps that are covered in the [Enterprise subsection](#enterprise).
 
 ! If you have already installed an Open Source server and wish to upgrade to
 ! Enterprise, you should follow [the Enterprise upgrade
-! guide](upgrading-from-os-to-enterprise) instead of this guide.
+! guide]() instead of this guide.
 
 
 ## Prerequisites
@@ -45,7 +45,7 @@ steps that are covered in the [Enterprise subsection](#enterprise).
 If you are setting up a Mender Enterprise server, you will also need:
 
 - An account with Mender in order to evaluate and use the commercial features in
-  Mender Enterprise. Please email [contact@mender.io](mailto:contact@mender.io)
+  Mender Enterprise. Please email [contact@mender.io]()
   to receive an evaluation account.
 
 !!! It is very likely possible to use other Linux distributions and versions. However, we recommend using this exact environment for running Mender because it is known to work and you will thus avoid any issues specific to your environment if you use this reference.
@@ -70,7 +70,7 @@ At the end of this guide you will have:
 - SSL certificate for the Storage Proxy
 - a set of keys for generating and validating access tokens
 
-Consult the section on [certificates and keys](../certificates-and-keys) for details on
+Consult the section on [certificates and keys](../03.Certificates-and-keys/docs.md) for details on
 how the certificates and keys are used in the system.
 
 #### Docker compose naming scheme
@@ -270,7 +270,7 @@ Your local directory tree should now look like this:
 The production template file `prod.yml` is already configured to load keys and
 certificates from locations created by the `keygen` script. If you wish to use a
 different set of certificates or keys, please consult the
-[relevant documentation](../certificates-and-keys).
+[relevant documentation](../03.Certificates-and-keys/docs.md).
 
 Next, we can add and commit generated keys and certificates:
 
@@ -298,7 +298,7 @@ git commit -m 'production: adding generated keys and certificates'
 
 The API Gateway and Storage Proxy certificates generated here need to be made
 available to the Mender client.
-Consult the section on [building for production](../../artifacts/yocto-project/building-for-production)
+Consult the section on [building for production](../../04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md)
 for a description on how to include the certificates in the client builds.
 
 !! Only certificates need to be made available to devices or end users. Private keys should never be shared.
@@ -432,7 +432,7 @@ The updated entry should look similar to this, you can verify with `git diff`:
 #### Deployments service
 
 The deployments service will upload artifact objects to `minio` storage via `storage-proxy`,
-see the [administration overview](../overview) for more details. For this reason,
+see the [administration overview](../01.Overview/docs.md) for more details. For this reason,
 access credentials `DEPLOYMENTS_AWS_AUTH_KEY` and `DEPLOYMENTS_AWS_AUTH_SECRET`
 need to be updated and `DEPLOYMENTS_AWS_URI` must point to the domain name of your Storage proxy.
 
@@ -489,7 +489,7 @@ The entry should now look like this:
 ```
 
 You can also change the values for `DOWNLOAD_SPEED` and `MAX_CONNECTIONS`.
-See the [section on bandwidth](../bandwidth) for more details on these
+See the [section on bandwidth](../04.Bandwidth/docs.md) for more details on these
 settings.
 
 
@@ -672,7 +672,7 @@ First log in to the Mender docker registry with your Mender Enterprise credentia
 docker login registry.mender.io
 ```
 
-!!! If you have lost your credentials or need an evaluation account please email [contact@mender.io](mailto:contact@mender.io).
+!!! If you have lost your credentials or need an evaluation account please email [contact@mender.io]().
 
 Bring up all services up in detached mode with the following command:
 
@@ -780,15 +780,15 @@ is going to be managed by Mender. Exactly how to include the token depends on
 which integration method is used with the client. Please refer to one of these sections:
 
 * [Migrating existing clients from an Open Source to an Enterprise
-  server](upgrading-from-os-to-enterprise#migrating-clients)
+  server](01.Upgrading-from-OS-to-Enterprise/docs.md#migrating-clients)
 * [Mender installed on device using a deb
-  package](../../client-configuration/installing#configuration-for-hosted-mender-server)
+  package](../../05.Client-configuration/06.Installing/docs.md#install-mender-using-the-debian-package)
 * [Device integration using Yocto
-  Project](../../artifacts/yocto-project/variables#mender_tenant_token)
+  Project](../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_tenant_token)
 * [Device integration with Debian
-  Family](../../artifacts/debian-family#convert-a-raw-disk-image)
+  Family](../../04.Artifacts/15.Debian-family/01.building-a-mender-debian-image/docs.md)
 * [Modifying an existing prebuilt
-  image](../../artifacts/modifying-a-mender-artifact#changing-the-mender-server)
+  image](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#changing-the-mender-server)
 
 
 ### Saving the Enterprise configuration
@@ -871,4 +871,4 @@ earlier](#creating-the-first-organization-and-user).
 
 If you encounter any issues while starting or running your Mender Server, you
 can take a look at the section for [troubleshooting Mender
-Server](../../../troubleshooting/mender-server).
+Server]().

--- a/07.Administration/03.Certificates-and-keys/docs.md
+++ b/07.Administration/03.Certificates-and-keys/docs.md
@@ -13,25 +13,25 @@ All keys are encoded in the PEM format. The public keys are shared in the
 standard X.509 certificate format, `cert.crt` below,
 while private keys are seen as `private.key` below.
 
-See the [service overview](../overview) for schematics of the service
+See the [service overview](../01.Overview/docs.md) for schematics of the service
 communication flow. An overview of the components that use keys and
 for which purpose can be seen below.
 
 | Component               | Purpose of keys                                                                                                                                                                                                                                                                                                                  | Shares certificate or key with                                                                                                                |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| API Gateway           | Listens to a public port for `https` requests only (plain `http` is disabled). These requests can come from Mender Clients that check for- or report status about updates through the [Device APIs](../../apis/open-source/device-apis), or from users and tools that manage deployments through the [Management APIs](../../apis/open-source/management-apis). | **Mender Clients** and users of the **Management APIs**, including web browsers accessing the **Mender UI**.                                       |
+| API Gateway           | Listens to a public port for `https` requests only (plain `http` is disabled). These requests can come from Mender Clients that check for- or report status about updates through the [Device APIs](../../200.APIs/01.Open-source/01.Device-APIs/docs.md), or from users and tools that manage deployments through the [Management APIs](../../200.APIs/01.Open-source/02.Management-APIs/docs.md). | **Mender Clients** and users of the **Management APIs**, including web browsers accessing the **Mender UI**.                                       |
 | Storage Proxy         | Listens to a public port for `https` requests only (plain `http` is disabled). The Deployment Service manages Artifacts through the Storage Proxy and Mender Clients make Artifact download requests.                                                                                                        | **Mender Clients** and **Deployment Service**.                                                                                                    |
-| User Administration   | Signs and verifies JSON Web Tokens that users of the [Management APIs](../../apis/open-source/management-apis), including end users of the Mender UI, include in their requests to authenticate themselves.                                                                                                                                     | Nothing. The service gets signature verification requests from the API Gateway, so all keys are kept private to the service and not shared. |
-| Device Authentication | Signs and verifies JSON Web Tokens that Mender Clients include in their requests to authenticate themselves when accessing the [Device APIs](../../apis/open-source/device-apis).                                                                                                                                                                   | Nothing. The service gets signature verification requests from the API Gateway, so all keys are kept private to the service and not shared. |
-| Mender Client | Signs requests for JSON Web Tokens sent to the Device Authentication service. A Mender Client will request a new token when it connects to the Mender Server for the first time, and when a token expires. The Mender Client includes a token in all its communication to authenticate itself when accessing the [Device APIs](../../apis/open-source/device-apis).                                                                                                                                                                   | The **Device Authentication** service stores the public keys of Mender Clients. |
-| Mender Artifact | Signs and verifies [Mender Artifacts](../../architecture/mender-artifacts). | The **Signing system** stores the private key used for signing Mender artifacts. After an artifact is signed using the private key it is verified by the **Mender Clients**. |
+| User Administration   | Signs and verifies JSON Web Tokens that users of the [Management APIs](../../200.APIs/01.Open-source/02.Management-APIs/docs.md), including end users of the Mender UI, include in their requests to authenticate themselves.                                                                                                                                     | Nothing. The service gets signature verification requests from the API Gateway, so all keys are kept private to the service and not shared. |
+| Device Authentication | Signs and verifies JSON Web Tokens that Mender Clients include in their requests to authenticate themselves when accessing the [Device APIs](../../200.APIs/01.Open-source/01.Device-APIs/docs.md).                                                                                                                                                                   | Nothing. The service gets signature verification requests from the API Gateway, so all keys are kept private to the service and not shared. |
+| Mender Client | Signs requests for JSON Web Tokens sent to the Device Authentication service. A Mender Client will request a new token when it connects to the Mender Server for the first time, and when a token expires. The Mender Client includes a token in all its communication to authenticate itself when accessing the [Device APIs](../../200.APIs/01.Open-source/01.Device-APIs/docs.md).                                                                                                                                                                   | The **Device Authentication** service stores the public keys of Mender Clients. |
+| Mender Artifact | Signs and verifies [Mender Artifacts](../../02.Architecture/04.Mender-Artifacts/docs.md). | The **Signing system** stores the private key used for signing Mender artifacts. After an artifact is signed using the private key it is verified by the **Mender Clients**. |
 
 
 ## Replacing keys and certificates
 
 In the following we will go through how to replace all the keys and certificates
 that the services use. This is very important as part of a
-[Production installation](../production-installation) because each installation
+[Production installation](../02.Production-installation/docs.md) because each installation
 must have unique keys in order to be secure, so that the private keys used are
 not compromised.
 
@@ -54,7 +54,7 @@ the heavy lifting. It is available in
 [Mender's Integration GitHub repository](https://github.com/mendersoftware/integration?target=_blank).
 
 Open a terminal and go to the directory where you cloned the integration repository
-as part of the [tutorial to create a test environment](../../getting-started/on-premise-installation/create-a-test-environment).
+as part of the [tutorial to create a test environment](../../01.Getting-started/02.On-premise-installation/02.Create-a-test-environment/docs.md).
 
 In order to generate the self-signed certificates, the script needs to know
 what the CN (Common Name) of the two certificates should be, i.e. which URL
@@ -73,7 +73,7 @@ CERT_API_CN=docker.mender.io CERT_STORAGE_CN=s3.docker.mender.io ./keygen
 
 !!! This generates keys with 128-bit security level (256-bit Elliptic Curve and 3072-bit RSA keys) and certificates valid for approximately 10 years. You can customize the parameters by adapting the script to your needs.
 
-!!! Make sure your device has the correct date/time set. If the date/time is incorrect, the certificate will not be validated. Consult the section on [Correct clock](../../devices/general-system-requirements#correct-clock) for details
+!!! Make sure your device has the correct date/time set. If the date/time is incorrect, the certificate will not be validated. Consult the section on [Correct clock](../../03.Devices/01.General-system-requirements/docs.md#correct-clock) for details
 
 The keys and certificates are placed in a directory `keys-generated`
 where you ran the script from, and each service has a subdirectory within it
@@ -175,7 +175,7 @@ The User Administration key can be mounted with the following snippet:
             - ./keys-generated/keys/useradm/private.key:/etc/useradm/rsa/private.pem
 ```
 
-The Management APIs are documented for [Open Source](../../apis/open-source/management-apis) and [Enterprise](../../apis/enterprise/management-apis).
+The Management APIs are documented for [Open Source](../../200.APIs/01.Open-source/02.Management-APIs/docs.md) and [Enterprise](../../200.APIs/02.Enterprise/02.Management-APIs/docs.md).
 
 #### Device Authentication
 
@@ -192,7 +192,7 @@ The Device Authentication key can be mounted with the following snippet:
             - ./keys-generated/keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem
 ```
 
-The Device APIs are documented for [Open Source](../../apis/open-source/device-apis) and [Enterprise](../../apis/enterprise/device-apis).
+The Device APIs are documented for [Open Source](../../200.APIs/01.Open-source/01.Device-APIs/docs.md) and [Enterprise](../../200.APIs/02.Enterprise/01.Device-APIs/docs.md).
 
 
 #### Mender Client
@@ -203,7 +203,7 @@ are typically provided by the `ca-certificates` package.
 
 If the certificate is self-signed, then clients that are to connect to the server need to have the file with
 the concatenated certificates (`keys-generated/certs/server.crt`) stored locally in order to verify
-the server's authenticity. Please see [the client section on building for production](../../artifacts/yocto-project/building-for-production)
+the server's authenticity. Please see [the client section on building for production](../../04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md)
 for a description on how to provision new device disk images with the new certificates. In this case, it
 is advisable to ensure there is a overlap between the issuance of new certificates and expiration of old
 ones so all clients are able to receive an update containing the new cert before the old one expires. You

--- a/07.Administration/06.Upgrading/docs.md
+++ b/07.Administration/06.Upgrading/docs.md
@@ -13,14 +13,14 @@ both Enterprise.
 
 !!! If you are looking to upgrade from Open Source to Enterprise, please visit
 !!! [the section on upgrading from Open Source to
-!!! Enterprise](../production-installation/upgrading-from-os-to-enterprise).
+!!! Enterprise](../02.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md).
 
 ! The upgrade procedure involves some downtime.
 
 ## Prerequisites
 
 It is assumed that the installation was performed following the steps
-in the [Production installation](../production-installation) guide. That means that
+in the [Production installation](../02.Production-installation/docs.md) guide. That means that
 you currently have:
 
 * a local git repository based
@@ -32,7 +32,7 @@ As a good engineering practice, it is advisable to perform the upgrade on a
 staging environment first. This will allow you to discover potential problems
 and allow to exercise the procedure in a safe manner.
 
-[Production installation](../production-installation) is largely based on using git and Mender integration
+[Production installation](../02.Production-installation/docs.md) is largely based on using git and Mender integration
 repository. This is the reason why the upgrade procedure follows a regular git
 workflow with branching, pulling remote changes and merging locally.
 
@@ -41,7 +41,7 @@ workflow with branching, pulling remote changes and merging locally.
 Before upgrading it is advisable to backup existing data and volumes.
 Consult the MongoDB and Docker manuals for the necessary steps.
 
-The [Backup and restore](../backup-and-restore) chapter provides examples and
+The [Backup and restore](../07.Backup-and-restore/docs.md) chapter provides examples and
 introduces example tools provided in Mender integration repository.
 
 ## Cleaning up the deviceauth database after device decommissioning.
@@ -49,7 +49,7 @@ introduces example tools provided in Mender integration repository.
 Before upgrading it is advisable to clean up any leftover devices from the deviceauth database.
 These can sometimes happen due to device decommissioning.
 You can find instructions on how to clean up the deviceauth database
-in the [Troubleshooting](../../troubleshooting/mender-server) chapter.
+in the [Troubleshooting](../../201.Troubleshooting/04.Mender-Server/docs.md) chapter.
 
 ## Updating your local repository
 
@@ -78,7 +78,7 @@ For each release there will be a corresponding release branch. For example, the
 branch named `2.0.x` provides the 2.0 release setup. Stable releases are tagged,
 e.g. `2.0.1`.
 
-Recall from the [production installation](../production-installation) guide that our
+Recall from the [production installation](../02.Production-installation/docs.md) guide that our
 local setup was introduced in a branch that was created from given release
 version. You can use git commands such as `git log` and `git diff` to review the changes
 introduced in upstream branch. For example:
@@ -211,9 +211,9 @@ Start the new environment:
 ## Upgrading Mender Clients
 
 The Mender Client binary is built into the root file system, so it can be upgraded by
-fetching the sources when [building a Yocto Project image](../../artifacts/yocto-project/building).
+fetching the sources when [building a Yocto Project image](../../04.Artifacts/10.Yocto-project/01.Building/docs.md).
 
-!! Older Mender clients do not support newer [versions of the Mender Artifact format](../../architecture/mender-artifacts#versions); they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
+!! Older Mender clients do not support newer [versions of the Mender Artifact format](../../02.Architecture/04.Mender-Artifacts/docs.md#versions); they will abort the deployment. You can build older versions of the Mender Artifact format to upgrade older Mender clients. See [Write a new Artifact](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#create-an-artifact-from-a-raw-root-file-system) for an introduction how to do this.
 
 
 

--- a/07.Administration/07.Backup-and-restore/docs.md
+++ b/07.Administration/07.Backup-and-restore/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 ## Docker volumes
 
-As described in the [production installation](../production-installation) chapter,
+As described in the [production installation](../02.Production-installation/docs.md) chapter,
 the Mender production stack requires a number of Docker volumes to be created. These
 volumes can be backed up using regular docker commands, such as `docker run` or
 `docker cp`.

--- a/08.Downloads/docs.md
+++ b/08.Downloads/docs.md
@@ -56,7 +56,7 @@ Note that you need to ensure that the mender-artifact utility is in a directory 
 $ sudo mv mender-artifact /usr/local/bin/
 ```
 
-!!! If you need to build `mender-artifact` from source, please see [Compiling mender-artifact](../artifacts/modifying-a-mender-artifact#compiling-mender-artifact).
+!!! If you need to build `mender-artifact` from source, please see [Compiling mender-artifact](../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#compiling-mender-artifact).
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 [x.x.x_mender-artifact-linux]: https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/linux/mender-artifact

--- a/201.Troubleshooting/01.Yocto-project-build/docs.md
+++ b/201.Troubleshooting/01.Yocto-project-build/docs.md
@@ -6,19 +6,19 @@ taxonomy:
 
 ##Your project is using a fork of U-Boot which conflicts with the U-Boot Mender uses
 
-When [Building a Mender Yocto Project image](../../artifacts/yocto-project/building) for your own project and device, you encounter a build error similar to the following:
+When [Building a Mender Yocto Project image](../../04.Artifacts/10.Yocto-project/01.Building/docs.md) for your own project and device, you encounter a build error similar to the following:
 
 ```
 ERROR: Multiple .bb files are due to be built which each provide u-boot (.../tisdk/sources/meta-variscite/recipes-bsp/u-boot/u-boot-var-som-am33.bb .../tisdk/sources/meta-ti/recipes-bsp/u-boot/u-boot_2014.07.bb).
  This usually means one provides something the other doesn't and should.
 ```
 
-Mender needs to configure U-Boot in order to support robust rootfs rollback. If your project relies on a fork of U-Boot this needs to be integrated. For more information, see [Integrating with U-Boot](../../devices/yocto-project/bootloader-support/u-boot), in particular the section on [Forks of U-boot](../../devices/yocto-project/bootloader-support/u-boot#forks-of-u-boot).
+Mender needs to configure U-Boot in order to support robust rootfs rollback. If your project relies on a fork of U-Boot this needs to be integrated. For more information, see [Integrating with U-Boot](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md), in particular the section on [Forks of U-boot](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md#forks-of-u-boot).
 
 
 ## A U-Boot component is failing to compile, and it compiles without Mender
 
-This may be an indication that Mender's automatic U-Boot patching has failed for the particular board that's being built for, and a manual patch may be required. For information on how to create such a patch, go to the [Manual U-Boot integration section](../../devices/yocto-project/bootloader-support/u-boot/manual-u-boot-integration).
+This may be an indication that Mender's automatic U-Boot patching has failed for the particular board that's being built for, and a manual patch may be required. For information on how to create such a patch, go to the [Manual U-Boot integration section](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md).
 
 
 ## The bootloader and the Linux kernel do not agree about the indexes of storage devices
@@ -55,7 +55,7 @@ If you see errors similar to the following during the Yocto Project build proces
 include/config_mender.h:34:3: error: #error CONFIG_BOOTCOUNT_ENV is required for Mender to work
 ```
 
-There are two alternatives to resolve this issue. Either you can upgrade to U-Boot v2014.07 or newer, where Boot Count Limit was introduced, or you can patch your current U-Boot version to support this or a similar feature. Please see [Bootloader support](../../devices/general-system-requirements#bootloader-support) for more information.
+There are two alternatives to resolve this issue. Either you can upgrade to U-Boot v2014.07 or newer, where Boot Count Limit was introduced, or you can patch your current U-Boot version to support this or a similar feature. Please see [Bootloader support](../../03.Devices/01.General-system-requirements/docs.md#bootloader-support) for more information.
 
 ## The build produces an error message "__populate_fs: Could not allocate block in ext2 filesystem while writing file..."
 
@@ -63,7 +63,7 @@ This is most likely because you are producing an image that has a lot of small f
 
 * Check if you have `dbg-pkgs` set in `IMAGE_FEATURES` or `EXTRA_IMAGE_FEATURES`. This will cause debug packages to be included in the image, which typically contain a lot of small files. If you don't need the debug information, this feature can be disabled.
 
-* Increase the size of the image by increasing the value in `MENDER_STORAGE_TOTAL_SIZE_MB` (see description in [Variables](../../artifacts/yocto-project/variables#mender_storage_total_size_mb)), which will also increase the number of blocks. However, note that unless it is increased greatly, this will still give you a filesystem which is fairly close to the block limit, so the problem could happen during production instead, if the device writes enough files.
+* Increase the size of the image by increasing the value in `MENDER_STORAGE_TOTAL_SIZE_MB` (see description in [Variables](../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_storage_total_size_mb)), which will also increase the number of blocks. However, note that unless it is increased greatly, this will still give you a filesystem which is fairly close to the block limit, so the problem could happen during production instead, if the device writes enough files.
 
 * Decrease the size of each block. This can be done by setting `EXTRA_IMAGECMD_ext4 = " -b 1024"` in `local.conf`. The default is 4096, it must be a power of 2, and it must not be smaller than 1024.
 
@@ -80,7 +80,7 @@ ERROR: Logfile of failure stored in: /home/user/poky/build/tmp/work/cortexa7hf-n
 ERROR: Task (/home/user/poky/meta-mender/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender-auto-provided_1.0.bb:do_package) failed with exit code '1'
 ```
 
-This is a known bug in U-Boot versions prior to v2017.05. If you get this error, the auto-provided recipe won't work, so you will have to carry out the steps in [the u-boot-fw-utils guide](../../devices/yocto-project/bootloader-support/u-boot/manual-u-boot-integration#u-boot-fw-utils). Note that only the section under "u-boot-fw-utils" is necessary, the other sections on the same page, such as `MENDER_UBOOT_AUTO_CONFIGURE = "0"`, should not be necessary to carry out unless you have other reasons to do so.
+This is a known bug in U-Boot versions prior to v2017.05. If you get this error, the auto-provided recipe won't work, so you will have to carry out the steps in [the u-boot-fw-utils guide](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils). Note that only the section under "u-boot-fw-utils" is necessary, the other sections on the same page, such as `MENDER_UBOOT_AUTO_CONFIGURE = "0"`, should not be necessary to carry out unless you have other reasons to do so.
 
 
 ## I get a build error if I am using PREFERRED_PROVIDER_virtual/bootloader instead of PREFERRED_PROVIDER_u-boot
@@ -101,7 +101,7 @@ PROVIDES += "u-boot"
 RPROVIDES_${PN} = "u-boot"
 ```
 
-Detailed explanation how to do it you can find in [Integrating with U-Boot](../../devices/yocto-project/bootloader-support/u-boot) section.
+Detailed explanation how to do it you can find in [Integrating with U-Boot](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md) section.
 
 
 ## I'm using Flash/UBI setup and getting the message that `BOOTENV_SIZE` is too big to fit two copies inside `MENDER_RESERVED_SPACE_BOOTLOADER_DATA` with proper alignment, but my Flash size should be big enough
@@ -189,7 +189,7 @@ Unlike x86, ARM based boards usually do not implement [the UEFI boot standard](h
 However, some boards do not call `distro_bootcmd` as part of their U-Boot startup script, and in this case the approach will not work. A typical symptom is that the U-Boot bootloader skips loading of GRUB entirely and goes directly to loading the kernel. If this happens to you, you have two choices:
 
 1. Change the bootscript to call `distro_bootcmd` by patching U-Boot
-2. Abandon GRUB integration and attempt [U-Boot integration](../../devices/yocto-project/bootloader-support/u-boot) instead
+2. Abandon GRUB integration and attempt [U-Boot integration](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md) instead
 
 
 ## My device ends up at the GRUB prompt and all error and debug messages are lost because it clears the screen
@@ -289,7 +289,7 @@ IMAGE_FSTYPES_remove = "mtdimg"
 Alternatively, if appropriate, you can remove the manually set `MENDER_MTDPARTS`
 variable, and let Mender set it automatically, but you will then get a generic
 `mtdimg` which may not work on the platform in question. Please refer to [the
-Raw Flash section](../../devices/yocto-project/raw-flash) for more information.
+Raw Flash section](../../03.Devices/02.Yocto-project/03.Raw-flash/docs.md) for more information.
 
 ## After updating, the RootfsPartA and RootfsPartB are missing from `/etc/mender/mender.conf`
 
@@ -312,7 +312,7 @@ to your `local.conf` file.
 
 This indicates that the size declared for the full Mender image is too small to contain all files in the root filesystem.
 
-Increase the size of the image by increasing the value in `MENDER_STORAGE_TOTAL_SIZE_MB` (see description in [Variables](../../artifacts/yocto-project/variables#mender_storage_total_size_mb)).
+Increase the size of the image by increasing the value in `MENDER_STORAGE_TOTAL_SIZE_MB` (see description in [Variables](../../04.Artifacts/10.Yocto-project/99.Variables/docs.md#mender_storage_total_size_mb)).
 
 ## Conflict between u-boot and grub-efi versions
 
@@ -337,4 +337,4 @@ There are several possible resolutions to this problem:
 
 2. See if you can use an updated version recipe for your fork of U-Boot, for example by fetching the latest Yocto branch for the layer that contains the U-Boot fork.
 
-3. Avoid UEFI altogether by switching off the `mender-grub` feature. This will require you to use [U-Boot integration](../../devices/yocto-project/bootloader-support/u-boot) instead.
+3. Avoid UEFI altogether by switching off the `mender-grub` feature. This will require you to use [U-Boot integration](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/docs.md) instead.

--- a/201.Troubleshooting/02.Running-Yocto-Project-image/docs.md
+++ b/201.Troubleshooting/02.Running-Yocto-Project-image/docs.md
@@ -49,7 +49,7 @@ Artifacts.
 
 Note that `mender-migrate-configuration` recipe uses a state script, and it
 might be needed to clean the yocto build after removing it. See note at [State
-Scripts](../../artifacts/state-scripts#including-state-scripts-in-artifacts-and-disk-images)
+Scripts](../../04.Artifacts/50.State-scripts/docs.md#including-state-scripts-in-artifacts-and-disk-images)
 
 
 ## Boot sequence fails with "Failed to mount /uboot" and "codepage cp437 not found"

--- a/201.Troubleshooting/03.Mender-Client/docs.md
+++ b/201.Troubleshooting/03.Mender-Client/docs.md
@@ -44,7 +44,7 @@ Each TLS certificate has a validity period, *Not Before* and *Not After*, and th
 the current time is outside this range.
 
 Most commonly this is caused by **incorrect time setting on the device** which runs the Mender client. Check this by
-running `date` on the device, and make sure it is correct. Consult the section on [Correct clock](../../devices/general-system-requirements#correct-clock)
+running `date` on the device, and make sure it is correct. Consult the section on [Correct clock](../../03.Devices/01.General-system-requirements/docs.md#correct-clock)
 for a more detailed discussion.
 
 To determine the status of your time synchronization, execute the following:
@@ -81,7 +81,7 @@ echo | openssl s_client -connect s3.example.com:9000 2>/dev/null | openssl x509 
 > ```
 
 We can see that both these certificates are currently valid.
-Also see the [documentation on certificates](../../administration/certificates-and-keys) for an
+Also see the [documentation on certificates](../../07.Administration/03.Certificates-and-keys/docs.md) for an
 overview and description on how to generate new certificates.
 
 
@@ -105,7 +105,7 @@ uses an official CA so the only reason your client would reject this is if it do
 in its system store.
 
 On the other hand, if you set up the Mender server yourself as described in
-[Production installation](../../administration/production-installation) and generated certificates as part of it,
+[Production installation](../../07.Administration/02.Production-installation/docs.md) and generated certificates as part of it,
 your need to make sure that the server certificates are in `/etc/mender/server.crt` on your device.
 
 To test that they match, run `cat /etc/mender/server.crt` on your device, and compare that to the output
@@ -117,7 +117,7 @@ openssl s_client -showcerts -connect mender.example.com:443 < /dev/null 2>/dev/n
 
 If these mismatch, then you need to update `/etc/mender/server.crt` on your client.
 You can do this manually for testing purposes, and you should
-[include the certificates in your Yocto Project build](../../artifacts/yocto-project/building-for-production#including-the-client-certificates).
+[include the certificates in your Yocto Project build](../../04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md#including-the-client-certificates).
 
 ## Artifact format not supported
 
@@ -127,11 +127,11 @@ When deploying an update with the Mender client, you see a log message similar t
 ERRO[0001] update install failed: failed to read and install update: reader: unsupported version: 2  module=state
 ```
 
-The problem here is most likely that you have built [a new version of the Artifact format](../../architecture/mender-artifacts#versions)
+The problem here is most likely that you have built [a new version of the Artifact format](../../02.Architecture/04.Mender-Artifacts/docs.md#versions)
 that your Mender Client does not support. It could also be that you are building a very old version of the
 Artifact format that your new version of the Mender Client does not support.
 
-In either case the solution is to [build a different version of the Artifact format](../../artifacts/modifying-a-mender-artifact#create-an-artifact-from-a-raw-root-file-system) that your Mender Client supports
+In either case the solution is to [build a different version of the Artifact format](../../04.Artifacts/25.Modifying-a-Mender-Artifact/docs.md#create-an-artifact-from-a-raw-root-file-system) that your Mender Client supports
 until you have upgraded all Mender Clients and can use the corresponding latest version of the Mender Artifact format.
 
 
@@ -147,12 +147,12 @@ ERRO[0000] exit status 1                                 module=partitions
 ERRO[0000] No match between boot and root partitions.    module=main
 ```
 
-The problem here is most likely that the device does not have the [partition layout Mender expects](../../devices/general-system-requirements#partition-layout). This could have happened if you just placed the Mender binary into your rootfs, but did not [reflash the entire storage device](../../artifacts/provisioning-a-new-device) with the `.sdimg.` file output from the [Yocto Project build](../../artifacts/yocto-project/building). When this happens, output from `mount` and `fw_printenv` can confirm that this is the problem you are seeing. The solution is to flash your entire storage device with the `.sdimg` output from the Yocto Project build process.
+The problem here is most likely that the device does not have the [partition layout Mender expects](../../03.Devices/01.General-system-requirements/docs.md#partition-layout). This could have happened if you just placed the Mender binary into your rootfs, but did not [reflash the entire storage device](../../04.Artifacts/20.Provisioning-a-new-device/docs.md) with the `.sdimg.` file output from the [Yocto Project build](../../04.Artifacts/10.Yocto-project/01.Building/docs.md). When this happens, output from `mount` and `fw_printenv` can confirm that this is the problem you are seeing. The solution is to flash your entire storage device with the `.sdimg` output from the Yocto Project build process.
 
 
 
 ## The Mender client uses excessive network traffic even when not deploying updates
 
-If you are using the Mender client in demo mode, either by selecting it when running `mender setup`, or by using one of the [prebuilt Yocto images](../../downloads#disk-images) and set up with the [demo layer](../../artifacts/yocto-project/building#adding-the-meta-layers), the Mender client has more aggressive [polling intervals](../../client-configuration/configuration-file/polling-intervals) to simplify testing.
+If you are using the Mender client in demo mode, either by selecting it when running `mender setup`, or by using one of the [prebuilt Yocto images](../../08.Downloads/docs.md#disk-images) and set up with the [demo layer](../../04.Artifacts/10.Yocto-project/01.Building/docs.md#adding-meta-mender-to-existing-yocto-project-environment), the Mender client has more aggressive [polling intervals](../../05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md) to simplify testing.
 
-See the documentation on [building for production](../../artifacts/yocto-project/building-for-production) and [polling intervals](../../client-configuration/configuration-file/polling-intervals) to reduce the network bandwidth usage.
+See the documentation on [building for production](../../04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md) and [polling intervals](../../05.Client-configuration/05.Configuration-file/01.Polling-intervals/docs.md) to reduce the network bandwidth usage.

--- a/201.Troubleshooting/04.Mender-Server/docs.md
+++ b/201.Troubleshooting/04.Mender-Server/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 This document details troubleshooting steps for the most common problems with the Mender server.
 The first part applies to all installations, while the section below on Production installations
-only applies when the Mender server is [installed for production](../../administration/production-installation).
+only applies when the Mender server is [installed for production](../../07.Administration/02.Production-installation/docs.md).
 
 ## Persistent certificate errors in demo mode
 Since the demo certificates are self-signed, browsers will produce relevant warnings.
@@ -27,7 +27,7 @@ Consult your browser's documentation for similar instructions.
 It is possible that after a failed device decommissioning operation there will be some unaccessible and unnecessary data in the deviceauth database. In this case, you should clean the database manually.
 
 Is is recommended to backup your data before performing the clean up operation.
-The [Backup and restore](../../administration/backup-and-restore) chapter provides examples and
+The [Backup and restore](../../07.Administration/07.Backup-and-restore/docs.md) chapter provides examples and
 introduces example tools provided in Mender integration repository.
 
 To clean up the deviceauth database, run the following from within the integration repository:
@@ -37,7 +37,7 @@ docker exec $(docker ps -q -n 1 -f 'name=device-auth') /usr/bin/deviceauth maint
 
 ## The virtual QEMU device is not showing up in demo mode
 
-When running the Mender server in demo mode, as described in the [getting started tutorial](../../getting-started/on-premise-installation),
+When running the Mender server in demo mode, as described in the [getting started tutorial](../../01.Getting-started/02.On-premise-installation/docs.md),
 the help tips in the UI give you an option to connect a virtual `qemux86-64` to the server for demo purposes.
 
 If you have trouble connecting this virtual device, please make sure your environment meets the resource requirements
@@ -47,7 +47,7 @@ start if you do not have enough memory.
 !!! The console of the virtual device can be seen by running `./demo --client logs mender-client`.
 
 ## A device shows up as pending after preauthorizing it
-If you see your device gets the `pending` status after [preauthorizing it](../../server-integration/preauthorizing-devices), something went wrong. Most likely there is a mismatch between the identity and public key [you preauthorized](../../server-integration/preauthorizing-devices#call-the-preauthorize-api) and what your Mender client is actually using.
+If you see your device gets the `pending` status after [preauthorizing it](../../06.Server-integration/02.Preauthorizing-devices/docs.md), something went wrong. Most likely there is a mismatch between the identity and public key [you preauthorized](../../06.Server-integration/02.Preauthorizing-devices/docs.md#call-the-preauthorize-api) and what your Mender client is actually using.
 
 To diagnose this, look for the device identity in the Device Authentication service, for example:
 
@@ -92,7 +92,7 @@ curl -H "Authorization: Bearer $JWT" $MENDER_SERVER_URI/api/management/v2/devaut
 
 In this case you can see that there are two authentication sets with the exact same device identity: `{"mac":"52:54:00:50:9b:84"}`, one `preauthorized` and one `pending`. So the device reported (see the `pending` set) the exact same identity as we preauthorized; however, there is a mismatch between the public keys.
 
-The solution is to decommission the device and [remove all authentication sets](../../server-integration/preauthorizing-devices#make-sure-there-are-no-existing-authentication-sets-for-your-dev) and make sure the key used in the [preauthorize API call](../../server-integration/preauthorizing-devices#call-the-preauthorize-api) matches exactly the one reported by the device, as seen in the `pending` data above.
+The solution is to decommission the device and [remove all authentication sets](../../06.Server-integration/02.Preauthorizing-devices/docs.md#make-sure-there-are-no-existing-authentication-sets-for-your-device) and make sure the key used in the [preauthorize API call](../../06.Server-integration/02.Preauthorizing-devices/docs.md#call-the-preauthorize-api) matches exactly the one reported by the device, as seen in the `pending` data above.
 
 
 ## mender-api-gateway exits with code 132
@@ -120,7 +120,7 @@ openresty from source for your architecture.
 # Production installations
 
 For the rest of this document, it is assumed that commands are run through production
-helper script `run` as detailed in the [production installation documentation](../../administration/production-installation).
+helper script `run` as detailed in the [production installation documentation](../../07.Administration/02.Production-installation/docs.md).
 
 ## Listing active containers
 
@@ -267,10 +267,10 @@ time="2017-01-31T08:25:15Z" level=fatal msg="NoCredentialProviders: no valid pro
 As seen in [container logs](#container-logs) section, `mender-deployments`
 service is restarting. The logs suggest there might be missing credentials for
 an AWS related service.
-From the [production installation](../../administration/production-installation) guide, we can recall
+From the [production installation](../../07.Administration/02.Production-installation/docs.md) guide, we can recall
 that
 `mender-deployments`
-[service configuration](../../administration/production-installation#deployments-service) contains
+[service configuration](../../07.Administration/02.Production-installation/docs.md#deployments-service) contains
 credentials for artifact storage service.
 
 Configuration of current instance of `mender-deployments` can be viewed using

--- a/201.Troubleshooting/05.Device-Runtime/docs.md
+++ b/201.Troubleshooting/05.Device-Runtime/docs.md
@@ -132,9 +132,9 @@ default.
 ### Accurate time required for certificate processing.
 
    Proper certificate processing requires an accurate system time. See
-   [Mender Client troubleshooting](../mender-client#certificate-expired-or-not-yet-valid)
+   [Mender Client troubleshooting](../03.Mender-Client/docs.md#certificate-expired-or-not-yet-valid)
    for more details.
 
 ## Next Steps
 
-If the above tests all pass, then please review [Mender Client troubleshooting](../mender-client) to help determine next steps.
+If the above tests all pass, then please review [Mender Client troubleshooting](../03.Mender-Client/docs.md) to help determine next steps.

--- a/README.markdown
+++ b/README.markdown
@@ -30,8 +30,8 @@ full license text.
 
 We take security very seriously. If you come across any issue regarding
 security, please disclose the information by sending an email to
-[security@mender.io](security@mender.io). Please do not create a new public
-issue. We thank you in advance for your cooperation.
+<security@mender.io>. Please do not create a new public issue. We thank you in
+advance for your cooperation.
 
 ## Connect with us
 

--- a/checkInternalLinks.js
+++ b/checkInternalLinks.js
@@ -1,0 +1,21 @@
+var remark = require('remark');
+var parse = require('remark-parse');
+var stringify = require('remark-stringify');
+var engine = require('unified-engine');
+
+engine(
+  {
+    // Standard engine configuration
+    processor: remark,
+    files: ['.'],
+    extensions: ['md'],
+    pluginPrefix: 'remark',
+    packageField: 'remarkConfig',
+    injectedPlugins: [parse, stringify],
+    color: true,
+    frail: true
+  },
+  (error, failed) => {
+    if (error || failed === 1) throw error;
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1105 @@
+{
+  "name": "mender-docs-verifier",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "requires": {
+        "@babel/highlight": "^7.10.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+    },
+    "@babel/highlight": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "ccount": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+    },
+    "character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+    },
+    "chokidar": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      }
+    },
+    "collapse-white-space": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
+    "figgy-pudding": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "optional": true
+    },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hosted-git-info": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
+      "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
+    },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+    },
+    "is-empty": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+      "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
+    "is-whitespace-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
+    },
+    "is-word-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "levenshtein-edit-distance": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
+      "integrity": "sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk="
+    },
+    "libnpmconfig": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "load-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/load-plugin/-/load-plugin-3.0.0.tgz",
+      "integrity": "sha512-od7eKCCZ62ITvFf8nHHrIiYmgOHb4xVNDRDqxBWSaao5FZyyZVX8OmRCbwjDGPrSrgIulwPNyBsWCGnhiDC0oQ==",
+      "requires": {
+        "libnpmconfig": "^1.0.0",
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "markdown-escapes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+    },
+    "markdown-extensions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
+      "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q=="
+    },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
+    "mdast-util-compact": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
+      "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
+      "requires": {
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+    },
+    "propose": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/propose/-/propose-0.0.5.tgz",
+      "integrity": "sha1-SKBl2ex9TIZn9AULFcSi2F28pWs=",
+      "requires": {
+        "levenshtein-edit-distance": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "remark": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.0.tgz",
+      "integrity": "sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==",
+      "requires": {
+        "remark-parse": "^8.0.0",
+        "remark-stringify": "^8.0.0",
+        "unified": "^9.0.0"
+      }
+    },
+    "remark-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-8.0.0.tgz",
+      "integrity": "sha512-5iRrk8ad+dU4espDl60H7ANhXqoaEXYsIyL8Mau0lDN6pP7QMAZsZTCX2XdoCfKfKEpiOggA7CHv43HkyVEppA==",
+      "requires": {
+        "markdown-extensions": "^1.1.0",
+        "remark": "^12.0.0",
+        "unified-args": "^8.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
+      "integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
+      "requires": {
+        "ccount": "^1.0.0",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^2.0.0",
+        "vfile-location": "^3.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.0.tgz",
+      "integrity": "sha512-FSPZv1ds76oAZjurhhuV5qXSUSoz6QRPuwYK38S41sLHwg4oB7ejnmZshj7qwjgYLf93kdz6BOX9j5aidNE7rA==",
+      "requires": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^2.0.0",
+        "mdast-util-compact": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^3.0.0",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-validate-links": {
+      "version": "git+https://github.com/oleorhagen/remark-validate-links.git#046decad83362314ceb2cbbc98927746ab50f88d",
+      "from": "git+https://github.com/oleorhagen/remark-validate-links.git#master",
+      "requires": {
+        "github-slugger": "^1.0.0",
+        "hosted-git-info": "^3.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "propose": "0.0.5",
+        "to-vfile": "^6.0.0",
+        "trough": "^1.0.0",
+        "unist-util-visit": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "state-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
+      "integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.2",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "to-vfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-6.1.0.tgz",
+      "integrity": "sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==",
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^4.0.0"
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "requires": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "unified": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
+      "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      }
+    },
+    "unified-args": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-8.1.0.tgz",
+      "integrity": "sha512-t1HPS1cQPsVvt/6EtyWIbQGurza5684WGRigNghZRvzIdHm3LPgMdXPyGx0npORKzdiy5+urkF0rF5SXM8lBuQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "chalk": "^3.0.0",
+        "chokidar": "^3.0.0",
+        "fault": "^1.0.2",
+        "json5": "^2.0.0",
+        "minimist": "^1.2.0",
+        "text-table": "^0.2.0",
+        "unified-engine": "^8.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "unified-engine": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/unified-engine/-/unified-engine-8.0.0.tgz",
+      "integrity": "sha512-vLUezxCnjzz+ya4pYouRQVMT8k82Rk4fIj406UidRnSFJdGXFaQyQklAnalsQHJrLqAlaYPkXPUa1upfVSHGCA==",
+      "requires": {
+        "concat-stream": "^2.0.0",
+        "debug": "^4.0.0",
+        "fault": "^1.0.0",
+        "figures": "^3.0.0",
+        "glob": "^7.0.3",
+        "ignore": "^5.0.0",
+        "is-buffer": "^2.0.0",
+        "is-empty": "^1.0.0",
+        "is-plain-obj": "^2.0.0",
+        "js-yaml": "^3.6.1",
+        "load-plugin": "^3.0.0",
+        "parse-json": "^5.0.0",
+        "to-vfile": "^6.0.0",
+        "trough": "^1.0.0",
+        "unist-util-inspect": "^5.0.0",
+        "vfile-reporter": "^6.0.0",
+        "vfile-statistics": "^1.1.0"
+      }
+    },
+    "unist-util-inspect": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-5.0.1.tgz",
+      "integrity": "sha512-fPNWewS593JSmg49HbnE86BJKuBi1/nMWhDSccBvbARfxezEuJV85EaARR9/VplveiwCoLm2kWq+DhP8TBaDpw==",
+      "requires": {
+        "is-empty": "^1.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+      "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
+    },
+    "unist-util-remove-position": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+      "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
+      "requires": {
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+      "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vfile": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
+      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ=="
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.1.tgz",
+      "integrity": "sha512-0OppK9mo8G2XUpv+hIKLVSDsoxJrXnOy73+vIm0jQUOUFYRduqpFHX+QqAQfvRHyX9B0UFiRuNJnBOjQCIsw1g==",
+      "requires": {
+        "repeat-string": "^1.5.0",
+        "string-width": "^4.0.0",
+        "supports-color": "^6.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-sort": "^2.1.2",
+        "vfile-statistics": "^1.1.0"
+      }
+    },
+    "vfile-sort": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
+      "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA=="
+    },
+    "vfile-statistics": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
+      "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "mender-docs-verifier",
+  "version": "1.0.0",
+  "description": "",
+  "main": "example.js",
+  "dependencies": {
+    "remark-cli": "^8.0.0",
+    "remark-validate-links": "https://github.com/oleorhagen/remark-validate-links#master"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mendersoftware/mender-docs.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/mendersoftware/mender-docs/issues"
+  },
+  "homepage": "https://github.com/mendersoftware/mender-docs#readme",
+  "remarkConfig": {
+    "plugins": [
+      "validate-links"
+    ]
+  },
+  "retextConfig": {
+    "plugins": [
+      "diacritics",
+      "english",
+      "indefinite-article",
+      "redundant-acronyms",
+      "repeated-words",
+      "sentence-spacing"
+    ]
+  }
+}


### PR DESCRIPTION
This PR:

* Adds a node.js script for verifying all internal links in the documentation (along with section headers)
* Rewrites all documentation links to use the directory relative (long form) style
* Adds a test to the Gitlab CI for broken internal links