### PR TITLE
MEN-3814: Format variable values correctly

### DIFF
--- a/04.System-updates-Debian-family/99.Variables/docs.md
+++ b/04.System-updates-Debian-family/99.Variables/docs.md
@@ -74,7 +74,7 @@ time spent generating the Mender Artifact (10x).
 
 #### `MENDER_ARTIFACT_NAME`
 
-> Value: <release-name>
+> Value: &lt;release-name&gt;
 
 Explicitly set the name of the generated update Artifact. Required for the
 conversion to succeed. However, should be specified on the command line, and not
@@ -142,7 +142,7 @@ Examples:
 
 #### `MENDER_DATA_PART_FSTAB_OPTS`
 
-> Values: defaults/<fstab specific options>
+> Values: defaults/&lt;fstab specific options&gt;
 
 Options passed on to fstab.
 
@@ -171,7 +171,7 @@ The size of the Mender data partition.
 
 #### `MENDER_DEVICE_TYPE`
 
-> Value: <device-type>
+> Value: &lt;device-type&gt;
 
 Set the device type specified by the Artifact. If left empty it will default to
 the value of '/etc/hostname'.

--- a/05.System-updates-Yocto-Project/99.Variables/docs.md
+++ b/05.System-updates-Yocto-Project/99.Variables/docs.md
@@ -13,7 +13,7 @@ and used by Mender.
 
 #### `ARTIFACTIMG_FSTYPE`
 
-> Value: `ext4` (default) / <filesystem type>
+> Value: `ext4` (default) / &lt;filesystem type&gt;
 
 Defines which file system type Mender will build for the rootfs partitions in
 the `.biosimg`, `.sdimg`, `.uefiimg` and the `.mender` file. See [File system
@@ -23,7 +23,7 @@ for more information.
 
 #### `ARTIFACTIMG_NAME`
 
-> Value: <any string> (defaults to the image name being built)
+> Value: &lt;any string&gt; (defaults to the image name being built)
 
 Overrides the default internal image name that mender will use to build the
 `.mender` file with.
@@ -31,7 +31,7 @@ Overrides the default internal image name that mender will use to build the
 
 #### `IMAGE_ROOTFS_SIZE`
 
-> Value: <size in KiB> (default calculated from several factors, see below)
+> Value: &lt;size in KiB&gt; (default calculated from several factors, see below)
 
 The size of the generated rootfs, expressed in kiB. This will be the size that
 is shipped in a `.mender` update. This variable is a standard Yocto Project
@@ -52,7 +52,7 @@ that.
 
 #### `MENDER_ARTIFACT_EXTRA_ARGS`
 
-> Value: <mender artifact arguments> (default: empty)
+> Value: &lt;mender artifact arguments&gt; (default: empty)
 
 Flags added to this variable will be used as extra arguments to the
 `mender-artifact` tool when creating the `.mender` artifact. For example:
@@ -66,7 +66,7 @@ The above example builds an artifact with the version 1 format.
 
 #### `MENDER_ARTIFACT_NAME`
 
-> Value: <name of artifact> (no default, must be set)
+> Value: &lt;name of artifact&gt; (no default, must be set)
 
 The name of the image or update that will be built. This is what the device will
 report that it is running, and different updates must have different names. This
@@ -75,7 +75,7 @@ variable must be defined or the build will fail.
 
 #### `MENDER_ARTIFACT_SIGNING_KEY`
 
-> Value: <key used to sign artifact> (default: empty)
+> Value: &lt;key used to sign artifact&gt; (default: empty)
 
 Can be set to a private key which will be used to sign the update artifact. The
 default is empty, which means the artifact won't be signed.
@@ -87,7 +87,7 @@ Mender Artifacts](../../06.Artifact-creation/07.Sign-and-verify/docs.md#signing)
 
 #### `MENDER_ARTIFACT_VERIFY_KEY`
 
-> Value: <key used to verify artifact> (default: empty)
+> Value: &lt;key used to verify artifact&gt; (default: empty)
 
 If set, this will add the given public verification key to the client
 configuration, which means that the client will reject updates which are not
@@ -112,7 +112,7 @@ Note that you cannot both use `MENDER_ARTIFACT_VERIFY_KEY` and have
 
 #### `MENDER_BOOT_PART`
 
-> Value: <block device> (default: 1st partition on `MENDER_STORAGE_DEVICE`)
+> Value: &lt;block device&gt; (default: 1st partition on `MENDER_STORAGE_DEVICE`)
 
 The partition Mender uses as the boot partition. See [More detailed storage
 configuration](../02.Board-integration/01.Partition-configuration/docs.md)
@@ -121,7 +121,7 @@ for more information.
 
 #### `MENDER_BOOT_PART_FSTYPE`
 
-> Value: auto (default) / <filesystem type>
+> Value: auto (default) / &lt;filesystem type&gt;
 
 Filesystem type of boot partition. This configuration is only used in fstab.
 Most filesystems can be auto detected, but some can not and hence this variable
@@ -140,7 +140,7 @@ for more information.
 
 #### `MENDER_DATA_PART`
 
-> Value: <block device> (default: 4th partition on `MENDER_STORAGE_DEVICE`)
+> Value: &lt;block device&gt; (default: 4th partition on `MENDER_STORAGE_DEVICE`)
 
 The partition Mender uses as the persistent data partition. See [More detailed
 storage
@@ -150,7 +150,7 @@ for more information.
 
 #### `MENDER_DATA_PART_FSTYPE`
 
-> Value: auto (default) / <filesystem type>
+> Value: auto (default) / &lt;filesystem type&gt;
 
 Filesystem type of data partition. This configuration is only used in fstab.
 Most filesystems can be auto detected, but some can not and hence this variable
@@ -169,7 +169,7 @@ for more information.
 
 #### `MENDER_DEMO_HOST_IP_ADDRESS`
 
-> Value: <IP address> (default: empty)
+> Value: &lt;IP address&gt; (default: empty)
 
 As the name indicates, this variable is only relevant if you are building Mender
 with the `meta-mender-demo` layer. If set to an IP address, this variable sets
@@ -181,7 +181,7 @@ its own DNS server).
 
 #### `MENDER_DEVICE_TYPE`
 
-> Value: <any string> (default: value of `${MACHINE}`)
+> Value: &lt;any string&gt; (default: value of `${MACHINE}`)
 
 A string that defines the type of device this image will be installed on. This
 variable is only relevant when building a complete partitioned image (any suffix
@@ -191,7 +191,7 @@ if the device is updated.
 
 #### `MENDER_DEVICE_TYPES_COMPATIBLE`
 
-> Value: <strings> (default: value of `${MACHINE}`)
+> Value: &lt;strings&gt; (default: value of `${MACHINE}`)
 
 A space separated string of device types that determine which types of devices
 this update is suitable for. This complements the `MENDER_DEVICE_TYPE` variable,
@@ -201,7 +201,7 @@ partitioned image (any suffix ending in `img`).
 
 #### `MENDER_EXTRA_PARTS`
 
-> Value: <Extra partitions list> (default: empty)
+> Value: &lt;Extra partitions list&gt; (default: empty)
 
 This variable is used to define extra partitions which will be added after data
 partition. `MENDER_EXTRA_PARTS_SIZES_MB` and `MENDER_EXTRA_PARTS_FSTAB` can be
@@ -228,7 +228,7 @@ See also [`MENDER_EXTRA_PARTS_FSTAB`](#mender_extra_parts_fstab) and
 
 #### `MENDER_EXTRA_PARTS_FSTAB`
 
-> Value: <List of fstab mount options for extra partitions> (default: empty)
+> Value: &lt;List of fstab mount options for extra partitions&gt; (default: empty)
 
 The mount options for `/etc/fstab` of the extra partitions defined by
 `MENDER_EXTRA_PARTS` in the generated .biosimg, .sdimg or .uefiimg file.
@@ -246,7 +246,7 @@ See [`MENDER_EXTRA_PARTS`](#mender_extra_parts).
 
 #### `MENDER_EXTRA_PARTS_SIZES_MB`
 
-> Value: <Extra partitions size list> (default: empty)
+> Value: &lt;Extra partitions size list&gt; (default: empty)
 
 The size of the extra partitions defined by `MENDER_EXTRA_PARTS` in the
 generated .biosimg, .sdimg or .uefiimg file.
@@ -265,7 +265,7 @@ See [`MENDER_EXTRA_PARTS`](#mender_extra_parts).
 
 #### `MENDER_FEATURES_DISABLE`
 
-> Value: <mender features> (default: empty)
+> Value: &lt;mender features&gt; (default: empty)
 
 Features appended to this variable will be disabled in the build. See [the
 section on features](../04.Image-customization/01.Features/docs.md) for more information.
@@ -273,7 +273,7 @@ section on features](../04.Image-customization/01.Features/docs.md) for more inf
 
 #### `MENDER_FEATURES_ENABLE`
 
-> Value: <mender features> (default: platform dependent)
+> Value: &lt;mender features&gt; (default: platform dependent)
 
 Features appended to this variable will be enabled in the build. See [the
 section on features](../04.Image-customization/01.Features/docs.md) for more information.
@@ -281,7 +281,7 @@ section on features](../04.Image-customization/01.Features/docs.md) for more inf
 
 #### `MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET`
 
-> Value: <sector number> (default: platform dependent)
+> Value: &lt;sector number&gt; (default: platform dependent)
 
 Together with `MENDER_IMAGE_BOOTLOADER_FILE`, this sets the offset where the
 bootloader should be placed, counting from the start of the storage medium. The
@@ -291,7 +291,7 @@ non-zero, or the partition table itself would be overwritten.
 
 #### `MENDER_IMAGE_BOOTLOADER_FILE`
 
-> Value: <bootloader filename> (default: platform dependent)
+> Value: &lt;bootloader filename&gt; (default: platform dependent)
 
 Together with `MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET`, this specifies a file
 that you would like to write directly into the boot sector, in the intervening
@@ -300,7 +300,7 @@ space between the partition table and the first partition.
 
 #### `MENDER_IS_ON_MTDID`
 
-> Value: <MTD ID> (default: first MTD ID in `MENDER_MTDIDS`)
+> Value: &lt;MTD ID&gt; (default: first MTD ID in `MENDER_MTDIDS`)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../04.Image-customization/01.Features/docs.md#list-of-features) is enabled. The
@@ -320,7 +320,7 @@ See also [`MENDER_MTDIDS`](#mender_mtdids).
 
 #### `MENDER_KERNEL_IMAGETYPE_FORCE`
 
-> Value: <kernel image type> (default: value of `KERNEL_IMAGETYPE`)
+> Value: &lt;kernel image type&gt; (default: value of `KERNEL_IMAGETYPE`)
 
 In certain build scenarios, the detection of kernel image type may not work for
 specific boards. This is usually caused by custom post-processing steps required
@@ -330,7 +330,7 @@ will ensure that Mender packages the proper files in these cases.
 
 #### `MENDER_MBR_BOOTLOADER_FILE`
 
-> Value: <MBR bootloader filename> (default: platform dependent)
+> Value: &lt;MBR bootloader filename&gt; (default: platform dependent)
 
 Specifies a first stage bootloader to flash to the very first sector of the
 storage device (Master Boot Record, or "MBR"), in the same sector as the
@@ -367,7 +367,7 @@ otherwise the default is empty.
 
 #### `MENDER_MTDIDS`
 
-> Value: <mtdids string> (no default, must be set if using UBI)
+> Value: &lt;mtdids string&gt; (no default, must be set if using UBI)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../04.Image-customization/01.Features/docs.md#list-of-features) is enabled, in which
@@ -384,7 +384,7 @@ must be set too.
 
 #### `MENDER_MTDPARTS`
 
-> Value: <mtdparts string> (default calculated from several factors)
+> Value: &lt;mtdparts string&gt; (default calculated from several factors)
 
 This variable is only relevant if the [the `mender-ubi`
 feature](../04.Image-customization/01.Features/docs.md#list-of-features) is enabled. The
@@ -416,7 +416,7 @@ is used to calculate parameters for the UBI volumes.
 
 #### `MENDER_PARTITIONING_OVERHEAD_KB`
 
-> Value: <number> (default calculated from several factors)
+> Value: &lt;number&gt; (default calculated from several factors)
 
 A rough estimate of space lost due to partition alignment, expressed in KiB. The
 build process will calculate that automatically using a simple heuristic. See
@@ -427,7 +427,7 @@ details on the calculation.
 
 #### `MENDER_PARTITION_ALIGNMENT`
 
-> Value: <number> (default: value of `MENDER_STORAGE_PEB_SIZE`)
+> Value: &lt;number&gt; (default: value of `MENDER_STORAGE_PEB_SIZE`)
 
 Alignment of partitions used when building partitioned images, expressed in
 bytes. Note that this is not always a whole number of KiB, particularly when the
@@ -436,7 +436,7 @@ storage device is a UBI volume.
 
 #### `MENDER_ROOTFS_PART_A`
 
-> Value: <block device> (default: 2nd partition on `MENDER_STORAGE_DEVICE`)
+> Value: &lt;block device&gt; (default: 2nd partition on `MENDER_STORAGE_DEVICE`)
 
 The partition Mender uses as the first (A) rootfs partition. See [More detailed
 storage
@@ -446,7 +446,7 @@ for more information.
 
 #### `MENDER_ROOTFS_PART_A_NAME`
 
-> Value: <name> (default: platform dependent)
+> Value: &lt;name&gt; (default: platform dependent)
 
 Alternative name for `MENDER_ROOTFS_PART_A`. Used if you need two different
 references to `MENDER_ROOTFS_PART_A`.
@@ -465,7 +465,7 @@ Defaults to `${MENDER_STORAGE_DEVICE}:rootfsa` when building `.ubimg`.
 
 #### `MENDER_ROOTFS_PART_B`
 
-> Value: <block device> (default: 3rd partition on `MENDER_STORAGE_DEVICE`)
+> Value: &lt;block device&gt; (default: 3rd partition on `MENDER_STORAGE_DEVICE`)
 
 The partition Mender uses as the second (B) rootfs partition. See [More detailed
 storage
@@ -475,7 +475,7 @@ for more information.
 
 #### `MENDER_ROOTFS_PART_B_NAME`
 
-> Value: <name> (default: platform dependent)
+> Value: &lt;name&gt; (default: platform dependent)
 
 See [`MENDER_ROOTFS_PART_A_NAME`](#mender_rootfs_part_a_name)
 
@@ -568,7 +568,7 @@ The size of the optional swap partition in the generated `.biosimg`, `.sdimg` or
 
 #### `MENDER_TENANT_TOKEN`
 
-> Value: <tenant token string> (default: empty)
+> Value: &lt;tenant token string&gt; (default: empty)
 
 Set this variable in `local.conf` in order to make the device recognize the
 organization to which it belongs. This option should always be set, except when
@@ -577,7 +577,7 @@ running a custom Mender server installation with multitenancy module disabled.
 
 #### `MENDER_UBI_LEB_PEB_BLOCK_OVERHEAD`
 
-> Value: <number> (default: 128 for NOR Flash, `${MENDER_NAND_FLASH_PAGE_SIZE} *
+> Value: &lt;number&gt; (default: 128 for NOR Flash, `${MENDER_NAND_FLASH_PAGE_SIZE} *
 > 2` for NAND Flash)
 
 The overhead that each logical erase block (LEB) of the UBI device adds to the
@@ -587,7 +587,7 @@ physical erase block (PEB), in bytes. In other words, how many bytes are
 
 #### `MENDER_UBI_LEB_SIZE`
 
-> Value: <number> (default: `${MENDER_STORAGE_PEB_SIZE} -
+> Value: &lt;number&gt; (default: `${MENDER_STORAGE_PEB_SIZE} -
 > ${MENDER_UBI_LEB_PEB_BLOCK_OVERHEAD}`)
 
 The size of each logical erase block (LEB) on the UBI device, in bytes. Usually
@@ -597,7 +597,7 @@ overridden.
 
 #### `MENDER_UBI_TOTAL_BAD_PEB_OVERHEAD`
 
-> Value: <number> (default: 0 for NOR Flash, 20 per PEB block for NAND Flash)
+> Value: &lt;number&gt; (default: 0 for NOR Flash, 20 per PEB block for NAND Flash)
 
 Total overhead on the whole UBI device, in bytes, that is reserved for bad
 physical erase blocks (PEBs). Usually zero for NOR Flash or [a variable
@@ -607,7 +607,7 @@ Flash.
 
 #### `MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET`
 
-> Value: <number> (default: Value of `MENDER_PARTITION_ALIGNMENT`)
+> Value: &lt;number&gt; (default: Value of `MENDER_PARTITION_ALIGNMENT`)
 
 Specifies the offset from the start of the raw block storage where the U-Boot
 environment should be stored, expressed in bytes. The default is equal to
@@ -617,7 +617,7 @@ overridden, it must also be aligned to `MENDER_PARTITION_ALIGNMENT_KB`.
 
 #### `MENDER_UBOOT_POST_SETUP_COMMANDS`
 
-> Value: <U-Boot command string> (default: empty)
+> Value: &lt;U-Boot command string&gt; (default: empty)
 
 A set of U-Boot commands to be executed at the end of the MENDER_SETUP code in
 the MENDER_BOOTENV.
@@ -625,7 +625,7 @@ the MENDER_BOOTENV.
 
 #### `MENDER_UBOOT_PRE_SETUP_COMMANDS`
 
-> Value: <U-Boot command string> (default: empty)
+> Value: &lt;U-Boot command string&gt; (default: empty)
 
 A set of U-Boot commands to be executed at the beginning of the MENDER_SETUP
 code in the MENDER_BOOTENV.
@@ -633,7 +633,7 @@ code in the MENDER_BOOTENV.
 
 #### `MENDER_UBOOT_STORAGE_DEVICE`
 
-> Value: <U-Boot storage device> (default: empty)
+> Value: &lt;U-Boot storage device&gt; (default: empty)
 
 The storage device, as referred to by U-Boot (e.g. `1`). This variable can be
 used in cases where the Linux kernel and U-Boot refer to the same device with
@@ -648,7 +648,7 @@ If the variable is empty, it is automatically deduced from
 
 #### `MENDER_UBOOT_STORAGE_INTERFACE`
 
-> Value: <U-Boot storage interface> (default: empty)
+> Value: &lt;U-Boot storage interface&gt; (default: empty)
 
 The storage interface, as referred to by U-Boot (e.g. `mmc`). This variable can
 be used in cases where the Linux kernel and U-Boot refer to the same device with


### PR DESCRIPTION
Use HTML `&lt;` and `&gt;` to represent < and >, otherwise the angled
brackets are interpreted as invalid HTML tags.