### PR TITLE
2.6.x: [Debian family/Variables] Correct style of Mender Connect variables

### DIFF
--- a/04.System-updates-Debian-family/99.Variables/docs.md
+++ b/04.System-updates-Debian-family/99.Variables/docs.md
@@ -117,14 +117,14 @@ The size of the boot partition.
 The version of the Mender client to include in the update.
 
 
-#### MENDER_ADDON_CONNECT_INSTALL
+#### `MENDER_ADDON_CONNECT_INSTALL`
 
 > Value: y/n(default)
 
 Install the Mender Connect add-on.
 
 
-#### MENDER_ADDON_CONNECT_VERSION
+#### `MENDER_ADDON_CONNECT_VERSION`
 
 <!--AUTOVERSION: "/%/"/ignore-->
 > Value: latest(default)/master/&lt;version&gt;


### PR DESCRIPTION
Porting relevant fix from #1376