### PR TITLE
[hosted] Update mtls-ambassador tag to mender-2.5.0

### DIFF
--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -218,7 +218,7 @@ docker run \
   -v $(pwd)/server-cert.pem:/etc/mtls/certs/server/server.crt \
   -v $(pwd)/server-private.key:/etc/mtls/certs/server/server.key \
   -v $(pwd)/ca-cert.pem:/etc/mtls/certs/tenant-ca/tenant.ca.pem \
-  registry.mender.io/mendersoftware/mtls-ambassador:1.0.0
+  registry.mender.io/mendersoftware/mtls-ambassador:mender-2.5.0
 ```
 
 Replace the following values with the ones that match your configuration:

--- a/autoversion.py
+++ b/autoversion.py
@@ -28,9 +28,11 @@ INTEGRATION_VERSION = None
 
 # Match version strings.
 YOCTO_BRANCHES = r"(?:dora|daisy|dizzy|jethro|krogoth|morty|pyro|rocko|sumo|thud|warrior|zeus|dunfell|gatesgarth)"
-VERSION_MATCHER = (
-    r"(?:(?<![0-9]\.)(?<![0-9])[1-9][0-9]*\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?![0-9])(?!\.[0-9])|(?<![a-z])(?:%s|master)(?![a-z]))"
-    % YOCTO_BRANCHES
+EXACT_VERSION_MATCH = r"(?<![0-9]\.)(?<![0-9])[1-9][0-9]*\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?![0-9])(?!\.[0-9])"
+VERSION_MATCHER = r"(?:%s|(?:mender-%s)|(?<![a-z])(?:%s|master)(?![a-z]))" % (
+    EXACT_VERSION_MATCH,
+    EXACT_VERSION_MATCH,
+    YOCTO_BRANCHES,
 )
 
 VERSION_CACHE = {}

--- a/test_autoversion.py
+++ b/test_autoversion.py
@@ -18,6 +18,16 @@ def test_version_regex():
     assert re.search(regex, "release.2_master_2") is not None
     assert re.search(regex, "morty") is not None
 
+    # Special case: mender-X.Y.Z
+    assert re.search(regex, "mender-1.2.3") is not None
+    assert re.search(regex, "mender-1.2.3").group(0) == "mender-1.2.3"
+    assert re.search(regex, "something-mender-1.2.3-else") is not None
+    assert re.search(regex, "something-mender-1.2.3-else").group(0) == "mender-1.2.3"
+    assert re.search(regex, "1.2.3-mender") is not None
+    assert re.search(regex, "1.2.3-mender").group(0) == "1.2.3"
+    assert re.search(regex, "mender.1.2.3") is not None
+    assert re.search(regex, "mender.1.2.3").group(0) == "1.2.3"
+
     # Should not match.
     assert re.search(regex, "1.2.3.4") is None
     assert re.search(regex, "11.2.3.4") is None


### PR DESCRIPTION
This is the tag that we build/test during releases and the one that we
should document for users to pull.