### PR TITLE
MEN-4256: Mender-convert no longer installs the client by default

### DIFF
--- a/04.System-updates-Debian-family/99.Variables/docs.md
+++ b/04.System-updates-Debian-family/99.Variables/docs.md
@@ -109,6 +109,12 @@ Set the default index for the boot partition.
 The size of the boot partition.
 
 
+#### `MENDER_CLIENT_INSTALL`
+
+> Value: y(default)/n
+
+Install the Mender client.
+
 #### `MENDER_CLIENT_VERSION`
 
 <!--AUTOVERSION: "/%/"/ignore-->

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -11,7 +11,7 @@ process:
 ## Disk images
 
 These disk images (`*.img` or `*.sdimg`) are based on images provided by board
-manufacturers and already have Mender fully integrated. They are used to
+manufacturers and are ready to install the Mender client. They are used to
 provision the device storage for devices without Mender running already.
 
 Mender provides images based on the following distributions:


### PR DESCRIPTION
Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

