### PR TITLE
Split snippet to avoid apt eating the input.

### DIFF
--- a/03.Client-installation/06.Use-the-device-side-api/docs.md
+++ b/03.Client-installation/06.Use-the-device-side-api/docs.md
@@ -63,9 +63,16 @@ On Debian based systems, such as Raspberry Pi OS, you can install the example ap
 the commands below. For more detailed installation instructions, see [the
 repository](https://github.com/mendersoftware/mender-client-python-example).
 
+First install the dependencies:
+
 ```bash
 sudo apt-get update
 sudo apt-get install -y git python3 python3-pip
+```
+
+Then install the application:
+
+```bash
 git clone https://github.com/mendersoftware/mender-client-python-example.git
 sudo pip3 install mender-client-python-example/
 ```


### PR DESCRIPTION
The second step, `apt-get install`, eats all the input, preventing the
two last steps from running. Split them so the user gets one Copy
button for each.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
