### PR TITLE
update link to Yocto Project rofs

### DIFF
--- a/05.System-updates-Yocto-Project/04.Image-customization/02.Read-only-root-filesystem/docs.md
+++ b/05.System-updates-Yocto-Project/04.Image-customization/02.Read-only-root-filesystem/docs.md
@@ -12,9 +12,7 @@ To build an image containing read-only rootfs add the following changes to the `
 IMAGE_FEATURES += "read-only-rootfs"
 ```
 
-You can read more about this feature in the [Yocto Project Mega-Manual - 7.27.
-Creating a Read-Only Root
-Filesystem](https://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#creating-a-read-only-root-filesystem?target=_blank)
+You can read more about this feature in the [Yocto Project Mega-Manual - Creating a Read-Only Root Filesystem](https://docs.yoctoproject.org/dunfell/singleindex.html#creating-a-read-only-root-filesystem)
 
 !!! This feature is highly package dependent and even though Mender works
 !!! correctly with this feature enabled, there might be other packages in your


### PR DESCRIPTION
The Yocto Project has updated its documentation from docbook/xml to sphinx, therefore many
of the links from the Mender documentation to the Yocto Project documentation need updating.
Additionally, link to the Dunfell (i.e. the latest 3.1.x) documentation since Mender is based on
the Yocto Project's Dunfell release and not master.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
