### PR TITLE
Remove inconsistent reference to `--client` argument.

### DIFF
--- a/07.Administration/02.Demo-installation/docs.md
+++ b/07.Administration/02.Demo-installation/docs.md
@@ -127,5 +127,5 @@ run the following commands in the `integration-master` directory:
 ```
 
 ```bash
-./demo --client up
+./demo up
 ```


### PR DESCRIPTION
It is not specified anywhere else that you should use client. Rely on
the onboarding to tell you this instead.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
