### PR TITLE
MEN-3677: Add the style-guide to the Mender-docs repo

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -1,0 +1,103 @@
+# Contribute to the Mender documentation
+
+Thank you for showing interest in contributing to the Mender project. Connecting
+with contributors and growing a community is very important to us. We hope you
+will find what you need to get started writing documentation on this page.
+
+## Provide a pull request
+
+Pull requests are very welcome, and the maintainers of Mender work hard to stay
+on top to review and hopefully merge your work.
+
+If your work is significant, it can make sense to discuss the idea with the
+maintainers and relevant project members upfront. Start a discussion on our
+[Mender Hub forum](https://hub.mender.io/c/general-discussions).
+
+### Sign your work
+
+Mender is licensed under the Apache License, Version 2.0. To ensure open source
+license compatibility, we need to keep track of the origin of all commits and
+make sure they comply with this license. To do this, we follow the same
+procedure as used by the Linux kernel, and ask every commit to be signed off.
+
+The sign-off is a simple line at the end of the explanation for the patch, which
+certifies that you wrote it or otherwise have the right to pass it on as an
+open-source commit.  The rules are pretty simple: if you can certify the below
+(from [developercertificate.org](http://developercertificate.org/)):
+
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Random J Developer <random@developer.example.org>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions).
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.
+
+## Write documentation
+
+### Documentation style guide
+
+Writing documentation for the Mender project requires that you follow the style
+guide as outlined in the [style guide document](./README-styleguide.markdown).
+
+The project also has a dedicated guide to the CLI and Bash script examples
+[here](./README-bash-styleguide.markdown).
+
+### Tools for documentation writers
+
+The project has a few tools to help with developing documentation:
+
+* [checklinks](README-checklinks.markdown) - Which automatically checks all internal links for duds.
+* [./scripts/passive.sh](./scripts/README-passive.markdown) - Checks a document for passive voice.
+* [./scripts/weasel.sh](./scripts/README-weasel.markdown) - Checks a document for weasel words.
+* [autoversion.py](README-autoversion.markdown) - Checks the version of a linked external tool.
+
+
+## Let us work together with you
+
+In an ever more digitized world, securing the world's connected devices is a
+very important and meaningful task. To succeed, we will need to row in the same
+direction and work to the best interest of the project.
+
+This project appreciates your friendliness, transparency and a collaborative
+spirit.

--- a/README-styleguide.markdown
+++ b/README-styleguide.markdown
@@ -1,0 +1,195 @@
+# Mender Documentation writing style guide
+
+## Why do we need one?
+
+To help us write documentation in a more clear way and keep a consistent tone,
+voice, and style.
+
+We have many writers and different reviewers, this guide is a reference for all
+to follow. Our audience members have diverse backgrounds in terms of language
+and skills, however we can assume a certain base level of reading, comprehension
+and technical knowledge. Keeping this in mind, we should make it as easy as
+possible for all of our target audience to use our product. Consistency and
+simplicity helps all our readers.
+
+## What does it cover?
+
+This documentation style guide borrows from the style guides of [IBM
+developerWorks](https://www.ibm.com/developerworks/library/styleguidelines/index.html),
+and [Red Hat style guides](https://stylepedia.net/style/). It covers the general
+guidelines of grammar and punctuation, but not design, layout or content, this
+is handled on a per PR basis.
+
+## Spelling
+
+Use American English conventions rather than British English.
+
+Examples:
+
+> * "-ize", not "-ise": e.g. "customize"
+> * "color" not "colour"
+
+Spelling can also be checked with the `spell-check.sh` script.
+
+## Use a single space before a new sentence after periods - not double spaces
+
+Example:
+
+> "First sentence. Second sentence."
+
+## Headers
+
+Capitalize using sentence case.
+
+Example:
+
+> "Deploy a system update demo"
+
+Headers should not end with a period.
+
+
+## Use second person ("you") when speaking to or about the reader
+
+Avoid gender-specific pronouns: use "they" and "their" rather than "he/she" and
+"his/hers." In most cases, use "you" when giving instructions, and "the user,"
+"new users," and so on in more general explanations.
+
+## Shorter words when possible
+
+Examples:
+
+> * "helps" rather than "facilitates"
+> * "uses" rather than "utilizes."
+
+## Active voice is preferred over passive voice
+
+Unless one of the following applies:
+
+* The system performs the action.
+* It is more appropriate to focus on the receiver of the action.
+* You want to avoid blaming the user for an error, such as in an error message.
+* The information is clearer in passive voice.
+* Avoid -ing endings if possible as they make the sentence longer and more passive / less actionable. Examples:.
+* "Get started", not "Getting started".
+* "Provision a new device", not "Provisioning a new device".
+* Helpful resource: the section titled "Passive Voice Should Never Be Used by
+  You" in the [Linux Journal Author's
+  Guide](https://www.linuxjournal.com/author/authguide).
+
+## Sentence structure
+
+* Shorter length.
+* Avoid run on sentences.
+* Avoid fragments.
+* Avoid unnecessary words (while not resorting to telegraphic style).
+* Word order (subject-verb-object).
+* Refer to https://stylepedia.net/style/#sentence-structure for details.
+
+## Colons and semicolons:
+
+Use a colon when introducing a list or bullet list.
+
+A phrase following a semicolon or colon should begin with a lowercase letter,
+unless it begins with a proper noun. Example:
+
+> "Older Mender clients do not support newer versions of the Mender Artifact format; they will abort the deployment."
+
+## Parentheses
+
+Use parentheses to improve the readability of sentences which include extra
+incidental information. Expressions beginning with i.e., e.g., that is and so on
+can be also set off with parentheses if they cause a major break in the
+sentence. If the break is minor, use commas instead.
+
+## Acronyms
+
+Should be defined the first time they are used, if they are likely to be
+unfamiliar to the user. However we can assume the user is familiar with common
+acronyms such as IP, OS, GB, RAM, SD card and so on).
+
+A/an before acronyms:
+
+The general rule is to use a before consonants and an before vowels. The trick
+here is to use your ears (how the acronym is pronounced), not your eyes (how
+it's spelled). Example:
+
+> * SD (pronounced "ess dee") begins with a vowel sound, so an SD card is correct.
+> * JSON (beginning with the "jay" consonant sound) would be a JSON object.
+
+## Abbreviations
+
+Use periods:
+
+Examples:
+
+> e.g., i.e., etc.
+
+## Numbering:
+
+* Numbers 1-9 should be written as words (one, two, three, etc.).
+* Numbers >=10 to be written as numbers.
+* Use a comma separate large numbers (e.g. 10,000).
+* Exceptions: avoid mixing number formats in same sentence.
+* Don't write: "...while three of our customers have over 20,000 devices...".
+* Do write: "...while 3 of our customers have over 20,000 devices...".
+
+## Use present tense as much as possible
+
+The users most often refer to the documentation while they are using the product.
+Example:
+
+> "The screen displays..." rather than "the screen will display..."
+
+## Bullet point lists
+
+* Complete sentence bullet points should end with a period.
+* Non-complete sentences (like simply a list of items) should not end in a period.
+
+Example of sentences:
+
+> * Alice is taller than Bob.
+> * Bob is heavier than Alice.
+
+Example of items:
+> * U-Boot
+> * GRUB
+> * Refer to How to Capitalize and Punctuate Bullet Points for details
+
+# Useful tools
+
+Punctuation and grammar tools: these apps can help evaluate your writing and warn about common problems such as passive voice, complexity, sentence length etc.
+
+* https://grammark.org
+* http://www.hemingwayapp.com
+* https://grammarly.com (payware)
+* [./scripts/passive.sh](./scripts/README-passive.markdown) <file>
+* [./scripts/weasel.sh](./scripts/README-weasel.markdown) <file>
+
+# Taxonomy
+
+Our taxonomy reference can be found [here](02.Overview/15.Taxonomy/docs.md).
+
+# Miscellaneous 
+
+* External links should always open in a new tab/window
+* Linking from docs.mender.io -> mender.io/Mender Hub counts as external
+* Internal links should open in the same tab/window. E.g. from one docs page to another
+
+Open links in the current tab:
+
+> [https://docs.mender.io](https://docs.mender.io)
+
+And in a new tab:
+
+> [https://docs.mender.io](https://docs.mender.io?target=_blank)
+
+
+
+
+# Readability
+
+Technical documents should be readable by the targeted audience. In this
+instance, we expect our audiences to have the minimum reading and comprehension
+level of an eighth-grade student, of an age between 14 and 15 years. The
+Flesch-Kincaid and Gunning Fog index provide measurable grades. A documentation
+tutorial should have a Gunning Fog index of 9-12.

--- a/README.markdown
+++ b/README.markdown
@@ -14,10 +14,9 @@ at [https://docs.mender.io](https://docs.mender.io?target=_blank)
 
 ## Contributing
 
-<!--AUTOVERSION: "mendersoftware/mender/blob/%/CONTRIBUTING.md"/ignore-->
-We welcome and ask for your contribution. If you would like to contribute to
-Mender, please read our guide on how to best get started [contributing code or
-documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md?target=_blank).
+We welcome and ask for your contribution. If you would like to contribute to the
+Mender documentation, please read our guide on how to best get started
+[contributing documentation](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
This adds the style-guide from:
https://docs.google.com/document/d/1LbrWKkVXf9s5Lq2Sa74WDb8Okh7h27Ptbf3a16fz57Y/edit
to the Mender-docs repo in markdown.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>