### PR TITLE
update docs to reflect actual state of the mender server

### DIFF
--- a/07.Server-installation/01.Overview/docs.md
+++ b/07.Server-installation/01.Overview/docs.md
@@ -15,7 +15,6 @@ The integration environment brings together the following services:
 - [Mender User Administration Service](https://github.com/mendersoftware/useradm?target=_blank)
 - [Mender API Gateway](https://github.com/mendersoftware/mender-api-gateway-docker?target=_blank)
 - [Minio](https://www.minio.io/?target=_blank) object storage
-- Storage service proxy based on [OpenResty](https://openresty.org/en/?target=_blank)
 
 Services are delivered in form of Docker images, available from
 official [Mender Docker repository](https://hub.docker.com/r/mendersoftware/?target=_blank).
@@ -44,19 +43,21 @@ provides a convenient setup based on Docker Compose tool. The
         |                                       |    |  (mender-useradm)       |
         |                                       |    +-------------------------+
         |                                       +--->|                         |
-        |                                            |  Deployments            |
-        |              +---------------------------->|  (mender-deployments)   |
-        |              |                             +-------------------------+
-        |              |
-        |              |
-        |              |
-        |              |
-        |              v
-        |        +------------------+                 +---------+
-   port |        |                  |                 |         |
-   9000 | <----> |  Storage Proxy   |<--------------->| Minio   |
-        |        |  (storage-proxy) |                 | (minio) |
-        |        +------------------+                 +---------+
+        |                                       |    |  Device Config          |
+        |                                       |    |  (mender-deviceconfig)  |
+        |                                       |    +-------------------------+
+        |                                       +--->|                         |
+        |                                       |    |  Device Connect         |
+        |                                       |    |  (mender-deviceconnect) |
+        |                                       |    +-------------------------+
+        |                                       +--->|                         |
+        |                                       |    |  Deployments            |
+        |                                       |    |  (mender-deployments)   |
+        |                                       |    +-------------------------+
+        |                                       +--->|                         |
+        |                                            |  Minio                  |
+        |                                            |                         |
+        |                                            +-------------------------+
         |
 ```
 

--- a/07.Server-installation/01.Overview/docs.md
+++ b/07.Server-installation/01.Overview/docs.md
@@ -10,11 +10,16 @@ small, well defined piece of functionality.
 The integration environment brings together the following services:
 
 - [Mender Device Authentication Service](https://github.com/mendersoftware/deviceauth?target=_blank)
-- [Mender Deployment Service](https://github.com/mendersoftware/deployments?target=_blank)
+- [Mender Device Configuration Service](https://github.com/mendersoftware/deviceconfig?target=_blank)
+- [Mender Device Connect Service](https://github.com/mendersoftware/deviceconnect?target=_blank)
+- [Mender Deployments Service](https://github.com/mendersoftware/deployments?target=_blank)
 - [Mender Device Inventory Service](https://github.com/mendersoftware/inventory?target=_blank)
 - [Mender User Administration Service](https://github.com/mendersoftware/useradm?target=_blank)
-- [Mender API Gateway](https://github.com/mendersoftware/mender-api-gateway-docker?target=_blank)
-- [Minio](https://www.minio.io/?target=_blank) object storage
+- [Mender Workflows Service](https://github.com/mendersoftware/workflows?target=_blank)
+- [Mender Create Artifact Worker](https://github.com/mendersoftware/create-artifact-worker?target=_blank)
+- API Gateway based on [traefik](https://doc.traefik.io/traefik/?target=_blank)
+- [Minio](https://www.minio.io?target=_blank) object storage
+- [NATS.io](https://nats.io?target=_blank) messageing system
 
 Services are delivered in form of Docker images, available from
 official [Mender Docker repository](https://hub.docker.com/r/mendersoftware/?target=_blank).
@@ -31,31 +36,31 @@ provides a convenient setup based on Docker Compose tool. The
         |
         |                                            +-------------------------+
         |                                            |                         |
-        |                                       +--->|  Device Authentication  |
-        |                                       |    |  (mender-device-auth)   |
-        |                                       |    +-------------------------+
-        |        +-----------------------+      |    |                         |
-   port |        |                       |      +--->|  Inventory              |
-    443 | <----> |  API Gateway          |      |    |  (mender-inventory)     |
-        |        |  (mender-api-gateway) |<-----+    +-------------------------+
-        |        +-----------------------+      |    |                         |
-        |                                       +--->|  User Administration    |
-        |                                       |    |  (mender-useradm)       |
-        |                                       |    +-------------------------+
-        |                                       +--->|                         |
-        |                                       |    |  Device Config          |
-        |                                       |    |  (mender-deviceconfig)  |
-        |                                       |    +-------------------------+
-        |                                       +--->|                         |
-        |                                       |    |  Device Connect         |
-        |                                       |    |  (mender-deviceconnect) |
-        |                                       |    +-------------------------+
-        |                                       +--->|                         |
-        |                                       |    |  Deployments            |
-        |                                       |    |  (mender-deployments)   |
-        |                                       |    +-------------------------+
-        |                                       +--->|                         |
-        |                                            |  Minio                  |
+        |                                       +--->|  Device Authentication  |<---+
+        |                                       |    |  (mender-device-auth)   |    |
+        |                                       |    +-------------------------+    |
+        |        +-----------------------+      |    |                         |    |
+   port |        |                       |      +--->|  Inventory              |<---+     +----------------------------------+
+    443 | <----> |  API Gateway          |      |    |  (mender-inventory)     |    +---> |  Workflows Engine                |
+        |        |  (traefik)            |<-----+    +-------------------------+    |     |  (mender-workflows-server)       |
+        |        +-----------------------+      |    |                         |    |     |  (mender-workflows-worker)       |
+        |                                       +--->|  User Administration    |    |     |  (mender-create-artifact-worker) |
+        |                                       |    |  (mender-useradm)       |<---+     +----------------------------------+
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |    |
+        |                                       |    |  Device Config          |<---+
+        |                                       |    |  (mender-deviceconfig)  |    |
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |    |
+        |                                       |    |  Deployments            |<---+
+        |                                       |    |  (mender-deployments)   |    |
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |<---+
+        |                                       |    |  Device Connect         |          +--------+
+        |                                       |    |  (mender-deviceconnect) |<-------->|        |
+        |                                       |    +-------------------------+          |  Nats  |
+        |                                       +--->|                         |          |        |
+        |                                            |  Minio                  |          +--------+
         |                                            |                         |
         |                                            +-------------------------+
         |

--- a/07.Server-installation/02.Demo-installation/docs.md
+++ b/07.Server-installation/02.Demo-installation/docs.md
@@ -69,18 +69,20 @@ After a short while, depending on your network connection speed, you should see
 similar output to the following:
 
 >```bash
->Creating integration_mender-gui_1   ... done
 >Creating integration_minio_1        ... done
+>Creating integration_mender-gui_1   ... done
+>Creating integration_mender-nats_1                   ... done
 >Creating integration_mender-mongo_1 ... done
->Creating integration_mender-workflows-server_1       ... done
->Creating integration_mender-inventory_1              ... done
 >Creating integration_mender-workflows-worker_1       ... done
->Creating integration_mender-create-artifact-worker_1 ... done
 >Creating integration_mender-useradm_1                ... done
+>Creating integration_mender-deviceconfig_1           ... done
+>Creating integration_mender-inventory_1              ... done
+>Creating integration_mender-workflows-server_1       ... done
+>Creating integration_mender-create-artifact-worker_1 ... done
+>Creating integration_mender-deviceconnect_1          ... done
 >Creating integration_mender-device-auth_1            ... done
->Creating integration_storage-proxy_1                 ... done
->Creating integration_mender-deployments_1            ... done
 >Creating integration_mender-api-gateway_1            ... done
+>Creating integration_mender-deployments_1            ... done
 >Creating a new user...
 >****************************************
 >
@@ -104,14 +106,9 @@ The script created a demo user, and you can login to the Mender UI by visiting
 
 ### Stopping the demo
 
-To stop the demo server run:
-
-```bash
-./demo down
-```
-
-This will stop and remove the containers with all user data, but will not remove
-the images.
+To stop the demo use Ctrl+C.
+This will only stop the containers, but will not remove them.
+To remove containers use commands from the section below.
 
 ### Clean up the environment
 

--- a/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -158,11 +158,11 @@ connect without a tenant token.
 <!-- Verification -->
 
 <!--AUTOMATION: test=sleep 30 -->
-<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 15 || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
+<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 16 || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
 <!--AUTOMATION: test=./run stop -->
 <!--AUTOMATION: test=./run up -d -->
 <!--AUTOMATION: test=sleep 30 -->
-<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 15 || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
+<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 16 || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
 <!--AUTOMATION: test=docker ps | grep menderproduction | grep "0.0.0.0:443" -->
 
 

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -218,13 +218,10 @@ necessary Docker images:
 
 First, set the public domain name of your server (the URL your devices will reach your Mender server on):
 
-<!--AUTOMATION: ignore=use s3.docker.mender.io (localhost) instead-->
 ```bash
 API_GATEWAY_DOMAIN_NAME="mender.example.com"  # NB! replace with your server's public domain name
 STORAGE_PROXY_DOMAIN_NAME="s3.docker.mender.io"  # change if you are using a different domain name than the the default one
 ```
-<!--AUTOMATION: execute=API_GATEWAY_DOMAIN_NAME="mender.example.com" -->
-<!--AUTOMATION: execute=STORAGE_PROXY_DOMAIN_NAME="s3.docker.mender.io" -->
 
 Prepare certificates using the helper script `keygen`:
 

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -68,7 +68,7 @@ At the end of this tutorial you will have:
   - artifact storage
   - MongoDB data
 - SSL certificate for the API Gateway
-- SSL certificate for the Storage Proxy
+- SSL certificate for the storage domain
 - a set of keys for generating and validating access tokens
 
 Consult the section on [certificates and keys](../04.Certificates-and-keys/docs.md) for details on
@@ -189,31 +189,21 @@ necessary Docker images:
 ```
 
 > ```
-> Pulling mender-mongo (mongo:3.4)...
-> 3.4: Pulling from library/mongo
-> Digest: sha256:aff0c497cff4f116583b99b21775a8844a17bcf5c69f7f3f6028013bf0d6c00c
-> Status: Image is up to date for mongo:3.4
-> ...
-> Pulling mender-gui (mendersoftware/gui:latest)...
-> latest: Pulling from mendersoftware/gui
-> b7f33cc0b48e: Already exists
-> 31e101b48355: Pull complete
-> 307a023cd01f: Pull complete
-> 2edcf3035646: Pull complete
-> aeb59eb28f90: Pull complete
-> ...
-> Pulling mender-useradm (mendersoftware/useradm:latest)...
-> latest: Pulling from mendersoftware/useradm
-> Digest: sha256:3346985a2679b7edd9243363c4b1c291871481f8c6f557ccdc51af58dc6d3a1a
-> Status: Image is up to date for mendersoftware/useradm:latest
-> Pulling mender-device-auth (mendersoftware/deviceauth:latest)...
-> latest: Pulling from mendersoftware/deviceauth
-> Digest: sha256:ed47310dc9a86cca70d52c520d565ef9814f39421f2faa02d60bbe8a1dbd63c5
-> Status: Image is up to date for mendersoftware/deviceauth:latest
-> Pulling mender-api-gateway (mendersoftware/api-gateway:latest)...
-> latest: Pulling from mendersoftware/api-gateway
-> Digest: sha256:97243de3da950e754ada73abf8c123001c0a0c8b20344256dc7db4c89c0ecd82
-> Status: Image is up to date for mendersoftware/api-gateway:latest
+> Pulling mender-mongo                  ... done
+> Pulling mender-deviceconfig           ... done
+> Pulling mender-useradm                ... done
+> Pulling mender-workflows-worker       ... done
+> Pulling mender-create-artifact-worker ... done
+> Pulling mender-workflows-server       ... done
+> Pulling mender-device-auth            ... done
+> Pulling mender-gui                    ... done
+> Pulling mender-inventory              ... done
+> Pulling mender-api-gateway            ... done
+> Pulling minio                         ... done
+> Pulling mender-deployments            ... done
+> Pulling mender-nats                   ... done
+> Pulling mender-deviceconnect          ... done
+> Pulling mender-mongo (mongo:4.4)...
 > ```
 
 ! Using the `run` helper script may fail when local user has insufficient permissions to reach a local docker daemon. Make sure that the Docker installation was completed successfully and the user has sufficient permissions (typically the user must be a member of the `docker` group).
@@ -231,10 +221,10 @@ First, set the public domain name of your server (the URL your devices will reac
 <!--AUTOMATION: ignore=use s3.docker.mender.io (localhost) instead-->
 ```bash
 API_GATEWAY_DOMAIN_NAME="mender.example.com"  # NB! replace with your server's public domain name
-STORAGE_PROXY_DOMAIN_NAME="$API_GATEWAY_DOMAIN_NAME"  # change if you are hosting the Storage Proxy on a different domain name (not the default)
+STORAGE_PROXY_DOMAIN_NAME="s3.docker.mender.io"  # change if you are using a different domain name than the the default one
 ```
-<!--AUTOMATION: execute=API_GATEWAY_DOMAIN_NAME="s3.docker.mender.io" -->
-<!--AUTOMATION: execute=STORAGE_PROXY_DOMAIN_NAME="$API_GATEWAY_DOMAIN_NAME" -->
+<!--AUTOMATION: execute=API_GATEWAY_DOMAIN_NAME="mender.example.com" -->
+<!--AUTOMATION: execute=STORAGE_PROXY_DOMAIN_NAME="s3.docker.mender.io" -->
 
 Prepare certificates using the helper script `keygen`:
 
@@ -388,7 +378,10 @@ docker volume create --name=mender-artifacts
 docker volume create --name=mender-db
 ```
 
-!!! The storage location of these volumes depends on your docker configuration. You can check the path for a specific volume by running `docker volume inspect --format '{{.Mountpoint}}' mender-artifacts`.
+!!! The storage location of these volumes depends on your docker configuration. You can check the path for a specific volume by running
+!!! ```bash
+!!! docker volume inspect --format '{{.Mountpoint}}' mender-artifacts
+!!! ```
 
 
 ### Configuration
@@ -475,30 +468,13 @@ After these three commands, the updated entry should look like this (you can aga
 
 #### Storage proxy
 
-Add your storage server's DNS name under the key `networks.mender.aliases` key
-by running the following command:
-
+In the default setup there is no separate process acting as a proxy to storage service.
+For this purpose you can use Mender API Gateway, but with an additional domain name.
+Change the placeholder value `set-my-alias-here` to a valid domain name to use
+Mender API Gateway as a proxy to the storage service, by running the following command:
 ```bash
 sed -i.bak "s/set-my-alias-here.com/$STORAGE_PROXY_DOMAIN_NAME/g" config/prod.yml
 ```
-
-The entry should now look like this:
-
-```yaml
-    ...
-    storage-proxy:
-        networks:
-            mender:
-                aliases:
-                    - mender.example.com
-    ...
-
-```
-
-You can also change the values for `DOWNLOAD_SPEED` and `MAX_CONNECTIONS`.
-See the [section on bandwidth](../05.Bandwidth/docs.md) for more details on these
-settings.
-
 
 
 #### API gateway
@@ -601,14 +577,20 @@ Bring up all services up in detached mode with the following command:
 ```
 > ```
 > Creating network "menderproduction_mender" with the default driver
-> Creating menderproduction_mender-mongo_1
-> Creating menderproduction_mender-gui_1
-> Creating menderproduction_minio_1
-> Creating menderproduction_mender-device-auth_1
-> Creating menderproduction_mender-inventory_1
-> Creating menderproduction_mender-useradm_1
-> Creating menderproduction_mender-deployments_1
-> Creating menderproduction_mender-api-gateway_1
+> Creating menderproduction_mender-nats_1                   ... done
+> Creating menderproduction_mender-mongo_1 ... done
+> Creating menderproduction_minio_1        ... done
+> Creating menderproduction_mender-gui_1   ... done
+> Creating menderproduction_mender-workflows-worker_1       ... done
+> Creating menderproduction_mender-create-artifact-worker_1 ... done
+> Creating menderproduction_mender-useradm_1                ... done
+> Creating menderproduction_mender-workflows-server_1       ... done
+> Creating menderproduction_mender-deviceconfig_1           ... done
+> Creating menderproduction_mender-inventory_1              ... done
+> Creating menderproduction_mender-deviceconnect_1          ... done
+> Creating menderproduction_mender-device-auth_1            ... done
+> Creating menderproduction_mender-api-gateway_1            ... done
+> Creating menderproduction_mender-deployments_1            ... done
 > ```
 
 !!! Services, networks and volumes have a `menderproduction` prefix, see the note about [docker-compose naming scheme](#docker-compose-naming-scheme) for more details. When using `docker ..` commands, a complete container name must be provided (ex. `menderproduction_mender-deployments_1`).
@@ -634,10 +616,10 @@ installing an Open Source server, please proceed to
 
 <!-- Verification of Open Source instance -->
 
-<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 13  || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
+<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 14  || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
 <!--AUTOMATION: test=./run stop -->
 <!--AUTOMATION: test=./run up -d -->
-<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 13  || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
+<!--AUTOMATION: test=for ((n=0;n<10;n++)); do sleep 3 && test "$(docker ps | grep menderproduction | grep -c -i 'up')" = 14  || ( echo "some containers are not 'Up'" && docker ps && ./run images && ./run logs && exit 1 ); done -->
 <!--AUTOMATION: test=docker ps | grep menderproduction | grep "0.0.0.0:443" -->
 
 <!-- End of test block for TEST_OPEN_SOURCE=1 -->
@@ -852,18 +834,23 @@ Below you can see typical output for the Enterprise server. The Open Source
 server will be similar, but will have fewer services running.
 
 > ```
->                       Name                                    Command                  State                  Ports
+>                       Name                                    Command                  State                  Ports            
 > -------------------------------------------------------------------------------------------------------------------------------
-> menderproduction_mender-api-gateway_1              /entrypoint.sh                   Up             0.0.0.0:443->443/tcp, 80/tcp
-> menderproduction_mender-create-artifact-worker_1   /usr/bin/workflows --confi ...   Up             8080/tcp
-> menderproduction_mender-deployments_1              /entrypoint.sh --config /e ...   Up             8080/tcp
-> menderproduction_mender-device-auth_1              /usr/bin/deviceauth --conf ...   Up             8080/tcp
-> menderproduction_mender-gui_1                      /entrypoint.sh nginx             Up (healthy)   80/tcp
-> menderproduction_mender-inventory_1                /usr/bin/inventory --confi ...   Up             8080/tcp
-> menderproduction_mender-mongo_1                    docker-entrypoint.sh mongod      Up             27017/tcp
-> menderproduction_mender-useradm_1                  /usr/bin/useradm --config  ...   Up             8080/tcp
-> menderproduction_mender-workflows-server_1         /usr/bin/workflows --confi ...   Up             8080/tcp
-> menderproduction_mender-workflows-worker_1         /usr/bin/workflows --confi ...   Up
+> menderproduction_mender-api-gateway_1              /entrypoint.sh --accesslog ...   Up             0.0.0.0:443->443/tcp, 80/tcp
+> menderproduction_mender-auditlogs_1                /usr/bin/auditlogs --confi ...   Up             8080/tcp                    
+> menderproduction_mender-create-artifact-worker_1   /usr/bin/workflows --confi ...   Up             8080/tcp                    
+> menderproduction_mender-deployments_1              /entrypoint.sh --config /e ...   Up             8080/tcp                    
+> menderproduction_mender-device-auth_1              /usr/bin/deviceauth --conf ...   Up             8080/tcp                    
+> menderproduction_mender-deviceconfig_1             /usr/bin/deviceconfig --co ...   Up             8080/tcp                    
+> menderproduction_mender-deviceconnect_1            /usr/bin/deviceconnect --c ...   Up             8080/tcp                    
+> menderproduction_mender-gui_1                      /entrypoint.sh nginx             Up (healthy)   80/tcp, 8080/tcp            
+> menderproduction_mender-inventory_1                /usr/bin/inventory-enterpr ...   Up             8080/tcp                    
+> menderproduction_mender-mongo_1                    docker-entrypoint.sh mongod      Up             27017/tcp                   
+> menderproduction_mender-nats_1                     docker-entrypoint.sh nats- ...   Up             4222/tcp, 6222/tcp, 8222/tcp
+> menderproduction_mender-tenantadm_1                /usr/bin/tenantadm --confi ...   Up             8080/tcp                    
+> menderproduction_mender-useradm_1                  /usr/bin/useradm-enterpris ...   Up             8080/tcp                    
+> menderproduction_mender-workflows-server_1         /usr/bin/workflows-enterpr ...   Up             8080/tcp                    
+> menderproduction_mender-workflows-worker_1         /entrypoint.sh worker --au ...   Up                                         
 > menderproduction_minio_1                           /usr/bin/docker-entrypoint ...   Up (healthy)   9000/tcp
 > ```
 

--- a/07.Server-installation/07.Upgrading/docs.md
+++ b/07.Server-installation/07.Upgrading/docs.md
@@ -129,29 +129,21 @@ First, pull in new container images:
 ```bash
 ./run pull
 ```
-<!--AUTOVERSION: "mender-%: Pulling from mendersoftware/deviceauth"/integration "mender-%: Pulling from mendersoftware/gui"/integration "mender-%: Pulling from mendersoftware/api-gateway"/integration "mendersoftware/deviceauth:mender-%"/integration "mendersoftware/gui:mender-%"/integration "mendersoftware/api-gateway:mender-%"/integration-->
 > ```
-> Pulling mender-mongo (mongo:3.4)...
-> 3.4: Pulling from library/mongo
-> Digest: sha256:e5a4f6caf4fb6773e41292b56308ed427692add67ffd7c655fdf11a78a72df4e
-> Status: Image is up to date for mongo:3.4
-> Pulling minio (mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z)...
-> RELEASE.2016-12-13T17-19-42Z: Pulling from mendersoftware/minio
-> Digest: sha256:0ded6733900e6e09760cd9a7c79ba4981dea6f6b142352719f7a4157b4a3352d
-> Status: Image is up to date for mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z
-> ...
-> Pulling mender-device-auth (mendersoftware/deviceauth:mender-master)...
-> mender-master: Pulling from mendersoftware/deviceauth
-> Digest: sha256:07ed10f6fdee40df1de8e10efc3115cb64b0c190bcf5bcd194b9f34086396058
-> Status: Image is up to date for mendersoftware/deviceauth:mender-master
-> Pulling mender-gui (mendersoftware/gui:mender-master)...
-> mender-master: Pulling from mendersoftware/gui
-> Digest: sha256:af2d2349f27dd96ca21940672aa3a91335b17153f8c7ef2ca865a9a7fdf2fd22
-> Status: Image is up to date for mendersoftware/gui:mender-master
-> Pulling mender-api-gateway (mendersoftware/api-gateway:mender-master)...
-> mender-master: Pulling from mendersoftware/api-gateway
-> Digest: sha256:0a2033a57f88afc38253a45301c83484e532047d75858df95d46c12b48f1f2f8
-> Status: Image is up to date for mendersoftware/api-gateway:mender-master````
+> Pulling mender-mongo                  ... done
+> Pulling mender-deviceconfig           ... done
+> Pulling mender-useradm                ... done
+> Pulling mender-workflows-worker       ... done
+> Pulling mender-create-artifact-worker ... done
+> Pulling mender-workflows-server       ... done
+> Pulling mender-device-auth            ... done
+> Pulling mender-gui                    ... done
+> Pulling mender-inventory              ... done
+> Pulling mender-api-gateway            ... done
+> Pulling minio                         ... done
+> Pulling mender-deployments            ... done
+> Pulling mender-nats                   ... done
+> Pulling mender-deviceconnect          ... done
 > ```
 
 Then stop and remove existing containers:
@@ -198,15 +190,20 @@ Start the new environment:
 ./run up -d
 ```
 > ```
-> Creating menderproduction_mender-mongo_1
-> Creating menderproduction_minio_1
-> Creating menderproduction_mender-gui_1
-> Creating menderproduction_mender-useradm_1
-> Creating menderproduction_mender-deployments_1
-> Creating menderproduction_storage-proxy_1
-> Creating menderproduction_mender-device-auth_1
-> Creating menderproduction_mender-inventory_1
-> Creating menderproduction_mender-api-gateway_1
+> Creating menderproduction_mender-nats_1  ... done
+> Creating menderproduction_mender-gui_1   ... done
+> Creating menderproduction_minio_1        ... done
+> Creating menderproduction_mender-mongo_1 ... done
+> Creating menderproduction_mender-deviceconfig_1           ... done
+> Creating menderproduction_mender-workflows-worker_1       ... done
+> Creating menderproduction_mender-create-artifact-worker_1 ... done
+> Creating menderproduction_mender-deviceconnect_1          ... done
+> Creating menderproduction_mender-useradm_1                ... done
+> Creating menderproduction_mender-inventory_1              ... done
+> Creating menderproduction_mender-workflows-server_1       ... done
+> Creating menderproduction_mender-device-auth_1            ... done
+> Creating menderproduction_mender-api-gateway_1            ... done
+> Creating menderproduction_mender-deployments_1            ... done
 > ```
 
 

--- a/07.Server-installation/08.Backup-and-restore/docs.md
+++ b/07.Server-installation/08.Backup-and-restore/docs.md
@@ -46,14 +46,16 @@ the contents of each DB into `$PWD/db-dump/<service-name>` directory.
 ../migration/dump-db
 ```
 > ```
-Stopping menderproduction_mender-deployments_1            ... done
-Stopping menderproduction_mender-device-auth_1            ... done
-Stopping menderproduction_mender-useradm_1                ... done
-Stopping menderproduction_mender-create-artifact-worker_1 ... done
-Stopping menderproduction_mender-workflows-worker_1       ... done
-Stopping menderproduction_mender-workflows-server_1       ... done
-Stopping menderproduction_mender-inventory_1              ... done
-Starting mender-mongo ... done
+> Stopping menderproduction_mender-deployments_1            ... done
+> Stopping menderproduction_mender-device-auth_1            ... done
+> Stopping menderproduction_mender-workflows-worker_1       ... done
+> Stopping menderproduction_mender-deviceconnect_1          ... done
+> Stopping menderproduction_mender-useradm_1                ... done
+> Stopping menderproduction_mender-inventory_1              ... done
+> Stopping menderproduction_mender-create-artifact-worker_1 ... done
+> Stopping menderproduction_mender-deviceconfig_1           ... done
+> Stopping menderproduction_mender-workflows-server_1       ... done
+> Starting mender-mongo ... done
 > 2017-06-06T11:20:05.004+0000    writing admin.system.version to
 > 2017-06-06T11:20:05.024+0000    done dumping admin.system.version (1 document)
 > 2017-06-06T11:20:05.024+0000    writing useradm.migration_info to
@@ -70,10 +72,15 @@ DB dumps previously created with `dump-db`.
 ../migration/restore-db
 ```
 > ```
-> Stopping menderproduction_mender-deployments_1 ... done
-> Stopping menderproduction_mender-inventory_1 ... done
-> Stopping menderproduction_mender-useradm_1 ... done
-> Stopping menderproduction_mender-device-auth_1 ... done
+> Stopping menderproduction_mender-deployments_1            ... done
+> Stopping menderproduction_mender-device-auth_1            ... done
+> Stopping menderproduction_mender-workflows-worker_1       ... done
+> Stopping menderproduction_mender-deviceconnect_1          ... done
+> Stopping menderproduction_mender-useradm_1                ... done
+> Stopping menderproduction_mender-inventory_1              ... done
+> Stopping menderproduction_mender-create-artifact-worker_1 ... done
+> Stopping menderproduction_mender-deviceconfig_1           ... done
+> Stopping menderproduction_mender-workflows-server_1       ... done
 > Starting mender-mongo ... done
 > 2017-06-06T11:35:09.988+0000    preparing collections to restore from
 > 2017-06-06T11:35:10.088+0000    reading metadata for useradm.migration_info from /srv/db-dump/mender-mongo/useradm/migration_info.metadata.json
@@ -91,26 +98,21 @@ Once the data has been dumped or restored, the services can be started using
 ./run up -d
 ```
 > ```
-> menderproduction_mender-gui_1 is up-to-date
-> menderproduction_minio_1 is up-to-date
 > menderproduction_mender-mongo_1 is up-to-date
-> menderproduction_storage-proxy_1 is up-to-date
-> menderproduction_mender-useradm_1 is up-to-date
-> menderproduction_mender-create-artifact-worker_1 is up-to-date
-> menderproduction_mender-workflows-worker_1 is up-to-date
-> menderproduction_mender-workflows-server_1 is up-to-date
-> menderproduction_mender-inventory_1 is up-to-date
-> menderproduction_mender-deployments_1 is up-to-date
-> menderproduction_mender-device-auth_1 is up-to-date
+> menderproduction_mender-gui_1 is up-to-date
+> menderproduction_mender-nats_1 is up-to-date
+> menderproduction_minio_1 is up-to-date
+> Starting menderproduction_mender-inventory_1 ... 
+> Starting menderproduction_mender-workflows-server_1 ... 
+> Starting menderproduction_mender-inventory_1              ... done
+> Starting menderproduction_mender-workflows-server_1       ... done
+> Starting menderproduction_mender-deviceconfig_1           ... done
+> Starting menderproduction_mender-workflows-worker_1       ... done
+> Starting menderproduction_mender-useradm_1                ... done
+> Starting menderproduction_mender-create-artifact-worker_1 ... done
+> Starting menderproduction_mender-deviceconnect_1          ... done
+> Starting menderproduction_mender-deployments_1            ... done
+> Starting menderproduction_mender-device-auth_1            ... done
 > menderproduction_mender-api-gateway_1 is up-to-date
 > ```
-
-Occasionally services may get new IP addresses and the API gateway DNS cache may no
-longer be correct. To refresh the API gateway's cache, run the following command:
-
-```bash
-./run exec mender-api-gateway kill -HUP 1
-```
-
-
 

--- a/201.Troubleshoot/04.Mender-Server/docs.md
+++ b/201.Troubleshoot/04.Mender-Server/docs.md
@@ -101,28 +101,6 @@ In this case you can see that there are two authentication sets with the exact s
 The solution is to decommission the device and [remove all authentication sets](../../08.Server-integration/02.Preauthorizing-devices/docs.md#make-sure-there-are-no-existing-authentication-sets-for-your-device) and make sure the key used in the [preauthorize API call](../../08.Server-integration/02.Preauthorizing-devices/docs.md#call-the-preauthorize-api) matches exactly the one reported by the device, as seen in the `pending` data above.
 
 
-## mender-api-gateway exits with code 132
-
-When starting the Mender server, `mender-api-gateway` exits immediately with a message
-similar to this:
-
-```bash
-mender-api-gateway_1 exited with code 132
-```
-
-The logs from docker-compose also show that `mender-api-gateway` exits with code 132:
-
-<!--AUTOVERSION: "com.docker.compose.version=%"/ignore "image=mendersoftware/api-gateway:%"/mender-api-gateway-docker-->
-```bash
-2017-07-03T11:14:17.223223822+02:00 container die c2a1cf1c19651950e804c7fe53cb9c0ffeb8b71de744500ab4844b370cf0480d (com.docker.compose.config-hash=5b9dfb050a59b9cbd67082037478562ff44c78cf4346d9a83225d1a74d557271, com.docker.compose.container-number=1, com.docker.compose.oneoff=False, com.docker.compose.project=menderproduction, com.docker.compose.service=mender-api-gateway, com.docker.compose.version=1.14.0, exitCode=132, image=mendersoftware/api-gateway:master, name=menderproduction_mender-api-gateway_1)
-```
-
-The problem here is most likely that your server CPU does not support the SSE 4.2
-instruction set, while [openresty is compiled assuming SSE4.2 support](https://github.com/openresty/openresty/issues/267?target=_blank).
-Try again with a more modern CPU (from 2009 or later), or consider building
-openresty from source for your architecture.
-
-
 # Production installations
 
 For the rest of this document, it is assumed that commands are run through production
@@ -148,24 +126,24 @@ menderproduction_mender-inventory_1           /usr/bin/inventory -config ...   U
 menderproduction_mender-mongo_1               /entrypoint.sh mongod            Up      27017/tcp
 menderproduction_mender-useradm_1             /usr/bin/useradm -config / ...   Up      8080/tcp
 menderproduction_minio_1                      minio server /export             Up      9000/tcp
-menderproduction_storage-proxy_1              /usr/local/openresty/bin/o ...   Up      0.0.0.0:9000->9000/tcp
 ```
 
 Alternatively, the same information can be obtained by running `docker ps`
 directly with a label filter, like this:
 
+<!--AUTOVERSION: "nats:%"/ignore-->
 ```
 user@local$ docker ps --filter label=com.docker.compose.project=menderproduction
-CONTAINER ID        IMAGE                                               COMMAND                  CREATED             STATUS              PORTS                    NAMES
-c668a91617ea        mendersoftware/api-gateway:latest                   "/entrypoint.sh"         39 minutes ago      Up 39 minutes       0.0.0.0:443->443/tcp     menderproduction_mender-api-gateway_1
-9ebb2fc86d0c        mendersoftware/useradm:latest                       "/usr/bin/useradm ..."   40 minutes ago      Up 39 minutes       8080/tcp                 menderproduction_mender-useradm_1
-566a2a3c3773        mendersoftware/inventory:latest                     "/usr/bin/inventor..."   40 minutes ago      Up 39 minutes       8080/tcp                 menderproduction_mender-inventory_1
-d33f8b4af1bd        mendersoftware/deployments:latest                   "/entrypoint.sh"         40 minutes ago      Up 39 minutes       8080/tcp                 menderproduction_mender-deployments_1
-1ddbad5520e9        mendersoftware/deviceauth:latest                    "/usr/bin/deviceau..."   40 minutes ago      Up 39 minutes       8080/tcp                 menderproduction_mender-device-auth_1
-e7ad33929628        mendersoftware/openresty:1.11.2.2-alpine            "/usr/local/openre..."   40 minutes ago      Up 39 minutes       0.0.0.0:9000->9000/tcp   menderproduction_storage-proxy_1
-cdaab7768ec7        mongo:3.4                                           "/entrypoint.sh mo..."   40 minutes ago      Up 40 minutes       27017/tcp                menderproduction_mender-mongo_1
-867e76066fad        mendersoftware/gui:latest                           "/entrypoint.sh"         40 minutes ago      Up 40 minutes                                menderproduction_mender-gui_1
-54ae287d24ac        mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z   "minio server /export"   40 minutes ago      Up 40 minutes       9000/tcp                 menderproduction_minio_1
+CONTAINER ID        IMAGE                                               COMMAND                  CREATED             STATUS              PORTS                                                             NAMES
+c668a91617ea        traefik:v2.4                                        "/entrypoint.sh --..."   39 minutes ago      Up 39 minutes       0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:8080->8080/tcp  menderproduction_mender-api-gateway_1
+9ebb2fc86d0c        mendersoftware/useradm:latest                       "/usr/bin/useradm ..."   40 minutes ago      Up 39 minutes       8080/tcp                                                          menderproduction_mender-useradm_1
+566a2a3c3773        mendersoftware/inventory:latest                     "/usr/bin/inventor..."   40 minutes ago      Up 39 minutes       8080/tcp                                                          menderproduction_mender-inventory_1
+d33f8b4af1bd        mendersoftware/deployments:latest                   "/entrypoint.sh"         40 minutes ago      Up 39 minutes       8080/tcp                                                          menderproduction_mender-deployments_1
+1ddbad5520e9        mendersoftware/deviceauth:latest                    "/usr/bin/deviceau..."   40 minutes ago      Up 39 minutes       8080/tcp                                                          menderproduction_mender-device-auth_1
+cdaab7768ec7        mongo:4.4                                           "/entrypoint.sh mo..."   40 minutes ago      Up 40 minutes       27017/tcp                                                         menderproduction_mender-mongo_1
+867e76066fad        mendersoftware/gui:latest                           "/entrypoint.sh"         40 minutes ago      Up 40 minutes                                                                         menderproduction_mender-gui_1
+762b36d164de        nats:2.1.9-alpine3.12                               "docker-entrypoint.s…"   40 minutes ago      Up 40 minutes       4222/tcp, 6222/tcp, 8222/tcp                                      menderproduction_mender-nats_1
+54ae287d24ac        mendersoftware/minio:RELEASE.2019-04-23T23-50-36Z   "minio server /export"   40 minutes ago      Up 40 minutes       9000/tcp                                                          menderproduction_minio_1
 ```
 
 
@@ -180,15 +158,15 @@ restarting:
 user@local$ ./run ps
                    Name                                  Command                 State              Ports
 ------------------------------------------------------------------------------------------------------------------
-menderproduction_mender-api-gateway_1         /entrypoint.sh                   Up           0.0.0.0:443->443/tcp
+menderproduction_mender-api-gateway_1         /entrypoint.sh                   Up           0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:8080->8080/tcp
 menderproduction_mender-deployments_1         /entrypoint.sh                   Restarting
 menderproduction_mender-device-auth_1         /usr/bin/deviceauth -confi ...   Up           8080/tcp
 menderproduction_mender-gui_1                 /entrypoint.sh                   Up
 menderproduction_mender-inventory_1           /usr/bin/inventory -config ...   Up           8080/tcp
 menderproduction_mender-mongo_1               /entrypoint.sh mongod            Up           27017/tcp
 menderproduction_mender-useradm_1             /usr/bin/useradm -config / ...   Up           8080/tcp
+menderproduction_mender-nats_1                docker-entrypoint.sh             Up           4222/tcp, 6222/tcp, 8222/tcp
 menderproduction_minio_1                      minio server /export             Up           9000/tcp
-menderproduction_storage-proxy_1              /usr/local/openresty/bin/o ...   Up           0.0.0.0:9000->9000/tcp
 ```
 In the case presented above, `mender-deployments` is restarting.
 
@@ -199,18 +177,24 @@ while, `docker ps` will show the containers having a shorter lifetime than
 others. In the listing show below, `mender-deployments` service uptime is
 shorter than that of the other containers:
 
+<!--AUTOVERSION: "mender-%"/ignore "nats:%"/ignore-->
 ```
 user@local$ docker ps --filter label=com.docker.compose.project=menderproduction
-CONTAINER ID        IMAGE                                               COMMAND                  CREATED             STATUS              PORTS                    NAMES
-2f4c700923f9        mendersoftware/api-gateway:latest                   "/entrypoint.sh"         4 minutes ago       Up 4 minutes        0.0.0.0:443->443/tcp     menderproduction_mender-api-gateway_1
-8f46579aefa4        mendersoftware/deployments:latest                   "/entrypoint.sh"         5 minutes ago       Up 54 seconds       8080/tcp                 menderproduction_mender-deployments_1
-7236def09c97        mendersoftware/useradm:latest                       "/usr/bin/useradm ..."   5 minutes ago       Up 5 minutes        8080/tcp                 menderproduction_mender-useradm_1
-be9cc9ee74b2        mendersoftware/deviceauth:latest                    "/usr/bin/deviceau..."   5 minutes ago       Up 5 minutes        8080/tcp                 menderproduction_mender-device-auth_1
-5d84b70d1187        mendersoftware/inventory:latest                     "/usr/bin/inventor..."   5 minutes ago       Up 5 minutes        8080/tcp                 menderproduction_mender-inventory_1
-1dc4843ec4db        mendersoftware/openresty:1.11.2.2-alpine            "/usr/local/openre..."   5 minutes ago       Up 5 minutes        0.0.0.0:9000->9000/tcp   menderproduction_storage-proxy_1
-fb216139bc60        mongo:3.4                                           "/entrypoint.sh mo..."   5 minutes ago       Up 5 minutes        27017/tcp                menderproduction_mender-mongo_1
-9d6eacd2ae83        mendersoftware/gui:latest                           "/entrypoint.sh"         5 minutes ago       Up 5 minutes                                 menderproduction_mender-gui_1
-cc0b330a3cd5        mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z   "minio server /export"   5 minutes ago       Up 5 minutes        9000/tcp                 menderproduction_minio_1
+CONTAINER ID   IMAGE                                                 COMMAND                  CREATED         STATUS                   PORTS                          NAMES
+d8c27d9376d7   mendersoftware/deployments:mender-master              "/entrypoint.sh --co…"   8 minutes ago   Up 54 seconds            8080/tcp                       menderproduction_mender-deployments_1
+9aa7713293fa   traefik:v2.4                                          "/entrypoint.sh --ac…"   9 minutes ago   Up 9 minutes             80/tcp, 0.0.0.0:443->443/tcp   menderproduction_mender-api-gateway_1
+faf89eb9a2e4   mendersoftware/deviceauth:mender-master               "/usr/bin/deviceauth…"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-device-auth_1
+2d9f075401f3   mendersoftware/workflows-worker:mender-master         "/usr/bin/workflows …"   9 minutes ago   Up 9 minutes                                            menderproduction_mender-workflows-worker_1
+f0ec07715d45   mendersoftware/deviceconnect:mender-master            "/usr/bin/deviceconn…"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-deviceconnect_1
+752e02c418fa   mendersoftware/create-artifact-worker:mender-master   "/usr/bin/workflows …"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-create-artifact-worker_1
+445aaff677e0   mendersoftware/workflows:mender-master                "/usr/bin/workflows …"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-workflows-server_1
+b2b100437282   mendersoftware/deviceconfig:mender-master             "/usr/bin/deviceconf…"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-deviceconfig_1
+75c783b93ba0   mendersoftware/useradm:mender-master                  "/usr/bin/useradm --…"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-useradm_1
+7782277b816e   mendersoftware/inventory:mender-master                "/usr/bin/inventory …"   9 minutes ago   Up 9 minutes             8080/tcp                       menderproduction_mender-inventory_1
+65a5e1f5e3be   minio/minio:RELEASE.2019-04-23T23-50-36Z              "/usr/bin/docker-ent…"   9 minutes ago   Up 9 minutes (healthy)   9000/tcp                       menderproduction_minio_1
+b537c7de2e8d   mendersoftware/gui:mender-master                      "/entrypoint.sh nginx"   9 minutes ago   Up 9 minutes (healthy)   80/tcp, 8080/tcp               menderproduction_mender-gui_1
+8d7fa928991e   mongo:4.4                                             "docker-entrypoint.s…"   9 minutes ago   Up 9 minutes             27017/tcp                      menderproduction_mender-mongo_1
+73698002bf23   nats:2.1.9-alpine3.12                                 "docker-entrypoint.s…"   9 minutes ago   Up 9 minutes             4222/tcp, 6222/tcp, 8222/tcp   menderproduction_mender-nats_1
 ```
 
 ### Docker event log


### PR DESCRIPTION
This is the first part of the https://tracker.mender.io/browse/MEN-4400
The task was originally about updating the docs after migration from nginx to traefik, but it occurred that our server installation docs were outdated in general, so I decided to try to make them up to date.
Related integration changes:
https://github.com/mendersoftware/integration/pull/1316
https://github.com/mendersoftware/integration/pull/1309

The next PR will include upgrade steps and info about optional storage proxy (the one from here - https://github.com/mendersoftware/integration/tree/master/storage-proxy).