### PR TITLE
Authorization set renamed to Authentication set (alignment with API docs)

### DIFF
--- a/02.Overview/12.Taxonomy/docs.md
+++ b/02.Overview/12.Taxonomy/docs.md
@@ -32,7 +32,7 @@ container, or other.
 * _Authorization status_ - An attribute assigned to a device by the Mender server.
 It reflects the current state of authentication of a device authorization set.
 
-* _Authorization set_ - A key assigned to a device. It can be in one of
+* _Authentication set_ - A key assigned to a device. It can be in one of
 the following states:
   * "rejected"
   * "accepted"


### PR DESCRIPTION
The thinking behind it:

1. user authorizes a device
2. device is identified by an authentication set
3. there is no such thing as "authorization set"

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>