### PR TITLE
Fix typo in artifacts documentation

### DIFF
--- a/06.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
+++ b/06.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
@@ -12,7 +12,7 @@ is relatively small. To address this issue you can use
 pass only the difference between the two images.
 
 To generate binary delta Artifacts, you must start with two full file system Artifacts. You can use [Yocto](https://hub.mender.io/t/robust-delta-update-rootfs/1144?target=_blank),
-[mender-convert](../../04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md), or any mechanism of your choice to create the images. You can generate an binary default Artifact with the following command.
+[mender-convert](../../04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md), or any mechanism of your choice to create the images. You can generate a binary default Artifact with the following command.
 
 ```bash
 ./mender-binary-delta-generator \


### PR DESCRIPTION
Signed-off-by: Kris van Rens <krisvanrens@gmail.com>

Fix simple typo.

Otherwise; great documentation and likewise project!
