### PR TITLE
removed backslash from last parameter

### DIFF
--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/02.State-scripts/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/02.State-scripts/docs.md
@@ -30,7 +30,7 @@ mender_create_artifact() {
       --output-path ${mender_artifact} \
       --artifact-name ${artifact_name} \
       --device-type ${device_type} \
-      --script my-state-scripts/ArtifactInstall_Enter_00" \
+      --script my-state-scripts/ArtifactInstall_Enter_00"
 
 }
 EOF


### PR DESCRIPTION
removed backslash from last parameter to avoid "syntax error: unexpected end of file".

# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

The example file didn't work because of a syntax error. So I removed the backslash after the last parameter option, to avoid "unexpected end of life"

