### PR TITLE
Revert mender-connect rename in changelogs

### DIFF
--- a/202.Release-information/01.Release-notes-changelog/docs.md
+++ b/202.Release-information/01.Release-notes-changelog/docs.md
@@ -1683,17 +1683,17 @@ New changes in meta-mender since zeus-v2020.10:
 * mender-client: Ensure growfs works on GPT filesystems
   ([MEN-4176](https://tracker.mender.io/browse/MEN-4176))
 * mender-client: Update LICENSE to include OpenSSL
-* Add a recipe for building 'mender-connect', remote shell support.
+* Add a recipe for building 'mender-shell', remote shell support.
   ([MEN-4083](https://tracker.mender.io/browse/MEN-4083))
-* meta-mender-demo: install mender-connect
+* meta-mender-demo: install mender-shell
   ([MEN-4187](https://tracker.mender.io/browse/MEN-4187))
-* mender-connect: generate and install mender-connect.conf with
+* mender-shell: generate and install mender-shell.conf with
   required fields. `ServerURL` can be configured setting yocto variable
   `MENDER_SERVER_URL`, same as used by mender-client recipe. If a
-  `mender-connect.conf` file is found in the `SRC_URI` the contents will be
+  `mender-shell.conf` file is found in the `SRC_URI` the contents will be
   merged. ([MEN-4242](https://tracker.mender.io/browse/MEN-4242))
-* mender-connect: Add `User` to generated mender-connect.conf. The
-  value of it is configured using `MENDER_CONNECT_USER` variable, which
+* mender-shell: Add `User` to generated mender-shell.conf. The
+  value of it is configured using `MENDER_SHELL_USER` variable, which
   defaults to `nobody` for meta-mender-core and `root` for
   meta-mender-demo.
   ([MEN-4242](https://tracker.mender.io/browse/MEN-4242))
@@ -1783,17 +1783,17 @@ New changes in meta-mender since warrior-v2020.10:
 * mender-client: Ensure growfs works on GPT filesystems
   ([MEN-4176](https://tracker.mender.io/browse/MEN-4176))
 * mender-client: Update LICENSE to include OpenSSL
-* Add a recipe for building 'mender-connect', remote shell support.
+* Add a recipe for building 'mender-shell', remote shell support.
   ([MEN-4083](https://tracker.mender.io/browse/MEN-4083))
-* meta-mender-demo: install mender-connect
+* meta-mender-demo: install mender-shell
   ([MEN-4187](https://tracker.mender.io/browse/MEN-4187))
-* mender-connect: generate and install mender-connect.conf with
+* mender-shell: generate and install mender-shell.conf with
   required fields. `ServerURL` can be configured setting yocto variable
   `MENDER_SERVER_URL`, same as used by mender-client recipe. If a
-  `mender-connect.conf` file is found in the `SRC_URI` the contents will be
+  `mender-shell.conf` file is found in the `SRC_URI` the contents will be
   merged. ([MEN-4242](https://tracker.mender.io/browse/MEN-4242))
-* mender-connect: Add `User` to generated mender-connect.conf. The
-  value of it is configured using `MENDER_CONNECT_USER` variable, which
+* mender-shell: Add `User` to generated mender-shell.conf. The
+  value of it is configured using `MENDER_SHELL_USER` variable, which
   defaults to `nobody` for meta-mender-core and `root` for
   meta-mender-demo.
   ([MEN-4242](https://tracker.mender.io/browse/MEN-4242))
@@ -1872,7 +1872,7 @@ New changes in meta-mender since dunfell-v2020.11:
   ([MEN-4176](https://tracker.mender.io/browse/MEN-4176))
 * mender-client: Update LICENSE to include OpenSSL
 * mender-client: Include OpenSSL license from 2.4.x onwards.
-* Add a recipe for building 'mender-connect', remote shell support.
+* Add a recipe for building 'mender-shell', remote shell support.
   ([MEN-4083](https://tracker.mender.io/browse/MEN-4083))
 * Fix a parsing issue where `inherit` could not be used with
   variables that had been defined with overrides that depended on


### PR DESCRIPTION
This text is auto generated and should not have been renamed together
with the rest.

This commit partially reverts 48519643.