### PR TITLE
Update the mender-binary-delta download links to the new URL scheme

### DIFF
--- a/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
@@ -26,7 +26,7 @@ command:
 <!--AUTOVERSION: "mender-binary-delta/%/mender-binary-delta-%.tar"/mender-binary-delta-->
 ```bash
 HOSTED_MENDER_EMAIL="myusername@example.com"
-curl -u $HOSTED_MENDER_EMAIL -O https://download.mender.io/hosted/content/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
+curl -u $HOSTED_MENDER_EMAIL -O https://download.mender.io/content/hosted/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
 ```
 
 Replace the value of `HOSTED_MENDER_EMAIL` with the email address you used to sign up on *Hosted Mender*, then enter your Hosted Mender password when prompted to proceed.
@@ -38,7 +38,7 @@ command:
 <!--AUTOVERSION: "mender-binary-delta/%/mender-binary-delta-%.tar"/mender-binary-delta-->
 ```bash
 MENDER_ENTERPRISE_EMAIL="myusername@example.com"
-curl -u $MENDER_ENTERPRISE_EMAIL -O https://download.mender.io/content/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
+curl -u $MENDER_ENTERPRISE_EMAIL -O https://download.mender.io/content/on-prem/mender-binary-delta/1.1.0/mender-binary-delta-1.1.0.tar.xz
 ```
 
 


### PR DESCRIPTION
Now the content is separated on /content/hosted and /content/on-prem in the URL's.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
