### PR TITLE
Mender-client 2.3.1 release docs

### DIFF
--- a/03.Devices/10.Update-Modules/docs.md
+++ b/03.Devices/10.Update-Modules/docs.md
@@ -248,4 +248,4 @@ Because of the possible re-execution described above, Update Modules, and in par
 ## Further reading
 
 <!--AUTOVERSION: "blob/%/Documentation"/mender -->
-* [Update modules v3 protocol](https://github.com/mendersoftware/mender/blob/2.3.0/Documentation/update-modules-v3-file-api.md)
+* [Update modules v3 protocol](https://github.com/mendersoftware/mender/blob/2.3.1/Documentation/update-modules-v3-file-api.md)

--- a/04.Artifacts/10.Yocto-project/01.Building/docs.md
+++ b/04.Artifacts/10.Yocto-project/01.Building/docs.md
@@ -97,7 +97,7 @@ MENDER_ARTIFACT_NAME = "release-1"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "2.3.0"
+# PREFERRED_VERSION_pn-mender = "2.3.1"
 # PREFERRED_VERSION_pn-mender-artifact = "3.4.0"
 # PREFERRED_VERSION_pn-mender-artifact-native = "3.4.0"
 
@@ -156,11 +156,11 @@ i.e. the top level of the Yocto Project build tree, and run these commands:
 
 <!--AUTOVERSION: "-b % git://github.com/mendersoftware/meta-mender"/meta-mender-->
 ```bash
-git clone -b zeus git://github.com/mendersoftware/meta-mender
+git clone -b dunfell git://github.com/mendersoftware/meta-mender
 ```
 
 <!--AUTOVERSION: "the HEAD of the % branch"/meta-mender-->
-Note that this command checks out the HEAD of the zeus branch and is not a specific tagged release. The [Yocto project release schedule](https://wiki.yoctoproject.org/wiki/Releases) differs from the Mender release schedule so even though you may be using a specific release of Mender, you will still need to take further steps if you want to use a tagged release of the Yocto project.
+Note that this command checks out the HEAD of the dunfell branch and is not a specific tagged release. The [Yocto project release schedule](https://wiki.yoctoproject.org/wiki/Releases) differs from the Mender release schedule so even though you may be using a specific release of Mender, you will still need to take further steps if you want to use a tagged release of the Yocto project.
 
 Next, initialize the build environment:
 
@@ -214,7 +214,7 @@ MACHINE = "<YOUR-MACHINE>"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "2.3.0"
+# PREFERRED_VERSION_pn-mender = "2.3.1"
 # PREFERRED_VERSION_pn-mender-artifact = "3.4.0"
 # PREFERRED_VERSION_pn-mender-artifact-native = "3.4.0"
 

--- a/04.Artifacts/40.Signing-and-verification/docs.md
+++ b/04.Artifacts/40.Signing-and-verification/docs.md
@@ -92,7 +92,7 @@ creating the signature.
 
 <!--AUTOVERSION: "mender-%"/mender-->
 ```bash
-mender-artifact write rootfs-image -t beaglebone -n mender-2.3.0 -f core-image-base-beaglebone.ext4 -k private.key -o artifact-signed.mender
+mender-artifact write rootfs-image -t beaglebone -n mender-2.3.1 -f core-image-base-beaglebone.ext4 -k private.key -o artifact-signed.mender
 ```
 
 ! Make sure the Artifact name specified by the `-n` parameter in the above command matches the value specified when your file system image was created.

--- a/05.Client-configuration/02.Cross-compiling/docs.md
+++ b/05.Client-configuration/02.Cross-compiling/docs.md
@@ -48,11 +48,11 @@ cd $GOPATH/src/github.com/mendersoftware/mender
 
 <!--AUTOVERSION: "to use Mender %"/mender-->
 Check out the version of the Mender client you want to compile; see `git tag` for available versions.
-For example, to use Mender 2.3.0 run the following command:
+For example, to use Mender 2.3.1 run the following command:
 
 <!--AUTOVERSION: "git checkout %"/mender-->
 ```bash
-git checkout 2.3.0
+git checkout 2.3.1
 ```
 
 Then cross-compile the `mender` binary with:

--- a/05.Client-configuration/03.Identity/docs.md
+++ b/05.Client-configuration/03.Identity/docs.md
@@ -128,4 +128,4 @@ cpuid=1234123-ABC
 ## Example device identity executables
 
 <!--AUTOVERSION: "mender/tree/%"/mender-->
-Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/2.3.0/support?target=_blank).
+Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/2.3.1/support?target=_blank).

--- a/05.Client-configuration/06.Installing/docs.md
+++ b/05.Client-configuration/06.Installing/docs.md
@@ -24,7 +24,7 @@ See [the downloads page](../../downloads) for links to download all package arch
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-wget https://d1b0l86ne08fsf.cloudfront.net/2.3.0/dist-packages/debian/armhf/mender-client_2.3.0-1_armhf.deb
+wget https://d1b0l86ne08fsf.cloudfront.net/2.3.1/dist-packages/debian/armhf/mender-client_2.3.1-1_armhf.deb
 ```
 
 !!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../downloads) for other architectures, and also make sure to modify the references to the package in commands below.
@@ -39,7 +39,7 @@ To install and configure Mender run the following command:
 
 <!--AUTOVERSION: "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-sudo dpkg -i mender-client_2.3.0-1_armhf.deb
+sudo dpkg -i mender-client_2.3.1-1_armhf.deb
 ```
 
 After the installation wizard is completed, Mender is correctly setup on your
@@ -63,7 +63,7 @@ are shown below. Use `mender setup --help` to learn about all configuration opti
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
@@ -80,7 +80,7 @@ sudo systemctl restart mender-client
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --demo \
@@ -95,7 +95,7 @@ sudo systemctl restart mender-client
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_URL="<INSERT YOUR ENTERPRISE SERVER URL>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM YOUR ENTERPRISE SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.0-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.3.1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --server-url $SERVER_URL \
@@ -110,7 +110,7 @@ sudo systemctl restart mender-client
 ## Install from source
 
 <!--AUTOVERSION: "mender/tree/%#installing-from-source"/mender -->
-As an alternative to using a Debian package, it is possible to install the Mender client from source by following the guidelines outlined in the [README.md](https://github.com/mendersoftware/mender/tree/2.3.0#installing-from-source) of the Mender client source repository.
+As an alternative to using a Debian package, it is possible to install the Mender client from source by following the guidelines outlined in the [README.md](https://github.com/mendersoftware/mender/tree/2.3.1#installing-from-source) of the Mender client source repository.
 
 
 ## Additional information

--- a/06.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/06.Server-integration/02.Preauthorizing-devices/docs.md
@@ -29,7 +29,7 @@ We assume you have either [built a disk image for your board](../../artifacts/yo
 When preauthorizing a device you need to know its [identity](../../client-configuration/identity). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI (note it is *not* the ID of the device, but the key-value attributes under Identity that are used for preauthorization).
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/2.3.0/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
+By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/2.3.1/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
 
 
 ### Mender client and server connectivity
@@ -62,11 +62,11 @@ When preauthorizing a device, device keys will be generated on separate system (
 We will use a script to generate a keypair the Mender client understands; it uses the `openssl` command to generate the keys.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-Download the [keygen-client](https://github.com/mendersoftware/mender/blob/2.3.0/support/keygen-client?target=_blank) script into a directory:
+Download the [keygen-client](https://github.com/mendersoftware/mender/blob/2.3.1/support/keygen-client?target=_blank) script into a directory:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/2.3.0/support/keygen-client
+wget https://raw.githubusercontent.com/mendersoftware/mender/2.3.1/support/keygen-client
 ```
 
 Ensure it is executable:

--- a/08.Downloads/docs.md
+++ b/08.Downloads/docs.md
@@ -77,16 +77,16 @@ Ubuntu or Raspberry Pi OS. We provide packages for the following architectures:
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 | Architecture   | Devices                                   | Download link                                                       |
 |----------------|-------------------------------------------|---------------------------------------------------------------------|
-| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_2.3.0-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
-| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_2.3.0-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
-| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_2.3.0-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
+| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_2.3.1-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
+| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_2.3.1-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
+| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_2.3.1-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
 
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
-[mender-client_x.x.x-1_armhf.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.0/dist-packages/debian/armhf/mender-client_2.3.0-1_armhf.deb
+[mender-client_x.x.x-1_armhf.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.1/dist-packages/debian/armhf/mender-client_2.3.1-1_armhf.deb
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_arm64.deb"/mender -->
-[mender-client_x.x.x-1_arm64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.0/dist-packages/debian/arm64/mender-client_2.3.0-1_arm64.deb
+[mender-client_x.x.x-1_arm64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.1/dist-packages/debian/arm64/mender-client_2.3.1-1_arm64.deb
 <!--AUTOVERSION: "cloudfront.net/%/"/mender "mender-client_%-1_amd64.deb"/mender -->
-[mender-client_x.x.x-1_amd64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.0/dist-packages/debian/amd64/mender-client_2.3.0-1_amd64.deb
+[mender-client_x.x.x-1_amd64.deb]: https://d1b0l86ne08fsf.cloudfront.net/2.3.1/dist-packages/debian/amd64/mender-client_2.3.1-1_amd64.deb
 
 ## Mender CLI
 

--- a/201.Troubleshooting/01.Yocto-project-build/docs.md
+++ b/201.Troubleshooting/01.Yocto-project-build/docs.md
@@ -323,7 +323,7 @@ A typical error message for this condition is:
 Error:
  Problem: package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon requires u-boot, but none of the providers can be installed
   - package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon conflicts with u-boot <= 1:2019.07 provided by u-boot-fork-1:2019.07-r0.beaglebone_yocto
-  - package mender-2.3.0-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
+  - package mender-2.3.1-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
   - conflicting requests
 ```
 

--- a/202.Release-information/01.Release-notes-changelog/docs.md
+++ b/202.Release-information/01.Release-notes-changelog/docs.md
@@ -3,6 +3,51 @@ title: Release notes & changelog
 taxonomy:
     category: docs
 ---
+## Mender client 2.3.1
+
+_Released 11.03.2020_
+
+### Statistics
+
+A total of 211 lines added, 26 removed (delta 185)
+
+| Developers with the most changesets | |
+|---|---|
+| Ole Petter Orhagen | 5 (55.6%) |
+| Lluis Campos | 3 (33.3%) |
+| Fabio Tranchitella | 1 (11.1%) |
+
+| Developers with the most changed lines | |
+|---|---|
+| Ole Petter Orhagen | 179 (80.6%) |
+| Lluis Campos | 42 (18.9%) |
+| Fabio Tranchitella | 1 (0.5%) |
+
+| Top changeset contributors by employer | |
+|---|---|
+| Northern.tech | 9 (100.0%) |
+
+| Top lines changed by employer | |
+|---|---|
+| Northern.tech | 222 (100.0%) |
+
+| Employers with the most hackers (total 3) | |
+|---|---|
+| Northern.tech | 3 (100.0%) |
+
+### Changelogs
+
+#### mender (2.3.1)
+
+New changes in mender since 2.3.0:
+
+* Add support for probing the U-Boot environment separator
+  ([MEN-3970](https://tracker.mender.io/browse/MEN-3970))
+* Fix: Do not switch boot partitions on installation errors on the
+  active partition.
+  ([MEN-3980](https://tracker.mender.io/browse/MEN-3980))
+
+
 
 ## meta-mender dunfell-v2020.10
 

--- a/autoversion.py
+++ b/autoversion.py
@@ -353,6 +353,10 @@ def main():
         help="Integration version to update to. Depends on --integration-dir option",
     )
     parser.add_argument(
+        "--mender-client-version",
+        help="Mender client version for client only releases to update to",
+    )
+    parser.add_argument(
         "--mender-convert-version", help="Mender-convert version to update to"
     )
     parser.add_argument(
@@ -380,6 +384,13 @@ def main():
                 )
             INTEGRATION_REPO = args.integration_dir
             INTEGRATION_VERSION = args.integration_version
+
+        if args.mender_client_version is not None:
+            if args.integration_version is not None:
+                raise Exception(
+                    "--mender-client-version and --integration-version are mutually exclusive"
+                )
+            VERSION_CACHE["mender"] = args.mender_client_version
 
         if args.mender_convert_version is not None:
             VERSION_CACHE["mender-convert"] = args.mender_convert_version


### PR DESCRIPTION
Cherry pick `mender-client-version` option to `autoversion`, and bump `Mender-client` version to `2.3.1`