### PR TITLE
Fix dead internal link

### DIFF
--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -294,7 +294,7 @@ There is one Mender disk image, which will have one of the following suffixes:
   * `.sdimg` if the system is an ARM system and boots using U-Boot (without UEFI emulation)
   * `.biosimg` if the system is an x86 system and boots using the traditional BIOS and GRUB bootloader
 
-!!! Please consult the [bootloader support section](../../../03.Devices/chapter.md/yocto-project/bootloader-support) for information on which boot method is typically used in each build configuration.
+!!! Please consult the [bootloader support section](../../../03.Devices/02.Yocto-project/02.Bootloader-support/docs.md) for information on which boot method is typically used in each build configuration.
 
 This disk image is used to provision the device storage for devices without
 Mender running already. Please proceed to [Provisioning a new device](../../20.Provisioning-a-new-device/docs.md)


### PR DESCRIPTION
See: https://github.com/remarkjs/remark-validate-links/issues/54 for why this
was not caught by the internal link checker.

This was a curious bug, and a result of a bug in my link migration script it
seems. bash '${VAR##.*#}' anyone? Seems it messed up the suffix placement :)

I also did a regex search for similar cases, and found none other than this one.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>