### PR TITLE
[autoversion.py] Exclude 200.API dir from version checks

### DIFF
--- a/autoversion.py
+++ b/autoversion.py
@@ -69,16 +69,15 @@ def get_version_of(repo):
 
 
 def walk_tree():
-    for dirpath, _, filenames in os.walk("."):
+    exclude_dirs = [
+        "node_modules",  # Several readme.md with version strings
+        "200.APIs",  # Might contain example versions (2.4.x and older)
+        "202.Release-information",  # References to old versions
+    ]
+    for dirpath, dirs, filenames in os.walk(".", topdown=True):
+        dirs[:] = list(filter(lambda x: not x in exclude_dirs, dirs))
         for file in filenames:
             if not file.endswith(".md") and not file.endswith(".markdown"):
-                continue
-
-            if dirpath.endswith("Release-notes-changelog") or dirpath.endswith(
-                "Open-source-licenses"
-            ):
-                # These files are exempt, since they are supposed to refer to
-                # old versions.
                 continue
 
             process_file(os.path.join(dirpath, file))


### PR DESCRIPTION
This directory contain the checked-in API specs on old branches, which
might contain version strings that we want to ignore.

Add also "node_modules" to the ignore list, so that we can run the
script locally together with the checklinks tool installed.