### PR TITLE
Move standalone deployments

### DIFF
--- a/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
+++ b/04.Artifacts/10.Yocto-project/03.Building-for-production/docs.md
@@ -80,7 +80,7 @@ Note in particular the `:` after the directory; this is mandatory.
 
 Please note that setting up for production will require that you explicitly set the [MENDER_SERVER_URL variable](../99.Variables/docs.md#mender_server_url) to the proper value for your server.
 
-!!! Note that, this step is not required for the [standalone mode](../../../02.Overview/06.Standalone-deployments/docs.md).
+!!! Note that, this step is not required for the [standalone mode](../../../05.Client-configuration/07.Standalone-deployments/docs.md).
 
 ## Artifact signing and verification keys
 

--- a/05.Client-configuration/07.Standalone-deployments/docs.md
+++ b/05.Client-configuration/07.Standalone-deployments/docs.md
@@ -18,53 +18,24 @@ For an explanation of the difference between *managed* and *standalone* deployme
 
 ## Setting Mender up for standalone mode
 
-The Mender client will by default run in *managed* mode, i.e. connected to a Mender server.
-In managed mode, mender runs as a daemon on the device.
-
 If you would like to run Mender in *standalone* mode, the only difference is that you
 must make sure that the Mender client does *not run as a daemon*. In most cases this
 will entail disabling or removing any `systemd` unit that starts the Mender client.
 
 
-## Building standalone images
-
-When [building a Mender Yocto Project image](../../04.Artifacts/10.Yocto-project/01.Building/docs.md),
-you can ensure Mender runs in standalone mode by following the
-[image configuration steps to make sure Mender does not run as a system service](../../04.Artifacts/10.Yocto-project/02.Image-configuration/docs.md#disabling-mender-as-a-system-service)
-before building.
-
-From the Yocto Project build output configured as above you will get two
-image types that work in standalone mode.
-
-The first is a disk image that is used to flash to the entire disk of the
-device, i.e. do the initial device storage provisioning.
-`meta-mender` creates these files with a `.sdimg`
-suffix, so they are easy to recognize. This file contains
-all the partitions of the given storage device, as
-described in [Partition layout](../../03.Devices/01.General-system-requirements/docs.md#partition-layout).
-Please see [Provisioning a new device](../../04.Artifacts/20.Provisioning-a-new-device/docs.md)
-for steps how to provision the device storage using the `*.sdimg` image.
-
-Secondly, you will get an Artifact file that is used for deployments with Mender,
-and it is recognized by its `.mender` suffix.
-See [Mender Artifacts](../../02.Overview/05.Artifact/docs.md)
-for a more detailed overview.
-
-
 ## Deploy an Artifact to a device
 
-After provisioning the device with the disk image (`.sdimg` file) and building a new Artifact (`.mender` file),
-you can trigger a deployment of the Artifact.
-To deploy the new Artifact to your device, run the following command in the device terminal:
+To deploy the new Artifact to your device, run the following command in the
+device terminal:
 
 
 ```bash
 mender -install <URI>
 ```
 
-`<URI>` can be any type of file-based storage or a https URL.
+`<URI>` can be any type of file-based storage or an HTTP/HTTPS URL.
 For example, if you are updating from a USB stick, you could use `/mnt/usb1/release1.mender`.
-To use http, simply replace it with a URL like `https://fileserver.example.com/mender/release1.mender`.
+To use HTTPS, simply replace it with a URL like `https://fileserver.example.com/mender/release1.mender`.
 
 Mender will download the new Artifact, process its metadata information, extract the contents and write it to the inactive rootfs partition. It will configure the bootloader to boot into it on the next reboot. This will likely take several minutes to complete, depending on the performance of your device and the size of the Artifact.
 Note that Mender does not use any temporary space, it [streams the Artifact](../../02.Overview/05.Artifact/docs.md#streaming-resume-and-compression).

--- a/05.Client-configuration/07.Standalone-deployments/docs.md
+++ b/05.Client-configuration/07.Standalone-deployments/docs.md
@@ -11,7 +11,7 @@ to deploy updates to devices which do not have network connectivity or
 are updated through external storage like a USB stick.
 
 For an explanation of the difference between *managed* and *standalone* deployments, please see
-[Modes of operation](../01.Introduction/docs.md#modes-of-operation).
+[Modes of operation](../../02.Overview/01.Introduction/docs.md#modes-of-operation).
 
 !!! Note that [state scripts](../../04.Artifacts/50.State-scripts/docs.md) work slightly differently in standalone mode, see [state scripts and standalone mode](../../04.Artifacts/50.State-scripts/docs.md#standalone-mode) for more information.
 
@@ -47,7 +47,7 @@ for steps how to provision the device storage using the `*.sdimg` image.
 
 Secondly, you will get an Artifact file that is used for deployments with Mender,
 and it is recognized by its `.mender` suffix.
-See [Mender Artifacts](../05.Artifact/docs.md)
+See [Mender Artifacts](../../02.Overview/05.Artifact/docs.md)
 for a more detailed overview.
 
 
@@ -67,7 +67,7 @@ For example, if you are updating from a USB stick, you could use `/mnt/usb1/rele
 To use http, simply replace it with a URL like `https://fileserver.example.com/mender/release1.mender`.
 
 Mender will download the new Artifact, process its metadata information, extract the contents and write it to the inactive rootfs partition. It will configure the bootloader to boot into it on the next reboot. This will likely take several minutes to complete, depending on the performance of your device and the size of the Artifact.
-Note that Mender does not use any temporary space, it [streams the Artifact](../05.Artifact/docs.md#streaming-resume-and-compression).
+Note that Mender does not use any temporary space, it [streams the Artifact](../../02.Overview/05.Artifact/docs.md#streaming-resume-and-compression).
 
 To run the newly deployed rootfs image, simply reboot your device:
 
@@ -88,4 +88,4 @@ mender -commit
 
 By running this command, Mender will configure the bootloader to persistently boot from this newly written deployment. To deploy another update, simply run `mender -install <URI>` again, then reboot and commit.
 
-!!! If we reboot the device again *without* running `mender -commit`, it will boot into the previous rootfs partition that is known to be working (where we deployed the update from). This ensures a robust update process in cases where the newly deployed rootfs does not boot or otherwise has issues that we want to roll back from. Also note that it is possible to automate deployments by [running the Mender client as a daemon](../01.Introduction/docs.md#modes-of-operation).
+!!! If we reboot the device again *without* running `mender -commit`, it will boot into the previous rootfs partition that is known to be working (where we deployed the update from). This ensures a robust update process in cases where the newly deployed rootfs does not boot or otherwise has issues that we want to roll back from. Also note that it is possible to automate deployments by [running the Mender client as a daemon](../../02.Overview/01.Introduction/docs.md#modes-of-operation).


### PR DESCRIPTION
standalone-deployment does not fit longer in "Overview" section. Standalone deployment should be covered in the Overview -> Introduction (briefly) and the details on how it works are moved to Client configuration (for now). 
