### PR TITLE
update yocto docs url

### DIFF
--- a/05.System-updates-Yocto-Project/04.Image-customization/docs.md
+++ b/05.System-updates-Yocto-Project/04.Image-customization/docs.md
@@ -9,4 +9,4 @@ Mender and the Yocto Project provide many ways to customize the image for differ
 this section we go through all of Mender's customization features, as well as some of the most
 relevant ones from Yocto. For more information about Mender, see the sub sections. For more
 information about the Yocto Project's customization features, see the [Yocto Project
-Mega-Manual](https://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html?target=_blank).
+Mega-Manual](https://docs.yoctoproject.org/singleindex.html?target=_blank).


### PR DESCRIPTION
The Yocto Project documentation switched from docbook/xml to sphinx, therefore some of the
output locations/filenames have changed as well. The YP website is forwarding the old links
to the new location, so this link works, but update it to avoid forwarding.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
