### PR TITLE
MEN-4983: Add note that `apt upgrade` is not safe when snapshotting.

### DIFF
--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -153,6 +153,15 @@ sudo apt update && sudo apt install vim --assume-yes
 You can now run `vim` to verify it is installed, as you would expect. Note that
 this modification *is not part of your system snapshot* created above.
 
+<!-- See MEN-4983 -->
+!! Do not call `apt upgrade` on a device with Mender system updates enabled. Doing so may brick your
+!! device! Always update single applications only. The reason is that kernel and boot loader Debian
+!! packages do not expect the Mender partition and filesystem layout, and therefore will try to
+!! perform actions that conflict with Mender. If you need to run `apt upgrade`, do it on a pristine
+!! system without Mender installed, and then [convert it to a Mender
+!! image](../../04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md)
+!! afterwards. This restriction may be lifted in the future.
+
 
 ## Step 5 - Deploy the snapshot and experiment
 

--- a/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
+++ b/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
@@ -12,8 +12,17 @@ system. When this device has been tested and the environment should be
 replicated, a snapshot can be taken with Mender. This results in a file system
 image and Mender Artifact that can be deployed to the rest of the device fleet.
 
-! This feature is fully supported by the
-! following filesystems: ext[234], XFS, JFS, btrfs, f2fs, and ReiserFS.
+!!! This feature is fully supported by the
+!!! following filesystems: ext[234], XFS, JFS, btrfs, f2fs, and ReiserFS.
+
+<!-- See MEN-4983 -->
+!! Do not call `apt upgrade` on a device with Mender system updates enabled. Doing so may brick your
+!! device! Always update single applications only. The reason is that kernel and boot loader Debian
+!! packages do not expect the Mender partition and filesystem layout, and therefore will try to
+!! perform actions that conflict with Mender. If you need to run `apt upgrade`, do it on a pristine
+!! system without Mender installed, and then [convert it to a Mender
+!! image](../../04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md)
+!! afterwards. This restriction may be lifted in the future.
 
 
 ## Option 1: Creating a snapshot using mender-artifact directly


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
