### PR TITLE
Inventory geo script configuration option documentation 

### DIFF
--- a/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -118,6 +118,19 @@ Replace `<DIRECTORY-WITH-INVENTORY-SCRIPT>` with the path to the `mender-invento
 file, relative to the recipe file. The string `custom-attribute` can be replaced with a string of
 your choice, as long as the filename starts with `mender-inventory-`.
 
+### Remove the mender-inventory-geolocation script
+
+By default the Mender client installs with the `mender-inventory-geo` script
+enabled. To some users this is undesireable, as the script relies on a third
+party service for geolocating the device through its IP address. If this is
+applicable to you, then disable the script through setting:
+
+```bash
+PACKAGECONFIG_remove_pn-mender-client = " inventory-network-scripts"
+```
+
+in your `local.conf` file.
+
 
 ## Update Modules
 

--- a/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -100,9 +100,20 @@ recipe file.
 
 ## Inventory
 
-In order to include an inventory script, simply augment the `mender-client` recipe and install the
-script in the expected folder. For example, create a `mender-client_%.bbappend` file in your layer,
-and add this:
+Mender comes with some inventory scripts available out of the box. These are:
+
+* mender-inventory-bootloader-integration
+* mender-inventory-geo
+* mender-inventory-hostinfo
+* mender-inventory-network
+* mender-inventory-os
+* mender-inventory-provides
+* mender-inventory-rootfs-type
+* mender-inventory-update-modules
+
+In order to include an inventory script of your own making, augment the
+`mender-client` recipe and install the script in the expected folder. For
+example, create a `mender-client_%.bbappend` file in your layer, and add this:
 
 ```bash
 FILESEXTRAPATHS_prepend := "${THISDIR}/<DIRECTORY-WITH-INVENTORY-SCRIPT>"


### PR DESCRIPTION
Simply document the PACKAGECONFIG option to remove the `mender-inventory-geo` script from updates.