### PR TITLE
Remove github metadata, not needed in mender-docs

### DIFF
--- a/201.Device-side-API/00.Overview/docs.md
+++ b/201.Device-side-API/00.Overview/docs.md
@@ -2,8 +2,6 @@
 title: Overview
 taxonomy:
     category: docs
-github:
-    enabled: false
 ---
 
 This section describes the Device-side API for the Mender clients. The Device-side API constitutes

--- a/201.Device-side-API/chapter.md
+++ b/201.Device-side-API/chapter.md
@@ -2,8 +2,6 @@
 title: Device-side API
 taxonomy:
     category: docs
-github:
-    enabled: false
 ---
 
 ### Chapter 12


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
