### PR TITLE
Rename Client certificates section to Mutual TLS authentication.

### DIFF
--- a/02.Overview/13.Device-authentication/docs.md
+++ b/02.Overview/13.Device-authentication/docs.md
@@ -156,7 +156,7 @@ mutual TLS ambassador:
 
 Futher communication between the Device and the Mender Server is intermediated by the mTLS ambassador which verifies the requests are authenticated with a valid client TLS certificate.
 
-Please refer to the [client certificates section](../../08.Server-integration/03.Client-certificates/docs.md)
+Please refer to the [Mutual TLS section](../../08.Server-integration/03.Mutual-TLS-authentication/docs.md)
 to find further details on the configuration of this feature.
 
 ## Authentication Token

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -883,9 +883,9 @@ can take a look at the section for [troubleshooting Mender
 Server]().
 
 
-## Client certificates and mutual TLS
+## Mutual TLS
 
 Mender Enterprise supports setting up a reverse proxy at the edge of the network, which can authenticate devices using TLS client certificates. Each client is equipped with a certificate signed by a CA certificate (Certificate Authority), and the edge proxy authenticates devices by verifying this signature. Authenticated devices are automatically authorized in the Mender backend, and do not need manual approval.
 
-Please refer to the [client certificates section](../../08.Server-integration/03.Client-certificates/docs.md)
+Please refer to the [Mutual TLS section](../../08.Server-integration/03.Mutual-TLS-authentication/docs.md)
 to find further details on the configuration of this feature.

--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -1,10 +1,10 @@
 ---
-title: Client certificates
+title: Mutual TLS authentication
 taxonomy:
     category: docs
 ---
 
-!!! Client certificate (aka. Mutual TLS) support is only available in the Mender Enterprise plan.
+!!! Mutual TLS authentication is only available in the Mender Enterprise plan.
 !!! See [the Mender features page](https://mender.io/plans/features?target=_blank)
 !!! for an overview of all Mender plans and features.
 


### PR DESCRIPTION
Aligns with website taxonomy and is more accurate.