### PR TITLE
[autoversion] Accept mender-X.Y.Z like versions

### DIFF
--- a/autoversion.py
+++ b/autoversion.py
@@ -28,9 +28,11 @@ INTEGRATION_VERSION = None
 
 # Match version strings.
 YOCTO_BRANCHES = r"(?:dora|daisy|dizzy|jethro|krogoth|morty|pyro|rocko|sumo|thud|warrior|zeus|dunfell|gatesgarth)"
-VERSION_MATCHER = (
-    r"(?:(?<![0-9]\.)(?<![0-9])[1-9][0-9]*\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?![0-9])(?!\.[0-9])|(?<![a-z])(?:%s|master)(?![a-z]))"
-    % YOCTO_BRANCHES
+EXACT_VERSION_MATCH = r"(?<![0-9]\.)(?<![0-9])[1-9][0-9]*\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?![0-9])(?!\.[0-9])"
+VERSION_MATCHER = r"(?:%s|(?:mender-%s)|(?<![a-z])(?:%s|master)(?![a-z]))" % (
+    EXACT_VERSION_MATCH,
+    EXACT_VERSION_MATCH,
+    YOCTO_BRANCHES,
 )
 
 VERSION_CACHE = {}

--- a/test_autoversion.py
+++ b/test_autoversion.py
@@ -18,6 +18,16 @@ def test_version_regex():
     assert re.search(regex, "release.2_master_2") is not None
     assert re.search(regex, "morty") is not None
 
+    # Special case: mender-X.Y.Z
+    assert re.search(regex, "mender-1.2.3") is not None
+    assert re.search(regex, "mender-1.2.3").group(0) == "mender-1.2.3"
+    assert re.search(regex, "something-mender-1.2.3-else") is not None
+    assert re.search(regex, "something-mender-1.2.3-else").group(0) == "mender-1.2.3"
+    assert re.search(regex, "1.2.3-mender") is not None
+    assert re.search(regex, "1.2.3-mender").group(0) == "1.2.3"
+    assert re.search(regex, "mender.1.2.3") is not None
+    assert re.search(regex, "mender.1.2.3").group(0) == "1.2.3"
+
     # Should not match.
     assert re.search(regex, "1.2.3.4") is None
     assert re.search(regex, "11.2.3.4") is None


### PR DESCRIPTION
As the ones used for the Docker tags of backend services.