### PR TITLE
MEN-3832 Mention explicitly how to use multiple ssh arguments in snapshots

### DIFF
--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -85,13 +85,13 @@ DEVICE_TYPE="raspberrypi4"
 !!! Make sure to replace `raspberrypi4` with the specific value that you are
 !!! seeing in your setup
 
-Set `SSH_ARGS` shell variable to specify the SSH access port:
+Set `SSH_ARG` shell variable to specify the SSH access port:
 
 ```bash
-SSH_ARGS="-p 22"
+SSH_ARG="-p 22"
 ```
 
-!!! If you are using a virtual device use `SSH_ARGS="-p 8822"`
+!!! If you are using a virtual device use `SSH_ARG="-p 8822"`
 
 
 ## Step 3 - Create a Mender Artifact using the snapshot feature
@@ -112,7 +112,7 @@ mender-artifact write rootfs-image \
     -t "${DEVICE_TYPE}" \
     -n system-v1 \
     -o system-v1.mender \
-    -S "${SSH_ARGS}"
+    -S "${SSH_ARG}"
 ```
 
 ! Your device is not usable while the snapshot operation is in progress. Mender

--- a/04.Artifacts/22.Snapshots/docs.md
+++ b/04.Artifacts/22.Snapshots/docs.md
@@ -78,9 +78,28 @@ on the golden device. For example, the command:
 USER="user"
 ADDR="device-ip:port"
 
-mender-artifact write rootfs-image -f ssh://$USER@$ADDR \
+mender-artifact write rootfs-image -f ssh://${USER}@${ADDR} \
                                    -n artifact-name \
                                    -o snapshot-release.1.0.mender \
                                    -t device-type
 ```
 Yields the exact same artifact as above.
+
+Please note you can pass extra arguments to ssh. To do this, specify
+each one of them in a separate `-S "${SSH_ARG}"` option, e.g.:
+
+```bash
+USER="user"
+ADDR="device-ip"
+
+mender-artifact write rootfs-image \
+    -f ssh://"${USER}@${ADDR}" \
+    -n artifact-name \
+    -o snapshot-release.1.0.mender \
+    -t device-type
+    --ssh-args="-p 8122" \
+    --ssh-args="-o UserKnownHostsFile=/dev/null" \
+    --ssh-args="-o StrictHostKeyChecking=no" \
+    --ssh-args="-o PubKeyAuthentication=no"
+```
+


### PR DESCRIPTION
MEN-3832 Mention explicitly how to use multiple ssh arguments in snapshots

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
