### PR TITLE
Overview/Device Group: Remove link to API section

### DIFF
--- a/02.Overview/02.Device-Group/docs.md
+++ b/02.Overview/02.Device-Group/docs.md
@@ -12,7 +12,7 @@ grouping. There are two types of groups: _static_ and _dynamic_.
 
 A *static group* contains a list of [Device IDs](../15.Taxonomy/docs.md).
 You can add devices to a static group in the UI or using the
-[APIs](https://docs.mender.io/apis/open-source/management-apis/device-inventory#devices-id-group-put?target=_blank).
+[APIs](../../06.Server-integration/01.Using-the-apis/docs.md).
 
 Some considerations when working with static groups:
 * Before you can add a device to a static group, it needs to be


### PR DESCRIPTION
The link does not work, as the default version of
docs.mender.io is now the 'Hosted' branch, which has
a slightly different API structure.

Replaced link with an internal reference instead.

