### PR TITLE
Update versions for release candidate Mender 3.0.0-build3

### DIFF
--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -32,14 +32,14 @@ Download the `mender-artifact` binary. If you're on Linux
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/3.6.0-build2/linux/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.6.0-build3/linux/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 On MacOS
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/3.6.0-build2/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.6.0-build3/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 

--- a/01.Get-started/04.Deploy-a-container-update/docs.md
+++ b/01.Get-started/04.Deploy-a-container-update/docs.md
@@ -78,14 +78,14 @@ Download the `mender-artifact` binary. If you're on Linux
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/3.6.0-build2/linux/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.6.0-build3/linux/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 On MacOS
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
-wget https://downloads.mender.io/mender-artifact/3.6.0-build2/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
+wget https://downloads.mender.io/mender-artifact/3.6.0-build3/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
 ```
 
 
@@ -117,7 +117,7 @@ Download the `docker-artifact-gen` utility script:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/3.0.0-build2/support/modules-artifact-gen/docker-artifact-gen
+wget https://raw.githubusercontent.com/mendersoftware/mender/3.0.0-build3/support/modules-artifact-gen/docker-artifact-gen
 ```
 
 Make `docker-artifact-gen` executable:

--- a/02.Overview/02.Device-Support/docs.md
+++ b/02.Overview/02.Device-Support/docs.md
@@ -98,7 +98,7 @@ community post for steps to create one.
 
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 You can compile the Mender client for a wide variety of architectures. Follow the steps in the
-[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build2?target=_blank#installing-from-source)
+[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build3?target=_blank#installing-from-source)
 of the Mender client source repository. This is also the first step to a board integration for other types of Linux OSes.
 
 
@@ -107,7 +107,7 @@ of the Mender client source repository. This is also the first step to a board i
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 For a POSIX compliant OS it may be possible to compile the Mender client to run natively,
 as outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build2?target=_blank#installing-from-source).
+[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build3?target=_blank#installing-from-source).
 
 For other types of OSes you can either use a nearby Linux system to update it via a
 [proxy deployment](../../02.Overview/01.Introduction/docs.md#proxy-deployments) or

--- a/02.Overview/03.Artifact/docs.md
+++ b/02.Overview/03.Artifact/docs.md
@@ -44,7 +44,7 @@ Mender Artifact file.
 
 <!--AUTOVERSION: "mender-artifact/blob/%"/mender-artifact-->
 You can find more details about the Mender Artifact format in the
-[Mender Artifact specification](https://github.com/mendersoftware/mender-artifact/blob/3.6.0-build2/Documentation?target=_blank).
+[Mender Artifact specification](https://github.com/mendersoftware/mender-artifact/blob/3.6.0-build3/Documentation?target=_blank).
 
 
 ### *Provides* and *Depends*

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -34,7 +34,7 @@ this is the most common for users getting starting with Mender.
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-wget https://downloads.mender.io/3.0.0-build2/dist-packages/debian/armhf/mender-client_3.0.0-build2-1_armhf.deb
+wget https://downloads.mender.io/3.0.0-build3/dist-packages/debian/armhf/mender-client_3.0.0-build3-1_armhf.deb
 ```
 
 !!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../09.Downloads/docs.md) for other architectures, and also make sure to modify the references to the package in commands below.
@@ -49,7 +49,7 @@ To install and configure Mender run the following command:
 
 <!--AUTOVERSION: "mender-client_%-1_armhf.deb"/mender -->
 ```bash
-sudo dpkg -i mender-client_3.0.0-build2-1_armhf.deb
+sudo dpkg -i mender-client_3.0.0-build3-1_armhf.deb
 ```
 
 After completing the installation wizard, Mender is correctly set up on your
@@ -73,7 +73,7 @@ configuration options.
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build2-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build3-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
@@ -90,7 +90,7 @@ sudo systemctl restart mender-client
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build2-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build3-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --demo \
@@ -105,7 +105,7 @@ sudo systemctl restart mender-client
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_URL="<INSERT YOUR ENTERPRISE SERVER URL>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM YOUR ENTERPRISE SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build2-1_armhf.deb
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_3.0.0-build3-1_armhf.deb
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --server-url $SERVER_URL \
@@ -122,7 +122,7 @@ sudo systemctl restart mender-client
 <!--AUTOVERSION: "mender/tree/%#installing-from-source"/mender -->
 As an alternative to using a Debian package, it is possible to install the
 Mender client from source by following the guidelines outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build2#installing-from-source?target=_blank)
+[README.md](https://github.com/mendersoftware/mender/tree/3.0.0-build3#installing-from-source?target=_blank)
 of the Mender client source repository.
 
 

--- a/03.Client-installation/03.Identity/docs.md
+++ b/03.Client-installation/03.Identity/docs.md
@@ -96,6 +96,6 @@ cpuid=1234123-ABC
 ## Example device identity executables
 
 <!--AUTOVERSION: "mender/tree/%"/mender-->
-Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/3.0.0-build2/support?target=_blank).
+Example scripts are provided in the [support directory in the Mender client source code repository](https://github.com/mendersoftware/mender/tree/3.0.0-build3/support?target=_blank).
 
 

--- a/03.Client-installation/04.Inventory/docs.md
+++ b/03.Client-installation/04.Inventory/docs.md
@@ -121,7 +121,7 @@ a-country=Poland
 a-city=Krakow
 ```
 <!--AUTOVERSION: "mender/tree/%/support"/mender-->
-You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/3.0.0-build2/support) directory.
+You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/3.0.0-build3/support) directory.
 
 
 ## Default inventory
@@ -133,7 +133,7 @@ By default, and without any inventory scripts added, the Mender client sends the
 |:----:|:-------:|:-------------:|
 | `device_type`  | type of the device | "raspberrypi4" |
 | `artifact_name` | name of the currently installed artifact | "release-v1" |
-| `mender_client_version` | client version | "3.0.0-build2" |
+| `mender_client_version` | client version | "3.0.0-build3" |
 
 
 ## Final remarks

--- a/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -113,9 +113,9 @@ MENDER_ARTIFACT_NAME = "release-1"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender-client = "3.0.0-build2"
-# PREFERRED_VERSION_pn-mender-artifact = "3.6.0-build2"
-# PREFERRED_VERSION_pn-mender-artifact-native = "3.6.0-build2"
+# PREFERRED_VERSION_pn-mender-client = "3.0.0-build3"
+# PREFERRED_VERSION_pn-mender-artifact = "3.6.0-build3"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.6.0-build3"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
@@ -230,9 +230,9 @@ MACHINE = "<YOUR-MACHINE>"
 # If you need an earlier version, please uncomment the following and set to the
 # required version.
 #
-# PREFERRED_VERSION_pn-mender = "3.0.0-build2"
-# PREFERRED_VERSION_pn-mender-artifact = "3.6.0-build2"
-# PREFERRED_VERSION_pn-mender-artifact-native = "3.6.0-build2"
+# PREFERRED_VERSION_pn-mender = "3.0.0-build3"
+# PREFERRED_VERSION_pn-mender-artifact = "3.6.0-build3"
+# PREFERRED_VERSION_pn-mender-artifact-native = "3.6.0-build3"
 
 # The following settings to enable systemd are needed for all Yocto
 # releases sumo and older.  Newer releases have these settings conditionally

--- a/06.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -70,10 +70,10 @@ Note specifically that in this case we are creating a *module-image*, using the 
 #### Update Modules generation script
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/3.0.0-build2/support/modules/single-file?target=_blank)
+You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/3.0.0-build3/support/modules/single-file?target=_blank)
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
-Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/3.0.0-build2/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
+Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/3.0.0-build3/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
 
 #### Server side Artifact generation
 
@@ -83,4 +83,4 @@ will carry the file you have uploaded, the destination
 directory, the filename, and permissions, exactly as we saw above.
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/Documentation"/mender-->
-For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/3.0.0-build2/Documentation/update-modules-v3-file-api.md?target=_blank).
+For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/3.0.0-build3/Documentation/update-modules-v3-file-api.md?target=_blank).

--- a/06.Artifact-creation/07.Sign-and-verify/docs.md
+++ b/06.Artifact-creation/07.Sign-and-verify/docs.md
@@ -85,7 +85,7 @@ creating the signature.
 ```bash
 mender-artifact write rootfs-image \
 -t beaglebone \
--n mender-3.0.0-build2 \
+-n mender-3.0.0-build3 \
 -f core-image-base-beaglebone.ext4 \
 -k private.key \
 -o artifact-signed.mender

--- a/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -255,4 +255,4 @@ Because of the possible re-execution described above, you should develop Update 
 ## Further reading
 
 <!--AUTOVERSION: "blob/%/Documentation"/mender -->
-* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/3.0.0-build2/Documentation/update-modules-v3-file-api.md?target=_blank)
+* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/3.0.0-build3/Documentation/update-modules-v3-file-api.md?target=_blank)

--- a/07.Server-installation/02.Demo-installation/docs.md
+++ b/07.Server-installation/02.Demo-installation/docs.md
@@ -50,13 +50,13 @@ Clone the [integration](https://github.com/mendersoftware/integration?target=_bl
 repository which contains everything that is need to start the demo server:
 <!--AUTOVERSION: "-b %"/integration "integration-%"/integration -->
 ```bash
-git clone -b 3.0.0-build2 https://github.com/mendersoftware/integration.git integration-3.0.0-build2
+git clone -b 3.0.0-build3 https://github.com/mendersoftware/integration.git integration-3.0.0-build3
 ```
 
 Change directory to the cloned repository:
 <!--AUTOVERSION: "integration-%"/integration -->
 ```bash
- cd integration-3.0.0-build2
+ cd integration-3.0.0-build3
 ```
 
 Start the demo server:
@@ -118,7 +118,7 @@ To remove containers use commands from the section below.
 
 <!--AUTOVERSION: "integration-%"/integration -->
 If you want to remove all state in your Mender demo environment and start clean,
-run the following commands in the `integration-3.0.0-build2` directory:
+run the following commands in the `integration-3.0.0-build3` directory:
 
 ```bash
 ./demo stop

--- a/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Server-installation/03.Production-installation/01.Upgrading-from-OS-to-Enterprise/docs.md
@@ -21,7 +21,7 @@ taxonomy:
 
 <!-- Basically a repeat of Open Source setup from Production Installation tutorial -->
 <!-- AUTOVERSION: "git clone -b %"/integration -->
-<!-- AUTOMATION: execute=git clone -b 3.0.0-build2 https://github.com/mendersoftware/integration mender-server -->
+<!-- AUTOMATION: execute=git clone -b 3.0.0-build3 https://github.com/mendersoftware/integration mender-server -->
 <!-- AUTOMATION: execute=cd mender-server -->
 <!-- AUTOMATION: execute=git checkout -b my-production-setup -->
 <!-- AUTOMATION: execute=cd production -->

--- a/07.Server-installation/03.Production-installation/docs.md
+++ b/07.Server-installation/03.Production-installation/docs.md
@@ -100,7 +100,7 @@ named `mender-server`:
 
 <!--AUTOVERSION: "-b %"/integration -->
 ```bash
-git clone -b 3.0.0-build2 https://github.com/mendersoftware/integration mender-server
+git clone -b 3.0.0-build3 https://github.com/mendersoftware/integration mender-server
 ```
 
 > ```
@@ -553,7 +553,7 @@ At this point your commit history should look as follows:
 <!--AUTOVERSION: "git log --oneline %..HEAD"/integration -->
 <!--AUTOMATION: ignore -->
 ```bash
-git log --oneline 3.0.0-build2..HEAD
+git log --oneline 3.0.0-build3..HEAD
 ```
 > ```
 > 7a4de3c production: configuration
@@ -804,7 +804,7 @@ At this point your commit history should look as follows:
 <!--AUTOVERSION: "git log --oneline %..HEAD"/integration -->
 <!--AUTOMATION: ignore -->
 ```bash
-git log --oneline 3.0.0-build2..HEAD
+git log --oneline 3.0.0-build3..HEAD
 ```
 > ```
 > 76b3d00 production: Enterprise configuration

--- a/07.Server-installation/07.Upgrading/docs.md
+++ b/07.Server-installation/07.Upgrading/docs.md
@@ -70,8 +70,8 @@ git fetch origin --tags
 > Receiving objects: 100% (367/367), 83.55 KiB | 0 bytes/s, done.
 > Resolving deltas: 100% (214/214), completed with 42 local objects.
 > From https://github.com/mendersoftware/integration
->    02cd118..75b7831  3.0.0-build2      -> origin/3.0.0-build2
->    06f3212..e9e5df4  3.0.0-build2     -> origin/3.0.0-build2
+>    02cd118..75b7831  3.0.0-build3      -> origin/3.0.0-build3
+>    06f3212..e9e5df4  3.0.0-build3     -> origin/3.0.0-build3
 > ```
 
 <!--AUTOVERSION: "branch named `%` provides"/ignore "e.g. `%`"/ignore-->
@@ -89,7 +89,7 @@ introduced in upstream branch. For example:
 # to list differences between current HEAD and remote branch
 git log HEAD..origin/2.0.x
 # to list differences between current HEAD and stable tag
-git log HEAD..3.0.0-build2
+git log HEAD..3.0.0-build3
 ```
 
 The most important thing to review is the diff between our production template
@@ -100,14 +100,14 @@ minor/major release, one can expect the diff to be larger. Example:
 <!--AUTOVERSION: "HEAD..%"/integration-->
 ```bash
 # while at the root of repository
-user@local$ git diff HEAD..3.0.0-build2 -- template
+user@local$ git diff HEAD..3.0.0-build3 -- template
 ```
 
 Upgrading our local production branch is performed by issuing a `git merge` command, like this:
 
 <!--AUTOVERSION: "git merge %"/integration-->
 ```bash
-git merge 3.0.0-build2
+git merge 3.0.0-build3
 ```
 > ```
 > Merge made by the 'recursive' strategy.

--- a/08.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/08.Server-integration/02.Preauthorizing-devices/docs.md
@@ -28,7 +28,7 @@ If you have not yet prepared a device visit one of the following:
 When preauthorizing a device you need to know its [identity](../../02.Overview/07.Identity/docs.md). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender server, you will see its identity in the Mender server UI. Note that preauthorization is *not* based on the ID of the device, only on the key-value attributes under Identity.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/3.0.0-build2/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
+By default the Mender client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/3.0.0-build3/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
 
 
 ### Mender client and server connectivity
@@ -61,11 +61,11 @@ We will generate the keys on a separate system (not on the device), and then pro
 We will use a script to generate a keypair the Mender client understands; it uses the `openssl` command to generate the keys.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-Download the [keygen-client](https://github.com/mendersoftware/mender/blob/3.0.0-build2/support/keygen-client?target=_blank) script into a directory:
+Download the [keygen-client](https://github.com/mendersoftware/mender/blob/3.0.0-build3/support/keygen-client?target=_blank) script into a directory:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/3.0.0-build2/support/keygen-client
+wget https://raw.githubusercontent.com/mendersoftware/mender/3.0.0-build3/support/keygen-client
 ```
 
 Ensure it is executable:

--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -240,7 +240,7 @@ docker run \
   -v $(pwd)/server-cert.pem:/etc/mtls/certs/server/server.crt \
   -v $(pwd)/server-private.key:/etc/mtls/certs/server/server.key \
   -v $(pwd)/ca-cert.pem:/etc/mtls/certs/tenant-ca/tenant.ca.pem \
-  registry.mender.io/mendersoftware/mtls-ambassador:mender-3.0.0-build2
+  registry.mender.io/mendersoftware/mtls-ambassador:mender-3.0.0-build3
 ```
 <!-- AUTOMATION: execute=} & -->
 

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -55,8 +55,8 @@ Follow the correct link according to your host platform to download
 <!--AUTOVERSION: "mender-artifact %"/mender-artifact -->
 | Platform | Download link                                                |
 |----------|--------------------------------------------------------------|
-| Linux    | [mender-artifact 3.6.0-build2][x.x.x_mender-artifact-linux]     |
-| Mac OS X | [mender-artifact 3.6.0-build2][x.x.x_mender-artifact-darwin] |
+| Linux    | [mender-artifact 3.6.0-build3][x.x.x_mender-artifact-linux]     |
+| Mac OS X | [mender-artifact 3.6.0-build3][x.x.x_mender-artifact-darwin] |
 
 Remember to add execute permission and ensure that the mender-artifact utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
 
@@ -69,9 +69,9 @@ Please refer to your host Operating System documentation for more details.
 
 
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/3.6.0-build2/linux/mender-artifact
+[x.x.x_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/3.6.0-build3/linux/mender-artifact
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/3.6.0-build2/darwin/mender-artifact
+[x.x.x_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/3.6.0-build3/darwin/mender-artifact
 
 ! If you are using Mac OS X, note that using `mender-artifact` with
 ! disk image files (e.g.: `*.sdimg`, `*.img`, or others holding the storage
@@ -245,16 +245,16 @@ mode](../02.Overview/01.Introduction/docs.md#client-modes-of-operation).
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 | Architecture   | Devices                                   | Download link                                                       |
 |----------------|-------------------------------------------|---------------------------------------------------------------------|
-| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_3.0.0-build2-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
-| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_3.0.0-build2-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
-| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_3.0.0-build2-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
+| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_3.0.0-build3-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] |
+| arm64 | ARM 64bit processors, for example Debian for Asus Tinker Board | [mender-client_3.0.0-build3-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] |
+| amd64 | Generic 64-bit x86 processors, the most popular among workstations | [mender-client_3.0.0-build3-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] |
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_armhf.deb"/mender -->
-[mender-client_x.x.x-1_armhf.deb]: https://downloads.mender.io/3.0.0-build2/dist-packages/debian/armhf/mender-client_3.0.0-build2-1_armhf.deb
+[mender-client_x.x.x-1_armhf.deb]: https://downloads.mender.io/3.0.0-build3/dist-packages/debian/armhf/mender-client_3.0.0-build3-1_armhf.deb
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_arm64.deb"/mender -->
-[mender-client_x.x.x-1_arm64.deb]: https://downloads.mender.io/3.0.0-build2/dist-packages/debian/arm64/mender-client_3.0.0-build2-1_arm64.deb
+[mender-client_x.x.x-1_arm64.deb]: https://downloads.mender.io/3.0.0-build3/dist-packages/debian/arm64/mender-client_3.0.0-build3-1_arm64.deb
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_amd64.deb"/mender -->
-[mender-client_x.x.x-1_amd64.deb]: https://downloads.mender.io/3.0.0-build2/dist-packages/debian/amd64/mender-client_3.0.0-build2-1_amd64.deb
+[mender-client_x.x.x-1_amd64.deb]: https://downloads.mender.io/3.0.0-build3/dist-packages/debian/amd64/mender-client_3.0.0-build3-1_amd64.deb
 
 
 ## Mender add-ons

--- a/301.Troubleshoot/01.Yocto-project-build/docs.md
+++ b/301.Troubleshoot/01.Yocto-project-build/docs.md
@@ -311,7 +311,7 @@ A typical error message for this condition is:
 Error:
  Problem: package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon requires u-boot, but none of the providers can be installed
   - package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon conflicts with u-boot <= 1:2019.07 provided by u-boot-fork-1:2019.07-r0.beaglebone_yocto
-  - package mender-3.0.0-build2-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
+  - package mender-3.0.0-build3-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
   - conflicting requests
 ```
 


### PR DESCRIPTION
Updated with:
```
./autoversion.py --update
    --integration-dir ...
    --integration-version 3.0.0-build3
    --mender-convert-version 2.5.x
    --mender-convert-client-version 3.0.0-build3
    --meta-mender-version poky
    --poky-version poky
    --mender-binary-delta-version 1.2.1

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
