### PR TITLE
fix mender-connect.conf target path

### DIFF
--- a/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -246,7 +246,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/<DIRECTORY-WITH-MENDER-CONNECT-CONF>"
 SRC_URI_append = " file://mender-connect.conf"
 
 do_install_append() {
-    install -m 600 ${WORKDIR}/mender-connect.conf ${datadir}/mender/mender-connect.conf
+    install -m 600 ${WORKDIR}/mender-connect.conf ${D}${sysconfdir}/mender/mender-connect.conf
 }
 
 ```


### PR DESCRIPTION
Fixed target directory of `mender-connect.conf` for yocto builds.
Replaces #1347 as this commit is signed off.