### PR TITLE
Remove mender-convert-client auto-versioning.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,6 @@ test:latest_versions:
     - ./autoversion.py
       --update
       --mender-convert-version $MENDER_CONVERT_VERSION
-      --mender-convert-client-version $MENDER_CLIENT_VERSION
       --mender-binary-delta-version $MENDER_BINARY_DELTA_VERSION
       --integration-dir $INTEGRATION_REPO_DIR
       --integration-version $INTEGRATION_VERSION

--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -33,9 +33,9 @@ Download the Raspberry Pi OS image with Mender integrated:
   * Download link: [Raspberry Pi 3 Model B and B+][raspios-buster-lite-raspberrypi3-mender.img.xz]
   * Download link: [Raspberry Pi 4 Model B][raspios-buster-lite-raspberrypi4-mender.img.xz]
 
-<!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi3-mender-latest.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi4-mender-latest.img.xz
+<!--AUTOVERSION: "mender-convert-%.img.xz"/mender-convert -->
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi3-mender-convert-master.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi4-mender-convert-master.img.xz
 
 
 Follow the steps outlined in the [Raspberry Pi OS documentation](https://www.raspberrypi.org/documentation/installation/installing-images?target=_blank)

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -32,9 +32,9 @@ Mender provides images based on the following distributions:
 | Raspberry Pi 3 Model B and B+ | Raspberry Pi OS Buster Lite 2021-01-11 | [raspios-buster-lite-raspberrypi3-mender.img.xz][raspios-buster-lite-raspberrypi3-mender.img.xz] | 8 GB         |
 | Raspberry Pi 4 Model B        | Raspberry Pi OS Buster Lite 2021-01-11 | [raspios-buster-lite-raspberrypi4-mender.img.xz][raspios-buster-lite-raspberrypi4-mender.img.xz] | 8 GB         |
 
-<!--AUTOVERSION: "mender-%.img.xz"/mender-convert-client -->
-[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi3-mender-latest.img.xz
-[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi4-mender-latest.img.xz
+<!--AUTOVERSION: "mender-convert-%.img.xz"/mender-convert -->
+[raspios-buster-lite-raspberrypi3-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi3-mender-convert-master.img.xz
+[raspios-buster-lite-raspberrypi4-mender.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2021-01-11-raspios-buster-armhf-lite/arm/2021-01-11-raspios-buster-armhf-lite-raspberrypi4-mender-convert-master.img.xz
 
 You can find images for other devices in our Mender Hub community forum, see
 [Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11?target=_blank) or

--- a/README-hosted-maintenance.markdown
+++ b/README-hosted-maintenance.markdown
@@ -54,12 +54,11 @@ conflicts are resolved here by choosing "our" version.
 To update version references of any incoming text from `master`,
 run `autoversion.py` tool using latest versions. For example:
 
-<!--AUTOVERSION: "--mender-convert-version %"/ignore "--mender-convert-client-version %"/ignore "--meta-mender-version %"/ignore "--poky-version %"/ignore "--mender-binary-delta-version %"/ignore-->
+<!--AUTOVERSION: "--mender-convert-version %"/ignore "--meta-mender-version %"/ignore "--poky-version %"/ignore "--mender-binary-delta-version %"/ignore-->
 ```
 ./autoversion.py --update --integration-dir <local-dir> \
       --integration-version staging \
       --mender-convert-version 2.1.0 \
-      --mender-convert-client-version 2.3.0 \
       --meta-mender-version dunfell \
       --poky-version dunfell \
       --mender-binary-delta-version 1.1.0

--- a/autoversion.py
+++ b/autoversion.py
@@ -363,10 +363,6 @@ def main():
         "--mender-convert-version", help="Mender-convert version to update to"
     )
     parser.add_argument(
-        "--mender-convert-client-version",
-        help="Mender client version used in mender-convert to update to",
-    )
-    parser.add_argument(
         "--meta-mender-version",
         help="meta-mender version to update to (usually a branch)",
     )
@@ -405,14 +401,6 @@ def main():
                 'Not replacing "mender-convert" instances, since it was not specified'
             )
             VERSION_CACHE["mender-convert"] = False
-
-        if args.mender_convert_client_version is not None:
-            VERSION_CACHE["mender-convert-client"] = args.mender_convert_client_version
-        else:
-            print(
-                'Not replacing "mender-convert-client" instances, since it was not specified'
-            )
-            VERSION_CACHE["mender-convert-client"] = False
 
         if args.meta_mender_version is not None:
             if args.poky_version is None:


### PR DESCRIPTION
Mender-convert images do not contain the client anymore, so this
information is obsolete.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
