### PR TITLE
replace occurrences of 'guide' with 'tutorial'

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -7,16 +7,16 @@ taxonomy:
 !!! If you do not have have a Raspberry Pi, please go to
 !!! [Prepare a virtual device](../02.Prepare-a-virtual-device/docs.md).
 
-In this guide we will prepare a Raspberry Pi with a custom Raspberry Pi OS
+In this tutorial we will prepare a Raspberry Pi with a custom Raspberry Pi OS
 (previously called Raspbian) image. The only difference from the official
 Raspberry Pi OS image is that it has been converted to support robust system
 updates with Mender.
 
-Completing this guide normally **takes less than one hour**.
+Completing this tutorial normally **takes less than one hour**.
 
 ## Prerequisites
 
-To follow this guide, you will need the following:
+To follow this tutorial, you will need the following:
 
 * One of these Raspberry Pi models:
   * [Raspberry Pi 3 Model B](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/?target=_blank)

--- a/01.Get-started/01.Preparation/02.Prepare-a-virtual-device/docs.md
+++ b/01.Get-started/01.Preparation/02.Prepare-a-virtual-device/docs.md
@@ -6,13 +6,13 @@ taxonomy:
 
 !!! Skip this section if you have already completed [Prepare a Raspberry Pi device](../01.Prepare-a-Raspberry-Pi-device/docs.md)
 
-This guide we help you prepare your workstation to be able to run a virtual
+This tutorial we help you prepare your workstation to be able to run a virtual
 device (QEMU) with Mender integrated which will connect to hosted Mender and
 simulate a physical device.
 
 ## Prerequisites
 
-To follow this guide, install
+To follow this tutorial, install
 [Docker Engine](https://docs.docker.com/engine/install?target=_blank) on your
 workstation.
 

--- a/01.Get-started/01.Preparation/docs.md
+++ b/01.Get-started/01.Preparation/docs.md
@@ -38,7 +38,7 @@ available or not:
   If you do not have a Raspberry Pi available, you can use a virtual device to
   evaluate key Mender use cases.
 
-  This guide provides the steps for preparing your workstation to be able to run
+  This tutorial provides the steps for preparing your workstation to be able to run
   a virtual ([QEMU process emulator](https://www.qemu.org/)) device with Mender
   integrated.
 

--- a/01.Get-started/02.Deploy-an-application-update/docs.md
+++ b/01.Get-started/02.Deploy-an-application-update/docs.md
@@ -119,7 +119,7 @@ using Mender!
 
 ## Next steps
 
-Proceed to one of the following guides (listed in recommended order):
+Proceed to one of the following tutorials (listed in recommended order):
 
 1. [Deploy a system update](../03.Deploy-a-system-update/docs.md)
 1. [Deploy a container update](../04.Deploy-a-container-update/docs.md)

--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-This guide will walk you trough how to do robust system level updates with
+This tutorial will walk you trough how to do robust system level updates with
 rollback. These type of updates cover the whole system including system level
 applications and the Linux kernel and ensure the device comes back in a
 consistent state even if the update process is interrupted for any reason such

--- a/01.Get-started/04.Deploy-a-container-update/docs.md
+++ b/01.Get-started/04.Deploy-a-container-update/docs.md
@@ -4,10 +4,10 @@ taxonomy:
     category: docs
 ---
 
-!!! This guide is not supported by the virtual device because it does not come
+!!! This tutorial is not supported by the virtual device because it does not come
 !!! with a package manager to install the needed dependencies.
 
-This guide will walk you trough how to deploy Docker container updates with
+This tutorial will walk you trough how to deploy Docker container updates with
 Mender. We will be using the
 [Docker Update Module](https://hub.mender.io/t/docker/324?target=blank) which
 allows you to specify a list of container images and their versions in a
@@ -16,12 +16,12 @@ can later be deployed to your device using the hosted Mender server.
 
 ## Prerequisites
 
-To follow this guide, you will need to install:
+To follow this tutorial, you will need to install:
 
 * [Docker Engine](https://docs.docker.com/engine/install?target=_blank) on your
 workstation.
 
-It is also assumed that you have completed the following guides:
+It is also assumed that you have completed the following tutorials:
 
 * [Prepare a Raspberry Pi device](../01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md)
 * [Deploy an application update](../02.Deploy-an-application-update/docs.md)

--- a/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/01.Providing-custom-u-boot-fw-utils/docs.md
+++ b/03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/01.Providing-custom-u-boot-fw-utils/docs.md
@@ -42,9 +42,9 @@ this is the change:
 -require u-boot.inc
 +require recipes-bsp/u-boot/u-boot.inc
 +require recipes-bsp/u-boot/u-boot-mender.inc
- 
+
  DEPENDS += "dtc-native"
- 
+
 ```
 
 The first line changes a path inside the recipe, since the include file is not
@@ -88,19 +88,19 @@ will go through each line and explain why they are needed.
 -require recipes-bsp/u-boot/u-boot.inc
 -require recipes-bsp/u-boot/u-boot-mender.inc
 +require recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
- 
+
 -DEPENDS += "dtc-native"
 +SUMMARY = "U-Boot bootloader fw_printenv/setenv utilities"
 +LICENSE = "GPLv2+"
 +LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 +SECTION = "bootloader"
 +DEPENDS = "mtd-utils"
- 
+
  # This revision corresponds to the tag "v2016.03"
  # We use the revision in order to avoid having to fetch it from the
 @@ -9,3 +12,30 @@
  SRCREV = "df61a74e6845ec9bdcdd48d2aff5e9c2c6debeaa"
- 
+
  PV = "v2016.03+git${SRCPV}"
 +
 +SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
@@ -200,7 +200,7 @@ You may notice that the file looks very similar to the one that already exists
 in the Yocto Project, under
 `meta/recipes-bsp/u-boot/u-boot-fw-utils_2016.03.bb`, and this is indeed the
 case. Much of the inspiration was taken from there, and this is a good place to
-look if you hit problems and this guide doesn't provide the answer.
+look if you hit problems and this tutorial doesn't provide the answer.
 
 After the adaptation is complete, you should go through the [Integration
 checklist](../../02.Integration-checklist/docs.md) to make sure that all functionality

--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -29,7 +29,7 @@ The other layers in *meta-mender* provide support for specific boards used in Me
 
 [meta-mender-community](https://github.com/mendersoftware/meta-mender-community?target=_blank) is a set of layers containing board-specific settings for Mender integration.
 
-!!! For general information about getting started with Yocto Project, it is recommended to read the [Yocto Project Quick Start guide](http://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html?target=_blank).
+!!! For general information about getting started with Yocto Project, it is recommended to read the [Yocto Project Quick Start tutorial](http://www.yoctoproject.org/docs/2.4/yocto-project-qs/yocto-project-qs.html?target=_blank).
 
 
 ## Prerequisites

--- a/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
+++ b/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
@@ -40,7 +40,7 @@ Certificates are used to ensure the communication between the client and the ser
 
 ### Preparing the client certificates
 
-You can either generate new certificates by following the guide for [generating certificates](../../../07.Administration/04.Certificates-and-keys/docs.md#generating-new-keys-and-certificates), or obtain the certificates in a different way - for example from your existing Certificate Authority. In either case the certificates on the client and server must be the same.
+You can either generate new certificates by following the tutorial for [generating certificates](../../../07.Administration/04.Certificates-and-keys/docs.md#generating-new-keys-and-certificates), or obtain the certificates in a different way - for example from your existing Certificate Authority. In either case the certificates on the client and server must be the same.
 
 ### Including the client certificates
 

--- a/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -13,7 +13,7 @@ taxonomy:
 <!-- AUTOMATION: execute=ORIG_DIR=$PWD; function cleanup() { set +e; cd $ORIG_DIR/mender-server/production; ./run down -v; docker volume rm mender-artifacts mender-db mender-artifacts-backup mender-db-backup; cd $ORIG_DIR; rm -rf mender-server; } -->
 <!-- AUTOMATION: execute=trap cleanup EXIT -->
 
-<!-- Basically a repeat of Open Source setup from Production Installation guide -->
+<!-- Basically a repeat of Open Source setup from Production Installation tutorial -->
 <!-- AUTOVERSION: "git clone -b %"/integration -->
 <!-- AUTOMATION: execute=git clone -b master https://github.com/mendersoftware/integration mender-server -->
 <!-- AUTOMATION: execute=cd mender-server -->
@@ -39,8 +39,8 @@ with upgrading to Mender Enterprise, please email
 
 !! In this version of Mender, there is no support for migrating data between the
 !! Open Source and Enterprise servers. Hence you will **lose all data** on the
-!! server by following this guide, and all users must be recreated, artifacts
-!! must be re-uploaded, and devices re-accepted. The focus in this guide will be
+!! server by following this tutorial, and all users must be recreated, artifacts
+!! must be re-uploaded, and devices re-accepted. The focus in this tutorial will be
 !! on how to migrate the device fleet. Support for migrating server data will be
 !! added to a later Mender release.
 
@@ -91,8 +91,8 @@ docker volume create --name=mender-artifacts
 docker volume create --name=mender-db
 ```
 
-After deleting the volumes, you need to follow [the main guide for installing
-the Enterprise server](../docs.md#enterprise). You will be directed back to this guide
+After deleting the volumes, you need to follow [the main tutorial for installing
+the Enterprise server](../docs.md#enterprise). You will be directed back to this tutorial
 when it is time to migrate the clients.
 
 <!-- AUTOMATION: execute=cp config/enterprise.yml.template config/enterprise.yml -->
@@ -165,7 +165,7 @@ connect without a tenant token.
 
 After the Enterprise server has been set up and verified to work correctly, it
 is recommended to switch to tenant tokens on each device, as opposed to the
-default tenant token that was configured earlier in this guide. This gives a
+default tenant token that was configured earlier in this tutorial. This gives a
 small security benefit, by completely blocking devices that don't have a tenant
 token, and prevents devices showing up in the default organization by mistake,
 for example if the tenant token has been misspelled.

--- a/07.Administration/03.Production-installation/docs.md
+++ b/07.Administration/03.Production-installation/docs.md
@@ -24,7 +24,7 @@ steps that are covered in the [Enterprise subsection](#enterprise).
 
 ! If you have already installed an Open Source server and wish to upgrade to
 ! Enterprise, you should follow [the Enterprise upgrade
-! tutorial]() instead of this tutorial.
+! tutorial](./01.Upgrading-from-OS-to-Enterprise/docs.md) instead of this tutorial.
 
 
 ## Prerequisites

--- a/07.Administration/03.Production-installation/docs.md
+++ b/07.Administration/03.Production-installation/docs.md
@@ -13,7 +13,7 @@ taxonomy:
 
 !!! You can save time by using [hosted Mender](https://hosted.mender.io?target=_blank), a secure Mender server ready to use, maintained by the Mender developers.
 
-This is a step by step guide for deploying the Mender Server for production
+This is a step by step tutorial for deploying the Mender Server for production
 environments, and will cover relevant security and reliability aspects of Mender
 production installations.  The Mender backend services can be deployed to
 production using a skeleton provided in the `production` directory of the
@@ -24,7 +24,7 @@ steps that are covered in the [Enterprise subsection](#enterprise).
 
 ! If you have already installed an Open Source server and wish to upgrade to
 ! Enterprise, you should follow [the Enterprise upgrade
-! guide]() instead of this guide.
+! tutorial]() instead of this tutorial.
 
 
 ## Prerequisites
@@ -37,7 +37,7 @@ steps that are covered in the [Enterprise subsection](#enterprise).
     - This heavily depends on your scale and environment, the supported [Mender Enterprise](https://mender.io/product/mender-enterprise) edition is recommended for larger-scale environments.
 - A public IP address assigned and ports 443 and 9000 publicly accessible.
 - Allocated DNS names for the Mender API Gateway and the Mender Storage Proxy
-  that resolve to the public IP of the Mender server by the devices. By following this guide
+  that resolve to the public IP of the Mender server by the devices. By following this tutorial
   all services will be hosted on the same server, so you can use just one domain name for both.
   If you are just testing you can use a temporary domain name obtained from services like
   [https://ipq.co](https://ipq.co?target=_blank).
@@ -53,13 +53,13 @@ If you are setting up a Mender Enterprise server, you will also need:
 
 ## Deployment steps
 
-The guide will use a publicly available Mender integration repository. Then
+The tutorial will use a publicly available Mender integration repository. Then
 proceed with setting up a local branch, preparing deployment configuration from
 a template, committing the changes locally. Keeping deployment configuration in
 a git repository ensures that the history of changes is tracked and subsequent
 updates can be easily applied.
 
-At the end of this guide you will have:
+At the end of this tutorial you will have:
 
 - production configuration in a single `docker-compose` file
 - a running Mender backend cluster
@@ -156,7 +156,7 @@ The template includes a few files:
 
 - `enterprise.yml.template` - configuration for running an Enterprise instance
   of the Mender server. This topic is covered separately in [the Enterprise
-  part](#enterprise) of the Production installation guide
+  part](#enterprise) of the Production installation tutorial
 
 !!! If an `enterprise.yml` file exists in the `config` directory, this will
 !!! automatically turn on Enterprise features in the backend service. If you
@@ -710,7 +710,7 @@ without them seeing each others data, as well as isolating devices and users in
 test and production environments.
 
 When using Mender Enterprise, multi tenancy is automatically enabled, and it
-cannot be turned off. Below follows a guide for setting up a single
+cannot be turned off. Below follows a tutorial for setting up a single
 organization. For additional information on administering organizations, see the
 help screen from:
 
@@ -866,7 +866,7 @@ and the username and password that was [created
 earlier](#creating-the-first-organization-and-user).
 
 !! It is advised to use the UI to change the password of all users that were
-!! added in this guide, since the shell may keep a record of the password in
+!! added in this tutorial, since the shell may keep a record of the password in
 !! plaintext.
 
 If you encounter any issues while starting or running your Mender Server, you

--- a/07.Administration/07.Upgrading/docs.md
+++ b/07.Administration/07.Upgrading/docs.md
@@ -4,10 +4,10 @@ taxonomy:
     category: docs
 ---
 
-This is a guide for upgrading the Mender Server in production environments. In
+This is a tutorial for upgrading the Mender Server in production environments. In
 general updating is only supported between connected minor versions, and latest
-minor to next major version, and this guide reflects this. Both the Open Source
-and Enterprise editions can be upgraded using this guide, but both the old and
+minor to next major version, and this tutorial reflects this. Both the Open Source
+and Enterprise editions can be upgraded using this tutorial, but both the old and
 the new version must be the same type of server, either both Open Source, or
 both Enterprise.
 
@@ -20,7 +20,7 @@ both Enterprise.
 ## Prerequisites
 
 It is assumed that the installation was performed following the steps
-in the [Production installation](../03.Production-installation/docs.md) guide. That means that
+in the [Production installation](../03.Production-installation/docs.md) tutorial. That means that
 you currently have:
 
 * a local git repository based
@@ -78,7 +78,7 @@ For each release there will be a corresponding release branch. For example, the
 branch named `2.0.x` provides the 2.0 release setup. Stable releases are tagged,
 e.g. `2.0.1`.
 
-Recall from the [production installation](../03.Production-installation/docs.md) guide that our
+Recall from the [production installation](../03.Production-installation/docs.md) tutorial that our
 local setup was introduced in a branch that was created from given release
 version. You can use git commands such as `git log` and `git diff` to review the changes
 introduced in upstream branch. For example:

--- a/201.Troubleshooting/01.Yocto-project-build/docs.md
+++ b/201.Troubleshooting/01.Yocto-project-build/docs.md
@@ -80,7 +80,7 @@ ERROR: Logfile of failure stored in: /home/user/poky/build/tmp/work/cortexa7hf-n
 ERROR: Task (/home/user/poky/meta-mender/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender-auto-provided_1.0.bb:do_package) failed with exit code '1'
 ```
 
-This is a known bug in U-Boot versions prior to v2017.05. If you get this error, the auto-provided recipe won't work, so you will have to carry out the steps in [the u-boot-fw-utils guide](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils). Note that only the section under "u-boot-fw-utils" is necessary, the other sections on the same page, such as `MENDER_UBOOT_AUTO_CONFIGURE = "0"`, should not be necessary to carry out unless you have other reasons to do so.
+This is a known bug in U-Boot versions prior to v2017.05. If you get this error, the auto-provided recipe won't work, so you will have to carry out the steps in [the u-boot-fw-utils tutorial](../../03.Devices/02.Yocto-project/02.Bootloader-support/02.U-Boot/01.Manual-U-Boot-integration/docs.md#u-boot-fw-utils). Note that only the section under "u-boot-fw-utils" is necessary, the other sections on the same page, such as `MENDER_UBOOT_AUTO_CONFIGURE = "0"`, should not be necessary to carry out unless you have other reasons to do so.
 
 
 ## I get a build error if I am using PREFERRED_PROVIDER_virtual/bootloader instead of PREFERRED_PROVIDER_u-boot

--- a/201.Troubleshooting/04.Mender-Server/docs.md
+++ b/201.Troubleshooting/04.Mender-Server/docs.md
@@ -267,7 +267,7 @@ time="2017-01-31T08:25:15Z" level=fatal msg="NoCredentialProviders: no valid pro
 As seen in [container logs](#container-logs) section, `mender-deployments`
 service is restarting. The logs suggest there might be missing credentials for
 an AWS related service.
-From the [production installation](../../07.Administration/03.Production-installation/docs.md) guide, we can recall
+From the [production installation](../../07.Administration/03.Production-installation/docs.md) tutorial, we can recall
 that
 `mender-deployments`
 [service configuration](../../07.Administration/03.Production-installation/docs.md#deployments-service) contains


### PR DESCRIPTION
We decided to align on "tutorial" as we are currently mixing guide/tutorial to describe the same thing.
