### PR TITLE
Use awk rather than GNU sed for formatting.

### DIFF
--- a/08.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/08.Server-integration/02.Preauthorizing-devices/docs.md
@@ -142,7 +142,7 @@ DEVICE_IDENTITY_JSON_OBJECT_STRING='{"mac":"02:12:61:13:6c:42"}'
 Secondly, set the contents of the device public key you generated above in a second variable:
 
 ```bash
-DEVICE_PUBLIC_KEY="$(cat keys-client-generated/public.key | sed -e :a  -e 'N;s/\n/\\n/;ta')"
+DEVICE_PUBLIC_KEY="$(cat keys-client-generated/public.key | awk 1 ORS='\\n')"
 ```
 
 Then simply call the [API to preauthorize a device](../../200.API/?target=_blank#post__devices):


### PR DESCRIPTION
The original sed command used gnu extension so did not work on MacOS.
This command using awk is simpler and works on MacOS and Linux.

Changelog: None
Signed-off-by: Drew Moseley <drew@moseleynet.net>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
