### PR TITLE
Adjust dependencies for Demo installation.

### DIFF
--- a/07.Server-installation/02.Demo-installation/docs.md
+++ b/07.Server-installation/02.Demo-installation/docs.md
@@ -29,7 +29,7 @@ on your system:
 * Install the following utilities, example for Ubuntu:
 
     ```bash
-    sudo apt install awk curl hexdump jq git
+    sudo apt install gawk curl bsdmainutils jq git
     ```
 
 In addition, add the following lines to `/etc/hosts`:


### PR DESCRIPTION
Did not work on Ubuntu. New ones confirmed to work.