### PR TITLE
[2.3.x] disabled shortcode detection on long release information sites

### DIFF
--- a/202.Release-information/01.Release-notes-changelog/docs.md
+++ b/202.Release-information/01.Release-notes-changelog/docs.md
@@ -2,6 +2,8 @@
 title: Release notes & changelog
 taxonomy:
     category: docs
+shortcode-core:
+    active: false
 ---
 
 ## meta-mender warrior-v2020.07

--- a/202.Release-information/02.Open-source-licenses/docs.md
+++ b/202.Release-information/02.Open-source-licenses/docs.md
@@ -2,6 +2,8 @@
 title: Open source licenses
 taxonomy:
     category: docs
+shortcode-core:
+    active: false
 ---
 
 All open source licenses used in Mender with the default build are shown below.


### PR DESCRIPTION
since the corresponding plugin caused errors
due to the increased memory footprint required to parse the pages

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>
(cherry picked from commit 2c28c9fce1b807bab4dd3bbedefd2b68ba9b9de4)