### PR TITLE
[autoversion] Fetch docker versions from release_tool

### DIFF
--- a/autoversion.py
+++ b/autoversion.py
@@ -55,6 +55,8 @@ def get_version_of(repo):
                     os.path.join(INTEGRATION_REPO, "extra", "release_tool.py"),
                     "--version-of",
                     repo,
+                    "--version-type",
+                    "docker",
                     "--in-integration-version",
                     INTEGRATION_VERSION,
                 ]


### PR DESCRIPTION
So that the backend services get mender-X.Y.Z tags instead of X.Y.Z.