### PR TITLE
Change API link to Enterprise and fix anchor

### DIFF
--- a/03.Client-installation/04.Inventory/docs.md
+++ b/03.Client-installation/04.Inventory/docs.md
@@ -20,7 +20,7 @@ name0=value0\n
 .
 nameN=valueN\n
 ```
-The client reports the attributes via the [device inventory service API calls](../../200.APIs/01.Open-source/01.Device-APIs/02.Device-inventory#device-attributes-patch),by issuing **PATCH** _/device/attributes_.
+The client reports the attributes via the [device inventory service API calls](../../200.APIs/02.Enterprise/01.Device-APIs/02.Device-inventory#assign-attributes), by issuing **PATCH** _/device/attributes_.
 
 
 ### Lists of values


### PR DESCRIPTION
In the context of this page, it is irrelevant if we point to OS or
Enterprise (and it will help on the hosted branch). Also fix the anchor
in the link that was broken.