### PR TITLE
[2.6.x] Update versions for Mender 2.6 build candidate 1

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -34,8 +34,8 @@ Download the Raspberry Pi OS image with Mender integrated:
   * Download link: [Raspberry Pi 4 Model B][raspios-buster-lite-raspberrypi4-mender.img.xz]
 
 <!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-master.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-master.img.xz
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.5.0-build1.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.5.0-build1.img.xz
 
 Follow the steps outlined in the [Raspberry Pi OS documentation](https://www.raspberrypi.org/documentation/installation/installing-images?target=_blank)
 to flash the OS image to the device.

--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -32,14 +32,14 @@ Download the `mender-artifact` binary. If you're on Linux
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/master/linux/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.5.0-build1/linux/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 On MacOS
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/master/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.5.0-build1/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 

--- a/01.Get-started/04.Deploy-a-container-update/docs.md
+++ b/01.Get-started/04.Deploy-a-container-update/docs.md
@@ -78,7 +78,7 @@ Download the `mender-artifact` binary
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/master/linux/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.5.0-build1/linux/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 Make the `mender-artifact` binary executable:
@@ -109,7 +109,7 @@ Download the `docker-artifact-gen` utility script:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/docker-artifact-gen
+wget https://raw.githubusercontent.com/mendersoftware/mender/2.5.0-build1-build1/support/modules-artifact-gen/docker-artifact-gen
 ```
 
 Make `docker-artifact-gen` executable:

--- a/02.Overview/02.Device-Support/docs.md
+++ b/02.Overview/02.Device-Support/docs.md
@@ -98,7 +98,7 @@ community post for steps to create one.
 
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 You can compile the Mender client for a wide variety of architectures. Follow the steps in the
-[README.md](https://github.com/mendersoftware/mender/tree/master?target=_blank#installing-from-source)
+[README.md](https://github.com/mendersoftware/mender/tree/2.5.0-build1?target=_blank#installing-from-source)
 of the Mender client source repository. This is also the first step to a board integration for other types of Linux OSes.
 
 
@@ -107,7 +107,7 @@ of the Mender client source repository. This is also the first step to a board i
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 For a POSIX compliant OS it may be possible to compile the Mender client to run natively,
 as outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/master?target=_blank#installing-from-source).
+[README.md](https://github.com/mendersoftware/mender/tree/2.5.0-build1?target=_blank#installing-from-source).
 
 For other types of OSes you can either use a nearby Linux system to update it via a
 [proxy deployment](../../02.Overview/01.Introduction/docs.md#proxy-deployments) or

--- a/02.Overview/03.Artifact/docs.md
+++ b/02.Overview/03.Artifact/docs.md
@@ -44,7 +44,7 @@ Mender Artifact file.
 
 <!--AUTOVERSION: "mender-artifact/blob/%"/mender-artifact-->
 You can find more details about the Mender Artifact format in the
-[Mender Artifact specification](https://github.com/mendersoftware/mender-artifact/blob/master/Documentation?target=_blank).
+[Mender Artifact specification](https://github.com/mendersoftware/mender-artifact/blob/3.5.0-build1-build1/Documentation?target=_blank).
 
 
 ### *Provides* and *Depends*

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -34,7 +34,7 @@ this is the most common for users getting starting with Mender.
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-wget https://downloads.mender.io/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
+wget https://downloads.mender.io/2.5.0-build1/dist-packages/debian/armhf/mender-client_2.5.0-build1-1_armhf.deb
 ```
 
 !!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../09.Downloads/docs.md) for other architectures, and also make sure to modify the references to the package in commands below.
@@ -49,7 +49,7 @@ To install and configure Mender run the following command:
 
 <!--AUTOVERSION: "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-sudo dpkg -i mender-client_master-1_armhf.deb
+sudo dpkg -i mender-client_2.5.0-build1-1_armhf.deb
 ```
 
 After completing the installation wizard, Mender is correctly set up on your
@@ -73,7 +73,7 @@ configuration options.
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.5.0-build1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
@@ -90,7 +90,7 @@ sudo systemctl restart mender-client
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.5.0-build1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --demo \
@@ -105,7 +105,7 @@ sudo systemctl restart mender-client
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_URL="<INSERT YOUR ENTERPRISE SERVER URL>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM YOUR ENTERPRISE SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_2.5.0-build1-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --server-url $SERVER_URL \
@@ -122,7 +122,7 @@ sudo systemctl restart mender-client
 <!--AUTOVERSION: "mender/tree/%#installing-from-source"/mender -->
 As an alternative to using a Debian package, it is possible to install the
 Mender client from source by following the guidelines outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/master#installing-from-source?target=_blank)
+[README.md](https://github.com/mendersoftware/mender/tree/2.5.0-build1#installing-from-source?target=_blank)
 of the Mender client source repository.
 
 

--- a/03.Client-installation/03.Identity/docs.md
+++ b/03.Client-installation/03.Identity/docs.md
@@ -96,6 +96,6 @@ cpuid=1234123-ABC
 ## Example device identity executables
 
 <!--AUTOVERSION: "mender/tree/%"/mender-->
-Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/master/support?target=_blank).
+Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/2.5.0-build1/support?target=_blank).
 
 

--- a/03.Client-installation/04.Inventory/docs.md
+++ b/03.Client-installation/04.Inventory/docs.md
@@ -121,7 +121,7 @@ a-country=Poland
 a-city=Krakow
 ```
 <!--AUTOVERSION: "mender/tree/%/support"/mender-->
-You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/master/support) directory.
+You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/2.5.0-build1/support) directory.
 
 
 ## Default inventory
@@ -133,7 +133,7 @@ By default, and without any inventory scripts added, the Mender client sends the
 |:----:|:-------:|:-------------:|
 | `device_type`  | type of the device | "raspberrypi4" |
 | `artifact_name` | name of the currently installed artifact | "release-v1" |
-| `mender_client_version` | client version | "2.2.0" |
+| `mender_client_version` | client version | "2.5.0-build1" |
 
 
 ## Final remarks

--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/01.Customization/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/01.Customization/docs.md
@@ -14,7 +14,7 @@ The configuration files are a means to customize the conversion process for
 `mender-convert`. In the `configs/` directory, there are customization scripts
 which add support for board-specific configurations. A run of `mender-convert`
 can include multiple configuration files, each one added with the `--config`
-command-line option. The standard configuration [configs/mender_convert_config](https://github.com/mendersoftware/mender-convert/blob/master/configs/mender_convert_config) includes the defaults for the configuration options which the tool supports.
+command-line option. The standard configuration [configs/mender_convert_config](https://github.com/mendersoftware/mender-convert/blob/2.3.x/configs/mender_convert_config) includes the defaults for the configuration options which the tool supports.
 
 ### Example
 

--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
@@ -96,7 +96,7 @@ Clone `mender-convert` from the official repository:
 
 <!--AUTOVERSION: "-b % https://github.com/mendersoftware/mender-convert"/mender-convert-->
 ```bash
-git clone -b master https://github.com/mendersoftware/mender-convert.git
+git clone -b 2.3.x https://github.com/mendersoftware/mender-convert.git
 ```
 
 ## Build the mender-convert container image

--- a/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -113,9 +113,9 @@ MENDER_ARTIFACT_NAME = "release-1"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender-client = "2.1.2"
-# PREFERRED_VERSION_pn-mender-artifact = "3.2.1"
-# PREFERRED_VERSION_pn-mender-artifact-native = "3.2.1"
+# PREFERRED_VERSION_pn-mender-client = "2.5.0-build1"
+# PREFERRED_VERSION_pn-mender-artifact = "3.5.0-build1"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.5.0-build1"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
@@ -172,11 +172,11 @@ i.e. the top level of the Yocto Project build tree, and run these commands:
 
 <!--AUTOVERSION: "-b % git://github.com/mendersoftware/meta-mender"/meta-mender-->
 ```bash
-git clone -b master git://github.com/mendersoftware/meta-mender
+git clone -b dunfell git://github.com/mendersoftware/meta-mender
 ```
 
 <!--AUTOVERSION: "the HEAD of the % branch"/meta-mender-->
-Note that this command checks out the HEAD of the master branch and is not a specific tagged release. The [Yocto project release schedule](https://wiki.yoctoproject.org/wiki/Releases) differs from the Mender release schedule so even though you may be using a specific release of Mender, you will still need to take further steps if you want to use a tagged release of the Yocto project.
+Note that this command checks out the HEAD of the dunfell branch and is not a specific tagged release. The [Yocto project release schedule](https://wiki.yoctoproject.org/wiki/Releases) differs from the Mender release schedule so even though you may be using a specific release of Mender, you will still need to take further steps if you want to use a tagged release of the Yocto project.
 
 Next, initialize the build environment:
 
@@ -230,9 +230,9 @@ MACHINE = "<YOUR-MACHINE>"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "2.1.2"
-# PREFERRED_VERSION_pn-mender-artifact = "3.2.1"
-# PREFERRED_VERSION_pn-mender-artifact-native = "3.2.1"
+# PREFERRED_VERSION_pn-mender = "2.5.0-build1"
+# PREFERRED_VERSION_pn-mender-artifact = "3.5.0-build1"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.5.0-build1"
 
 # The following settings to enable systemd are needed for all Yocto
 # releases sumo and older.  Newer releases have these settings conditionally

--- a/05.System-updates-Yocto-Project/04.Image-customization/03.State-scripts/docs.md
+++ b/05.System-updates-Yocto-Project/04.Image-customization/03.State-scripts/docs.md
@@ -15,7 +15,7 @@ scripts](../../../06.Artifact-creation/04.State-scripts/docs.md#root-file-system
 
 <!--AUTOVERSION: "meta-mender/tree/%"/meta-mender-->
 Take a look at the
-[example-state-scripts](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-demo/recipes-mender/example-state-scripts?target=_blank)
+[example-state-scripts](https://github.com/mendersoftware/meta-mender/tree/dunfell/meta-mender-demo/recipes-mender/example-state-scripts?target=_blank)
 recipe to get started.
 
 !! If you add or remove a recipe containing state scripts to a build, you need

--- a/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
@@ -26,7 +26,7 @@ command:
 <!--AUTOVERSION: "mender-binary-delta/%/mender-binary-delta-%.tar"/mender-binary-delta-->
 ```bash
 HOSTED_MENDER_EMAIL="myusername@example.com"
-curl -u $HOSTED_MENDER_EMAIL -O https://download.mender.io/hosted/content/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
+curl -u $HOSTED_MENDER_EMAIL -O https://download.mender.io/hosted/content/mender-binary-delta/1.2.0/mender-binary-delta-1.2.0.tar.xz
 ```
 
 Replace the value of `HOSTED_MENDER_EMAIL` with the email address you used to sign up on *Hosted Mender*, then enter your Hosted Mender password when prompted to proceed.
@@ -38,14 +38,14 @@ command:
 <!--AUTOVERSION: "mender-binary-delta/%/mender-binary-delta-%.tar"/mender-binary-delta-->
 ```bash
 MENDER_ENTERPRISE_EMAIL="myusername@example.com"
-curl -u $MENDER_ENTERPRISE_EMAIL -O https://download.mender.io/content/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
+curl -u $MENDER_ENTERPRISE_EMAIL -O https://download.mender.io/content/mender-binary-delta/1.2.0/mender-binary-delta-1.2.0.tar.xz
 ```
 
 
 ## Unpack `mender-binary-delta`
 
 <!--AUTOVERSION: "mender-binary-delta-%.tar.xz"/mender-binary-delta-->
-The archive `mender-binary-delta-1.1.0.tar.xz` contains the binaries needed to generate and apply
+The archive `mender-binary-delta-1.2.0.tar.xz` contains the binaries needed to generate and apply
 deltas.
 
 Change directory to `$HOME`:
@@ -55,11 +55,11 @@ cd ${HOME}
 ```
 
 <!--AUTOVERSION: "mender-binary-delta-%.tar.xz"/mender-binary-delta-->
-Unpack the `mender-binary-delta-1.1.0.tar.xz` in your home directory:
+Unpack the `mender-binary-delta-1.2.0.tar.xz` in your home directory:
 
 <!--AUTOVERSION: "mender-binary-delta-%.tar.xz"/mender-binary-delta-->
 ```bash
-tar xvf mender-binary-delta-1.1.0.tar.xz
+tar xvf mender-binary-delta-1.2.0.tar.xz
 ```
 
 
@@ -81,7 +81,7 @@ cat <<EOF >> conf/local.conf
 
 IMAGE_INSTALL_append = " mender-binary-delta"
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-binary-delta"
-FILESEXTRAPATHS_prepend_pn-mender-binary-delta := "${HOME}/mender-binary-delta-1.1.0/:"
+FILESEXTRAPATHS_prepend_pn-mender-binary-delta := "${HOME}/mender-binary-delta-1.2.0/:"
 
 EOF
 ```

--- a/06.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -70,10 +70,10 @@ Note specifically that in this case we are creating a *module-image*, using the 
 #### Update Modules generation script
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/master/support/modules/single-file?target=_blank)
+You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/2.5.0-build1/support/modules/single-file?target=_blank)
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/master/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
+Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/2.5.0-build1/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
 
 #### Server side Artifact generation
 
@@ -83,4 +83,4 @@ will carry the file you have uploaded, the destination
 directory, the filename, and permissions, exactly as we saw above.
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/Documentation"/mender-->
-For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/master/Documentation/update-modules-v3-file-api.md?target=_blank).
+For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/2.5.0-build1/Documentation/update-modules-v3-file-api.md?target=_blank).

--- a/06.Artifact-creation/07.Sign-and-verify/docs.md
+++ b/06.Artifact-creation/07.Sign-and-verify/docs.md
@@ -85,7 +85,7 @@ creating the signature.
 ```bash
 mender-artifact write rootfs-image \
 -t beaglebone \
--n mender-master \
+-n mender-2.5.0-build1 \
 -f core-image-base-beaglebone.ext4 \
 -k private.key \
 -o artifact-signed.mender

--- a/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -255,4 +255,4 @@ Because of the possible re-execution described above, you should develop Update 
 ## Further reading
 
 <!--AUTOVERSION: "blob/%/Documentation"/mender -->
-* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/master/Documentation/update-modules-v3-file-api.md?target=_blank)
+* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/2.5.0-build1/Documentation/update-modules-v3-file-api.md?target=_blank)

--- a/07.Server-installation/02.Demo-installation/docs.md
+++ b/07.Server-installation/02.Demo-installation/docs.md
@@ -50,13 +50,13 @@ Clone the [integration](https://github.com/mendersoftware/integration?target=_bl
 repository which contains everything that is need to start the demo server:
 <!--AUTOVERSION: "-b %"/integration "integration-%"/integration -->
 ```bash
-git clone -b master https://github.com/mendersoftware/integration.git integration-master
+git clone -b 2.6.0-build1 https://github.com/mendersoftware/integration.git integration-2.6.0-build1
 ```
 
 Change directory to the cloned repository:
 <!--AUTOVERSION: "integration-%"/integration -->
 ```bash
- cd integration-master
+ cd integration-2.6.0-build1
 ```
 
 Start the demo server:
@@ -121,7 +121,7 @@ the images.
 
 <!--AUTOVERSION: "integration-%"/integration -->
 If you want to remove all state in your Mender demo environment and start clean,
-run the following commands in the `integration-master` directory:
+run the following commands in the `integration-2.6.0-build1` directory:
 
 ```bash
 ./demo stop

--- a/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -16,7 +16,7 @@ taxonomy:
 
 <!-- Basically a repeat of Open Source setup from Production Installation tutorial -->
 <!-- AUTOVERSION: "git clone -b %"/integration -->
-<!-- AUTOMATION: execute=git clone -b master https://github.com/mendersoftware/integration mender-server -->
+<!-- AUTOMATION: execute=git clone -b 2.6.0-build1 https://github.com/mendersoftware/integration mender-server -->
 <!-- AUTOMATION: execute=cd mender-server -->
 <!-- AUTOMATION: execute=git checkout -b my-production-setup -->
 <!-- AUTOMATION: execute=cd production -->

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -94,7 +94,7 @@ named `mender-server`:
 
 <!--AUTOVERSION: "-b %"/integration -->
 ```bash
-git clone -b master https://github.com/mendersoftware/integration mender-server
+git clone -b 2.6.0-build1 https://github.com/mendersoftware/integration mender-server
 ```
 
 > ```
@@ -574,7 +574,7 @@ At this point your commit history should look as follows:
 <!--AUTOVERSION: "git log --oneline %..HEAD"/integration -->
 <!--AUTOMATION: ignore -->
 ```bash
-git log --oneline master..HEAD
+git log --oneline 2.6.0-build1..HEAD
 ```
 > ```
 > 7a4de3c production: configuration
@@ -820,7 +820,7 @@ At this point your commit history should look as follows:
 <!--AUTOVERSION: "git log --oneline %..HEAD"/integration -->
 <!--AUTOMATION: ignore -->
 ```bash
-git log --oneline master..HEAD
+git log --oneline 2.6.0-build1..HEAD
 ```
 > ```
 > 76b3d00 production: Enterprise configuration

--- a/07.Server-installation/07.Upgrading/docs.md
+++ b/07.Server-installation/07.Upgrading/docs.md
@@ -70,8 +70,8 @@ git fetch origin --tags
 > Receiving objects: 100% (367/367), 83.55 KiB | 0 bytes/s, done.
 > Resolving deltas: 100% (214/214), completed with 42 local objects.
 > From https://github.com/mendersoftware/integration
->    02cd118..75b7831  2.0.x      -> origin/2.0.x
->    06f3212..e9e5df4  master     -> origin/master
+>    02cd118..75b7831  2.6.0-build1      -> origin/2.6.0-build1
+>    06f3212..e9e5df4  2.6.0-build1     -> origin/2.6.0-build1
 > ```
 
 <!--AUTOVERSION: "branch named `%` provides"/ignore "e.g. `%`"/ignore-->
@@ -89,7 +89,7 @@ introduced in upstream branch. For example:
 # to list differences between current HEAD and remote branch
 git log HEAD..origin/2.0.x
 # to list differences between current HEAD and stable tag
-git log HEAD..master
+git log HEAD..2.6.0-build1
 ```
 
 The most important thing to review is the diff between our production template
@@ -100,14 +100,14 @@ minor/major release, one can expect the diff to be larger. Example:
 <!--AUTOVERSION: "HEAD..%"/integration-->
 ```bash
 # while at the root of repository
-user@local$ git diff HEAD..master -- template
+user@local$ git diff HEAD..2.6.0-build1 -- template
 ```
 
 Upgrading our local production branch is performed by issuing a `git merge` command, like this:
 
 <!--AUTOVERSION: "git merge %"/integration-->
 ```bash
-git merge master
+git merge 2.6.0-build1
 ```
 > ```
 > Merge made by the 'recursive' strategy.
@@ -140,18 +140,18 @@ First, pull in new container images:
 > Digest: sha256:0ded6733900e6e09760cd9a7c79ba4981dea6f6b142352719f7a4157b4a3352d
 > Status: Image is up to date for mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z
 > ...
-> Pulling mender-device-auth (mendersoftware/deviceauth:mender-master)...
-> mender-master: Pulling from mendersoftware/deviceauth
+> Pulling mender-device-auth (mendersoftware/deviceauth:mender-2.6.0-build1)...
+> mender-2.6.0-build1: Pulling from mendersoftware/deviceauth
 > Digest: sha256:07ed10f6fdee40df1de8e10efc3115cb64b0c190bcf5bcd194b9f34086396058
-> Status: Image is up to date for mendersoftware/deviceauth:mender-master
-> Pulling mender-gui (mendersoftware/gui:mender-master)...
-> mender-master: Pulling from mendersoftware/gui
+> Status: Image is up to date for mendersoftware/deviceauth:mender-2.6.0-build1
+> Pulling mender-gui (mendersoftware/gui:mender-2.6.0-build1)...
+> mender-2.6.0-build1: Pulling from mendersoftware/gui
 > Digest: sha256:af2d2349f27dd96ca21940672aa3a91335b17153f8c7ef2ca865a9a7fdf2fd22
-> Status: Image is up to date for mendersoftware/gui:mender-master
-> Pulling mender-api-gateway (mendersoftware/api-gateway:mender-master)...
-> mender-master: Pulling from mendersoftware/api-gateway
+> Status: Image is up to date for mendersoftware/gui:mender-2.6.0-build1
+> Pulling mender-api-gateway (mendersoftware/api-gateway:mender-2.6.0-build1)...
+> mender-2.6.0-build1: Pulling from mendersoftware/api-gateway
 > Digest: sha256:0a2033a57f88afc38253a45301c83484e532047d75858df95d46c12b48f1f2f8
-> Status: Image is up to date for mendersoftware/api-gateway:mender-master````
+> Status: Image is up to date for mendersoftware/api-gateway:mender-2.6.0-build1````
 > ```
 
 Then stop and remove existing containers:

--- a/08.Server-integration/01.Using-the-apis/docs.md
+++ b/08.Server-integration/01.Using-the-apis/docs.md
@@ -104,4 +104,4 @@ If it succeeds it will return something like the following:
 If this fails, e.g. returns `401 Authorization Required`, make sure that the contents of your `JWT` and `MENDER_SERVER_URI` shell variables is correct and re-run the steps above if necessary.
 
 <!--AUTOVERSION: "mender-cli/%/"/mender-cli -->
-[x.x.x_mender-cli]: https://downloads.mender.io/mender-cli/master/linux/mender-cli
+[x.x.x_mender-cli]: https://downloads.mender.io/mender-cli/1.6.0-build1/linux/mender-cli

--- a/08.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/08.Server-integration/02.Preauthorizing-devices/docs.md
@@ -28,7 +28,7 @@ If you have not yet prepared a device visit one of the following:
 When preauthorizing a device you need to know its [identity](../../02.Overview/07.Identity/docs.md). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI. Note that preauthorization is *not* based on the ID of the device, only on the key-value attributes under Identity.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/master/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
+By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/2.5.0-build1/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
 
 
 ### Mender client and server connectivity
@@ -61,11 +61,11 @@ We will generate the keys on a separate system (not on the device), and then pro
 We will use a script to generate a keypair the Mender client understands; it uses the `openssl` command to generate the keys.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-Download the [keygen-client](https://github.com/mendersoftware/mender/blob/master/support/keygen-client?target=_blank) script into a directory:
+Download the [keygen-client](https://github.com/mendersoftware/mender/blob/2.5.0-build1/support/keygen-client?target=_blank) script into a directory:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/master/support/keygen-client
+wget https://raw.githubusercontent.com/mendersoftware/mender/2.5.0-build1/support/keygen-client
 ```
 
 Ensure it is executable:

--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -218,7 +218,7 @@ docker run \
   -v $(pwd)/server-cert.pem:/etc/mtls/certs/server/server.crt \
   -v $(pwd)/server-private.key:/etc/mtls/certs/server/server.key \
   -v $(pwd)/ca-cert.pem:/etc/mtls/certs/tenant-ca/tenant.ca.pem \
-  registry.mender.io/mendersoftware/mtls-ambassador:master
+  registry.mender.io/mendersoftware/mtls-ambassador:mender-2.6.0-build1
 ```
 
 Replace the following values with the ones that match your configuration:

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -33,8 +33,8 @@ Mender provides images based on the following distributions:
 | Raspberry Pi 4 Model B        | Raspberry Pi OS Buster Lite 2020-05-27 | [raspios-buster-lite-raspberrypi4-mender.img.xz][raspios-buster-lite-raspberrypi4-mender.img.xz] | 8 GB         |
 
 <!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-master.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-master.img.xz
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi3-mender-2.5.0-build1.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2020-05-27-raspios-buster-lite-armhf/arm/2020-05-27-raspios-buster-lite-armhf-raspberrypi4-mender-2.5.0-build1.img.xz
 
 You can find images for other devices in our Mender Hub community forum, see
 [Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11?target=_blank) or
@@ -55,8 +55,8 @@ Follow the correct link according to your host platform to download
 <!--AUTOVERSION: "mender-artifact %"/mender-artifact -->
 | Platform | Download link                                                |
 |----------|--------------------------------------------------------------|
-| Linux    | [mender-artifact master][x.x.x_mender-artifact-linux]     |
-| Mac OS X | [mender-artifact master][x.x.x_mender-artifact-darwin] |
+| Linux    | [mender-artifact 3.5.0-build1][x.x.x_mender-artifact-linux]     |
+| Mac OS X | [mender-artifact 3.5.0-build1][x.x.x_mender-artifact-darwin] |
 
 Remember to add execute permission and ensure that the mender-artifact utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
 
@@ -69,9 +69,9 @@ Please refer to your host Operating System documentation for more details.
 
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
+[x.x.x_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/3.5.0-build1/linux/mender-artifact
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/master/darwin/mender-artifact
+[x.x.x_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/3.5.0-build1/darwin/mender-artifact
 
 ! If you are using Mac OS X, note that using `mender-artifact` with
 ! disk image files (e.g.: `*.sdimg`, `*.img`, or others holding the storage
@@ -229,16 +229,16 @@ mode](../02.Overview/01.Introduction/docs.md#client-modes-of-operation).
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 | Architecture   | Devices                                   | Download link                                                       |
 |----------------|-------------------------------------------|---------------------------------------------------------------------|
-| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_master-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
-| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_master-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
-| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_master-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
+| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_2.5.0-build1-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
+| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_2.5.0-build1-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
+| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_2.5.0-build1-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
-[mender-client_x.x.x-1_armhf.deb]: https://downloads.mender.io/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
+[mender-client_x.x.x-1_armhf.deb]: https://downloads.mender.io/2.5.0-build1/dist-packages/debian/armhf/mender-client_2.5.0-build1-1_armhf.deb
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_arm64.deb"/mender -->
-[mender-client_x.x.x-1_arm64.deb]: https://downloads.mender.io/master/dist-packages/debian/arm64/mender-client_master-1_arm64.deb
+[mender-client_x.x.x-1_arm64.deb]: https://downloads.mender.io/2.5.0-build1/dist-packages/debian/arm64/mender-client_2.5.0-build1-1_arm64.deb
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_amd64.deb"/mender -->
-[mender-client_x.x.x-1_amd64.deb]: https://downloads.mender.io/master/dist-packages/debian/amd64/mender-client_master-1_amd64.deb
+[mender-client_x.x.x-1_amd64.deb]: https://downloads.mender.io/2.5.0-build1/dist-packages/debian/amd64/mender-client_2.5.0-build1-1_amd64.deb
 
 
 ## Remote Terminal add-on
@@ -277,8 +277,8 @@ Follow the correct link according to your host platform to download `mender-cli`
 <!--AUTOVERSION: "mender-cli %"/mender-cli -->
 | Platform | Download link                                                |
 |----------|--------------------------------------------------------------|
-| Linux    | [mender-cli master][x.x.x_mender-cli-linux]                  |
-| Mac OS X | [mender-cli master][x.x.x_mender-cli-darwin]                 |
+| Linux    | [mender-cli 1.6.0-build1][x.x.x_mender-cli-linux]                  |
+| Mac OS X | [mender-cli 1.6.0-build1][x.x.x_mender-cli-darwin]                 |
 
 
 Remember to add execute permission and ensure that the mender-cli utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
@@ -291,6 +291,6 @@ sudo cp mender-cli /usr/local/bin/
 Please refer to your host Operating System documentation for more details.
 
 <!--AUTOVERSION: "mender-cli/%/"/mender-cli -->
-[x.x.x_mender-cli-linux]: https://downloads.mender.io/mender-cli/master/linux/mender-cli
+[x.x.x_mender-cli-linux]: https://downloads.mender.io/mender-cli/1.6.0-build1/linux/mender-cli
 <!--AUTOVERSION: "mender-cli/%/"/mender-cli -->
-[x.x.x_mender-cli-darwin]: https://downloads.mender.io/mender-cli/master/darwin/mender-cli
+[x.x.x_mender-cli-darwin]: https://downloads.mender.io/mender-cli/1.6.0-build1/darwin/mender-cli

--- a/200.API/chapter.md
+++ b/200.API/chapter.md
@@ -1,6 +1,6 @@
 ---
 title: API
-redirect: /../api/development/
+redirect: /../api/2.6/
 ---
 <!--AUTOVERSION: "redirect: /../api/development/"/integration/complain-->
 <!--

--- a/201.Troubleshoot/01.Yocto-project-build/docs.md
+++ b/201.Troubleshoot/01.Yocto-project-build/docs.md
@@ -311,7 +311,7 @@ A typical error message for this condition is:
 Error:
  Problem: package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon requires u-boot, but none of the providers can be installed
   - package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon conflicts with u-boot <= 1:2019.07 provided by u-boot-fork-1:2019.07-r0.beaglebone_yocto
-  - package mender-master-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
+  - package mender-2.5.0-build1-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
   - conflicting requests
 ```
 

--- a/201.Troubleshoot/04.Mender-Server/docs.md
+++ b/201.Troubleshoot/04.Mender-Server/docs.md
@@ -114,7 +114,7 @@ The logs from docker-compose also show that `mender-api-gateway` exits with code
 
 <!--AUTOVERSION: "com.docker.compose.version=%"/ignore "image=mendersoftware/api-gateway:%"/mender-api-gateway-docker-->
 ```bash
-2017-07-03T11:14:17.223223822+02:00 container die c2a1cf1c19651950e804c7fe53cb9c0ffeb8b71de744500ab4844b370cf0480d (com.docker.compose.config-hash=5b9dfb050a59b9cbd67082037478562ff44c78cf4346d9a83225d1a74d557271, com.docker.compose.container-number=1, com.docker.compose.oneoff=False, com.docker.compose.project=menderproduction, com.docker.compose.service=mender-api-gateway, com.docker.compose.version=1.14.0, exitCode=132, image=mendersoftware/api-gateway:master, name=menderproduction_mender-api-gateway_1)
+2017-07-03T11:14:17.223223822+02:00 container die c2a1cf1c19651950e804c7fe53cb9c0ffeb8b71de744500ab4844b370cf0480d (com.docker.compose.config-hash=5b9dfb050a59b9cbd67082037478562ff44c78cf4346d9a83225d1a74d557271, com.docker.compose.container-number=1, com.docker.compose.oneoff=False, com.docker.compose.project=menderproduction, com.docker.compose.service=mender-api-gateway, com.docker.compose.version=1.14.0, exitCode=132, image=mendersoftware/api-gateway:mender-2.6.0-build1, name=menderproduction_mender-api-gateway_1)
 ```
 
 The problem here is most likely that your server CPU does not support the SSE 4.2

--- a/home/chapter.md
+++ b/home/chapter.md
@@ -1,5 +1,5 @@
 ---
-title: "Development"
+title: "2.6"
 taxonomy:
     category: docs
 ---
@@ -10,9 +10,9 @@ For page headers the tag may come after due to misrendering if it is above.
 -->
 
 <!--AUTOVERSION: "### Development"/integration/complain-->
-### Development
+### 2.6
 
 # Documentation
 
 <!--AUTOVERSION: "bleeding-edge % branch"/integration/complain-->
-Documentation for Mender's bleeding-edge master branch.
+Documentation for Mender 2.6.


### PR DESCRIPTION
Updated with:
```
./autoversion.py --update \
  --integration-version 2.6.0-build1 \
  --meta-mender-version dunfell \
  --poky-version dunfell \
  --mender-convert-version 2.3.x \
  --mender-convert-client-version 2.5.0-build1 \
  --mender-binary-delta-version 1.2.0 \
  --integration-dir ...
```