### PR TITLE
Fix incorrect reference to `mender-uboot` default.

### DIFF
--- a/05.System-updates-Yocto-Project/02.Board-integration/02.Bootloader-support/02.U-Boot/docs.md
+++ b/05.System-updates-Yocto-Project/02.Board-integration/02.Bootloader-support/02.U-Boot/docs.md
@@ -77,7 +77,7 @@ Project you need to enable the `mender-uboot` feature using
 MENDER_FEATURES_ENABLE_append = " mender-uboot"
 ```
 
-!!! If the architecture is ARM, and the `mender-full` or `mender-full-ubi` class is inherited in a Bitbake `.conf` file, then the `mender-uboot` feature is already on by default. See [the documentation on features](../../../04.Image-customization/01.Features/docs.md) for more information.
+!!! If the `mender-full-ubi` class is inherited in a Bitbake `.conf` file, then the `mender-uboot` feature is already on by default. See [the documentation on features](../../../04.Image-customization/01.Features/docs.md) for more information.
 
 This enables U-Boot integration, and also enables full automatic patching of
 U-Boot.


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
