### PR TITLE
[hosted] Update links for 2.5 on overridden pages

### DIFF
--- a/07.Server-installation/01.Overview/docs.md
+++ b/07.Server-installation/01.Overview/docs.md
@@ -7,4 +7,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/02.Demo-installation/docs.md
+++ b/07.Server-installation/02.Demo-installation/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -9,4 +9,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/04.Certificates-and-keys/docs.md
+++ b/07.Server-installation/04.Certificates-and-keys/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/05.Bandwidth/docs.md
+++ b/07.Server-installation/05.Bandwidth/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/06.Storage/docs.md
+++ b/07.Server-installation/06.Storage/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/07.Upgrading/docs.md
+++ b/07.Server-installation/07.Upgrading/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/08.Backup-and-restore/docs.md
+++ b/07.Server-installation/08.Backup-and-restore/docs.md
@@ -8,4 +8,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/07.Server-installation/chapter.md
+++ b/07.Server-installation/chapter.md
@@ -7,4 +7,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. To read documentation for self-managed
 installations of the Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/administration).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/server-installation).

--- a/201.Troubleshoot/04.Mender-Server/docs.md
+++ b/201.Troubleshoot/04.Mender-Server/docs.md
@@ -7,4 +7,4 @@ taxonomy:
 [Hosted Mender](https://hosted.mender.io?target=_blank) is configured, managed
 and upgraded by the Mender team. For troubleshooting steps for the most common
 problems in a self-managed Mender server, visit
-[the documentation page of the latest stable release](https://docs.mender.io/2.5/troubleshooting/mender-server).
+[the documentation page of the latest stable release](https://docs.mender.io/2.5/troubleshoot/mender-server).


### PR DESCRIPTION
These have now changed from 2.4 (old docs structure) to 2.5 (new).