### PR TITLE
[tests] Fix "the input device is not a TTY" error in CI tests

### DIFF
--- a/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -113,7 +113,7 @@ connect without a tenant token.
    user](../docs.md#creating-the-first-organization-and-user) (replace `$TENANT_ID`
    accordingly):
 
-   <!-- AUTOMATION: execute=TENANT_ID=$( ( ./run exec mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword ) | tr -d '\r' ) -->
+   <!-- AUTOMATION: execute=TENANT_ID=$( ( ./run exec -T mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword ) | tr -d '\r' ) -->
    <!--AUTOMATION: test=test -n "$TENANT_ID" -->
    <!-- AUTOMATION: execute=sleep 10 -->
 
@@ -121,7 +121,7 @@ connect without a tenant token.
    line endings for whatever reason. -->
    <!-- AUTOMATION: execute=TENANT_TOKEN=$( ( -->
    ```bash
-   ./run exec mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token
+   ./run exec -T mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token
    ```
    <!-- AUTOMATION: execute=) | tr -d '\r' ) -->
    <!--AUTOMATION: test=test -n "$TENANT_TOKEN" -->

--- a/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Administration/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -114,6 +114,7 @@ connect without a tenant token.
    accordingly):
 
    <!-- AUTOMATION: execute=TENANT_ID=$( ( ./run exec mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword ) | tr -d '\r' ) -->
+   <!--AUTOMATION: test=test -n "$TENANT_ID" -->
    <!-- AUTOMATION: execute=sleep 10 -->
 
    <!-- Trick to capture the output. The `tr` is because Go prints with Windows
@@ -123,6 +124,7 @@ connect without a tenant token.
    ./run exec mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token
    ```
    <!-- AUTOMATION: execute=) | tr -d '\r' ) -->
+   <!--AUTOMATION: test=test -n "$TENANT_TOKEN" -->
 
    > eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZW5kZXIudGVuYW50IjoiNWQ4MzM1MzJkMTMwNTgwMDI4NDhmZmRmIiwia<br>
    XNzIjoiTWVuZGVyIiwic3ViIjoiNWQ4MzM1MzJkMTMwNTgwMDI4NDhmZmRmIn0.HJDGHzqZqbosAYyJpSIEeL0W4HMiOmb15ETnu<br>

--- a/07.Administration/03.Production-installation/docs.md
+++ b/07.Administration/03.Production-installation/docs.md
@@ -732,7 +732,7 @@ Replace the organization name, username and password with desired values and run
 <!-- Trick to capture the output. The `tr` is because Go prints with Windows
 line endings for whatever reason. -->
 ```bash
-TENANT_ID=$(./run exec mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword | tr -d '\r') && (echo $TENANT_ID)
+TENANT_ID=$(./run exec -T mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword | tr -d '\r') && (echo $TENANT_ID)
 ```
 <!--AUTOMATION: test=test -n "$TENANT_ID" -->
 
@@ -754,7 +754,7 @@ tool:
 !!! On the Debian family of distributions you can install `jq` with `apt-get install jq`.
 
 ```bash
-TENANT_TOKEN=$(./run exec mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token) && (echo $TENANT_TOKEN)
+TENANT_TOKEN=$(./run exec -T mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token) && (echo $TENANT_TOKEN)
 ```
 <!--AUTOMATION: test=test -n "$TENANT_TOKEN" -->
 

--- a/07.Administration/03.Production-installation/docs.md
+++ b/07.Administration/03.Production-installation/docs.md
@@ -734,6 +734,7 @@ line endings for whatever reason. -->
 ```bash
 TENANT_ID=$(./run exec mender-tenantadm /usr/bin/tenantadm create-org --name=MyOrganization --username=myusername@host.com --password=mysecretpassword | tr -d '\r') && (echo $TENANT_ID)
 ```
+<!--AUTOMATION: test=test -n "$TENANT_ID" -->
 
 <!-- create-org is an async workflow, give it some time -->
 <!--AUTOMATION: execute=sleep 10 -->
@@ -755,7 +756,6 @@ tool:
 ```bash
 TENANT_TOKEN=$(./run exec mender-tenantadm /usr/bin/tenantadm get-tenant --id $TENANT_ID | jq -r .tenant_token) && (echo $TENANT_TOKEN)
 ```
-
 <!--AUTOMATION: test=test -n "$TENANT_TOKEN" -->
 
 where `$TENANT_ID` is the ID that was printed by the previous command.


### PR DESCRIPTION
* [tests] Add tests for all TENANT_ID/TENANT_TOKEN variables
All these variables are actually empty at the moment. We'll fix it, but
these tests will catch future regressions.

* [tests] Production installation: add -T flag to docker-compose exec
Fixes "the input device is not a TTY" error in CI tests.