### PR TITLE
Release Mender-client 2.4.1

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -34,8 +34,8 @@ Download the Raspberry Pi OS image with Mender integrated:
   * Download link: [Raspberry Pi 4 Model B][raspios-buster-lite-raspberrypi4-mender.img.xz]
 
 <!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.4.0.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.4.0.img.xz
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.4.1.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.4.1.img.xz
 
 Follow the steps outlined in the [Raspberry Pi OS documentation](https://www.raspberrypi.org/documentation/installation/installing-images?target=_blank)
 to flash the OS image to the device.

--- a/01.Get-started/04.Deploy-a-container-update/docs.md
+++ b/01.Get-started/04.Deploy-a-container-update/docs.md
@@ -109,7 +109,7 @@ Download the `docker-artifact-gen` utility script:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/2.4.0/support/modules-artifact-gen/docker-artifact-gen
+wget https://raw.githubusercontent.com/mendersoftware/mender/2.4.1/support/modules-artifact-gen/docker-artifact-gen
 ```
 
 Make `docker-artifact-gen` executable:

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -26,7 +26,7 @@ See [the downloads page](../../09.Downloads/docs.md) for links to download all p
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-wget https://d1b0l86ne08fsf.cloudfront.net/2.4.0/dist-packages/debian/armhf/mender-client_2.4.0-1_armhf.deb
+wget https://d1b0l86ne08fsf.cloudfront.net/2.4.1/dist-packages/debian/armhf/mender-client_2.4.1-1_armhf.deb
 ```
 
 !!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../09.Downloads/docs.md) for other architectures, and also make sure to modify the references to the package in commands below.
@@ -41,7 +41,7 @@ To install and configure Mender run the following command:
 
 <!--AUTOVERSION: "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-sudo dpkg -i mender-client_2.4.0-1_armhf.deb
+sudo dpkg -i mender-client_2.4.1-1_armhf.deb
 ```
 
 After the installation wizard is completed, Mender is correctly set up on your
@@ -65,7 +65,7 @@ are shown below. Use `mender setup --help` to learn about all configuration opti
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
@@ -82,7 +82,7 @@ sudo systemctl restart mender-client
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --demo \
@@ -97,7 +97,7 @@ sudo systemctl restart mender-client
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_URL="<INSERT YOUR ENTERPRISE SERVER URL>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM YOUR ENTERPRISE SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.4.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --server-url $SERVER_URL \
@@ -112,7 +112,7 @@ sudo systemctl restart mender-client
 ## Install from source
 
 <!--AUTOVERSION: "mender/tree/%#installing-from-source"/mender -->
-As an alternative to using a Debian package, it is possible to install the Mender client from source by following the guidelines outlined in the [README.md](https://github.com/mendersoftware/mender/tree/2.4.0#installing-from-source?target=_blank) of the Mender client source repository.
+As an alternative to using a Debian package, it is possible to install the Mender client from source by following the guidelines outlined in the [README.md](https://github.com/mendersoftware/mender/tree/2.4.1#installing-from-source?target=_blank) of the Mender client source repository.
 
 
 

--- a/03.Client-installation/03.Identity/docs.md
+++ b/03.Client-installation/03.Identity/docs.md
@@ -96,6 +96,6 @@ cpuid=1234123-ABC
 ## Example device identity executables
 
 <!--AUTOVERSION: "mender/tree/%"/mender-->
-Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/2.4.0/support?target=_blank).
+Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/2.4.1/support?target=_blank).
 
 

--- a/03.Client-installation/04.Inventory/docs.md
+++ b/03.Client-installation/04.Inventory/docs.md
@@ -121,7 +121,7 @@ a-country=Poland
 a-city=Krakow
 ```
 <!--AUTOVERSION: "mender/tree/%/support"/mender-->
-You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/2.4.0/support) directory.
+You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/2.4.1/support) directory.
 
 
 ## Default inventory
@@ -133,7 +133,7 @@ By default, and without any inventory scripts added, the Mender client sends the
 |:----:|:-------:|:-------------:|
 | `device_type`  | type of the device | "raspberrypi4" |
 | `artifact_name` | name of the currently installed artifact | "release-v1" |
-| `mender_client_version` | client version | "2.4.0" |
+| `mender_client_version` | client version | "2.4.1" |
 
 
 ## Final remarks

--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/01.Customization/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/01.Customization/docs.md
@@ -16,7 +16,7 @@ which add support for board-specific configurations. A run of `mender-convert`
 can include multiple configuration files, each one added with the `--config`
 command-line option. The standard configuration which will always be included
 can be found in the
-[configs/mender_convert_config](https://github.com/mendersoftware/mender-convert/blob/2.2.0/configs/mender_convert_config)
+[configs/mender_convert_config](https://github.com/mendersoftware/mender-convert/blob/2.2.1/configs/mender_convert_config)
 file, and includes the defaults for the configuration options which the tool
 supports.
 

--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
@@ -96,7 +96,7 @@ Clone `mender-convert` from the official repository:
 
 <!--AUTOVERSION: "-b % https://github.com/mendersoftware/mender-convert"/mender-convert-->
 ```bash
-git clone -b 2.2.0 https://github.com/mendersoftware/mender-convert.git
+git clone -b 2.2.1 https://github.com/mendersoftware/mender-convert.git
 ```
 
 ## Build the mender-convert container image

--- a/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -99,7 +99,7 @@ MENDER_ARTIFACT_NAME = "release-1"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender-client = "2.4.0"
+# PREFERRED_VERSION_pn-mender-client = "2.4.1"
 # PREFERRED_VERSION_pn-mender-artifact = "3.4.0"
 # PREFERRED_VERSION_pn-mender-artifact-native = "3.4.0"
 
@@ -216,7 +216,7 @@ MACHINE = "<YOUR-MACHINE>"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "2.4.0"
+# PREFERRED_VERSION_pn-mender = "2.4.1"
 # PREFERRED_VERSION_pn-mender-artifact = "3.4.0"
 # PREFERRED_VERSION_pn-mender-artifact-native = "3.4.0"
 

--- a/06.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -64,10 +64,10 @@ Note specifically that in this case we are creating a *module-image*, using the 
 #### Update Modules generation script
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/2.4.0/support/modules/single-file?target=_blank)
+You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/2.4.1/support/modules/single-file?target=_blank)
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/2.4.0/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
+Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/2.4.1/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
 
 #### Server side Artifact generation
 
@@ -77,4 +77,4 @@ will carry the file you have uploaded, the destination
 directory, the filename, and permissions, exactly as we saw above.
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/Documentation"/mender-->
-For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/2.4.0/Documentation/update-modules-v3-file-api.md?target=_blank).
+For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/2.4.1/Documentation/update-modules-v3-file-api.md?target=_blank).

--- a/06.Artifact-creation/07.Sign-and-verify/docs.md
+++ b/06.Artifact-creation/07.Sign-and-verify/docs.md
@@ -85,7 +85,7 @@ creating the signature.
 ```bash
 mender-artifact write rootfs-image \
 -t beaglebone \
--n mender-2.4.0 \
+-n mender-2.4.1 \
 -f core-image-base-beaglebone.ext4 \
 -k private.key \
 -o artifact-signed.mender

--- a/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -255,4 +255,4 @@ Because of the possible re-execution described above, you should develop Update 
 ## Further reading
 
 <!--AUTOVERSION: "blob/%/Documentation"/mender -->
-* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/2.4.0/Documentation/update-modules-v3-file-api.md?target=_blank)
+* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/2.4.1/Documentation/update-modules-v3-file-api.md?target=_blank)

--- a/08.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/08.Server-integration/02.Preauthorizing-devices/docs.md
@@ -28,7 +28,7 @@ If you have not yet prepared a device visit one of the following:
 When preauthorizing a device you need to know its [identity](../../02.Overview/07.Identity/docs.md). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI (note it is *not* the ID of the device, but the key-value attributes under Identity that are used for preauthorization).
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/2.4.0/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
+By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/2.4.1/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
 
 
 ### Mender client and server connectivity
@@ -61,11 +61,11 @@ When preauthorizing a device, device keys will be generated on a separate system
 We will use a script to generate a keypair the Mender client understands; it uses the `openssl` command to generate the keys.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-Download the [keygen-client](https://github.com/mendersoftware/mender/blob/2.4.0/support/keygen-client?target=_blank) script into a directory:
+Download the [keygen-client](https://github.com/mendersoftware/mender/blob/2.4.1/support/keygen-client?target=_blank) script into a directory:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/2.4.0/support/keygen-client
+wget https://raw.githubusercontent.com/mendersoftware/mender/2.4.1/support/keygen-client
 ```
 
 Ensure it is executable:

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -89,16 +89,16 @@ Ubuntu or Raspberry Pi OS. We provide packages for the following architectures:
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 | Architecture   | Devices                                   | Download link                                                       |
 |----------------|-------------------------------------------|---------------------------------------------------------------------|
-| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_2.4.0-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
-| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_2.4.0-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
-| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_2.4.0-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
+| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_2.4.1-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
+| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_2.4.1-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
+| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_2.4.1-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
-[mender-client_x.x.x-1_armhf.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.0/dist-packages/debian/armhf/mender-client_2.4.0-1_armhf.deb
+[mender-client_x.x.x-1_armhf.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.1/dist-packages/debian/armhf/mender-client_2.4.1-1_armhf.deb
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_arm64.deb"/mender -->
-[mender-client_x.x.x-1_arm64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.0/dist-packages/debian/arm64/mender-client_2.4.0-1_arm64.deb
+[mender-client_x.x.x-1_arm64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.1/dist-packages/debian/arm64/mender-client_2.4.1-1_arm64.deb
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_amd64.deb"/mender -->
-[mender-client_x.x.x-1_amd64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.0/dist-packages/debian/amd64/mender-client_2.4.0-1_amd64.deb
+[mender-client_x.x.x-1_amd64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.4.1/dist-packages/debian/amd64/mender-client_2.4.1-1_amd64.deb
 
 
 ## mender-cli

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -29,8 +29,8 @@ Mender provides images based on the following distributions:
 | Raspberry Pi 4 Model B        | Raspberry Pi OS Buster Lite 2020-05-27 | [raspios-buster-lite-raspberrypi4-mender.img.xz][raspios-buster-lite-raspberrypi4-mender.img.xz] | 8 GB         |
 
 <!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.4.0.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.4.0.img.xz
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.4.1.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.4.1.img.xz
 
 You can find images for other devices in our Mender Hub community forum, see
 [Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11?target=_blank) or

--- a/201.Troubleshoot/01.Yocto-project-build/docs.md
+++ b/201.Troubleshoot/01.Yocto-project-build/docs.md
@@ -311,7 +311,7 @@ A typical error message for this condition is:
 Error:
  Problem: package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon requires u-boot, but none of the providers can be installed
   - package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon conflicts with u-boot <= 1:2019.07 provided by u-boot-fork-1:2019.07-r0.beaglebone_yocto
-  - package mender-2.4.0-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
+  - package mender-2.4.1-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
   - conflicting requests
 ```
 

--- a/202.Release-information/01.Release-notes-changelog/docs.md
+++ b/202.Release-information/01.Release-notes-changelog/docs.md
@@ -3,6 +3,60 @@ title: Release notes & changelog
 taxonomy:
     category: docs
 ---
+
+## mender-convert 2.2.1
+
+_Released 11.05.2020_
+
+### Statistics
+
+A total of 144 lines added, 96 removed (delta 48)
+
+| Developers with the most changesets | |
+|---|---|
+| Kristian Amlie | 6 (60.0%) |
+| Ole Petter Orhagen | 2 (20.0%) |
+| Lluis Campos | 2 (20.0%) |
+
+| Developers with the most changed lines | |
+|---|---|
+| Kristian Amlie | 119 (81.0%) |
+| Lluis Campos | 23 (15.6%) |
+| Ole Petter Orhagen | 5 (3.4%) |
+
+| Developers with the most lines removed | |
+|---|---|
+| Ole Petter Orhagen | 3 (3.1%) |
+
+| Top changeset contributors by employer | |
+|---|---|
+| Northern.tech | 10 (100.0%) |
+
+| Top lines changed by employer | |
+|---|---|
+| Northern.tech | 147 (100.0%) |
+
+| Employers with the most hackers (total 3) | |
+|---|---|
+| Northern.tech | 3 (100.0%) |
+
+### Changelogs
+
+#### mender-convert (2.2.1)
+
+New changes in mender-convert since 2.2.0:
+
+* grub-efi: Fix inability to upgrade to a different kernel.
+* Fix massive root filesystem corruption under some build conditions.
+* beaglebone: Implement workaround for broken U-Boot and kernel.
+  ([MEN-3952](https://tracker.mender.io/browse/MEN-3952))
+* beaglebone: Remove U-Boot integration, which has not worked
+  for a long time. U-Boot will still be used for booting, but GRUB will
+  be used for integration with Mender, by chainloading via UEFI.
+  ([MEN-3952](https://tracker.mender.io/browse/MEN-3952))
+* Install the latest Mender-client release (2.4.1) by default.
+
+
 ## Mender client 2.4.1
 
 _Released 11.03.2020_

--- a/202.Release-information/01.Release-notes-changelog/docs.md
+++ b/202.Release-information/01.Release-notes-changelog/docs.md
@@ -3,6 +3,54 @@ title: Release notes & changelog
 taxonomy:
     category: docs
 ---
+## Mender client 2.4.1
+
+_Released 11.03.2020_
+
+### Statistics
+
+A total of 397 lines added, 161 removed (delta 236)
+
+| Developers with the most changesets | |
+|---|---|
+| Ole Petter Orhagen | 4 (36.4%) |
+| Peter Grzybowski | 3 (27.3%) |
+| Lluis Campos | 3 (27.3%) |
+| Fabio Tranchitella | 1 (9.1%) |
+
+| Developers with the most changed lines | |
+|---|---|
+| Ole Petter Orhagen | 314 (77.0%) |
+| Peter Grzybowski | 51 (12.5%) |
+| Lluis Campos | 42 (10.3%) |
+| Fabio Tranchitella | 1 (0.2%) |
+
+| Top changeset contributors by employer | |
+|---|---|
+| Northern.tech | 11 (100.0%) |
+
+| Top lines changed by employer | |
+|---|---|
+| Northern.tech | 408 (100.0%) |
+
+| Employers with the most hackers (total 4) | |
+|---|---|
+| Northern.tech | 4 (100.0%) |
+
+### Changelogs
+
+#### mender (2.4.1)
+
+New changes in mender since 2.4.0:
+
+* Add support for probing the U-Boot environment separator
+  ([MEN-3970](https://tracker.mender.io/browse/MEN-3970))
+* Fix: Do not switch boot partitions on installation errors on the
+  active partition.
+  ([MEN-3980](https://tracker.mender.io/browse/MEN-3980))
+* Allow to load private key from the Security configuration section
+  ([MEN-3924](https://tracker.mender.io/browse/MEN-3924))
+
 
 ## meta-mender dunfell-v2020.10
 

--- a/autoversion.py
+++ b/autoversion.py
@@ -353,6 +353,10 @@ def main():
         help="Integration version to update to. Depends on --integration-dir option",
     )
     parser.add_argument(
+        "--mender-client-version",
+        help="Mender client version for client only releases to update to",
+    )
+    parser.add_argument(
         "--mender-convert-version", help="Mender-convert version to update to"
     )
     parser.add_argument(
@@ -383,6 +387,13 @@ def main():
                 )
             INTEGRATION_REPO = args.integration_dir
             INTEGRATION_VERSION = args.integration_version
+
+        if args.mender_client_version is not None:
+            if args.integration_version is not None:
+                raise Exception(
+                    "--mender-client-version and --integration-version are mutually exclusive"
+                )
+            VERSION_CACHE["mender"] = args.mender_client_version
 
         if args.mender_convert_version is not None:
             VERSION_CACHE["mender-convert"] = args.mender_convert_version


### PR DESCRIPTION
This cherry-picks the `autoversion.py --mender-client-version` option, and bumps the `mender-client-version` to `2.4.1`