### PR TITLE
MEN-4273: Adapt self-signed server instructions to new recipe

### DIFF
--- a/05.System-updates-Yocto-Project/06.Build-for-production/docs.md
+++ b/05.System-updates-Yocto-Project/06.Build-for-production/docs.md
@@ -72,11 +72,22 @@ method below that does not require a separate layer.
 
 #### Using a layer
 
-Put the certificate inside your own layer, under `recipes-mender/mender-client/files/server.crt`. Then create the file `recipes-mender/mender-client/mender-client_%.bbappend`. Inside this file, add the following content:
+Put the certificate inside your own layer, under
+`recipes-mender/mender-server-certificate/files/server.crt`. Then create the
+file
+`recipes-mender/mender-server-certificate/mender-server-certificate.bbappend`.
+Inside this file, add the following content:
 
 ```bash
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI_append = " file://server.crt"
+```
+
+Next, install `mender-server-certificate` package into your image by adding to
+your `conf/layer.conf` the following content:
+
+```bash
+IMAGE_INSTALL_append = " mender-server-certificate"
 ```
 
 This will make sure that the correct certificate is included in the build.
@@ -88,8 +99,9 @@ If you do not have a custom layer, you can also specify the certificate directly
 To add the certificate using `local.conf`, first make sure that the certificate has the name `server.crt`, and is stored somewhere accessible to the build. Then add the following to `local.conf`:
 
 ```bash
-FILESEXTRAPATHS_prepend_pn-mender-client := "<DIRECTORY-CONTAINING-server.crt>:"
-SRC_URI_append_pn-mender-client = " file://server.crt"
+FILESEXTRAPATHS_prepend_pn-mender-server-certificate := "<DIRECTORY-CONTAINING-server.crt>:"
+SRC_URI_append_pn-mender-server-certificate = " file://server.crt"
+IMAGE_INSTALL_append = " mender-server-certificate"
 ```
 
 Note in particular the `:` after the directory; this is mandatory.


### PR DESCRIPTION
The functionality to ship a self-signed certificate with the image is
now moved to its own recipe mender-server-certificate. Update
documentation accordingly.