### PR TITLE
MEN-5391: autoversion: Add logic to query either git or docker version

### DIFF
--- a/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
+++ b/04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
@@ -94,7 +94,7 @@ documentation for your host OS if you encounter connection issues with docker.
 
 Clone `mender-convert` from the official repository:
 
-<!--AUTOVERSION: "-b % https://github.com/mendersoftware/mender-convert"/mender-convert-->
+<!--AUTOVERSION: "-b % https://github.com/"/mender-convert-->
 ```bash
 git clone -b master https://github.com/mendersoftware/mender-convert.git
 ```

--- a/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -174,7 +174,7 @@ here are the basic steps needed to do this however your actual setup may require
 Please make sure you are standing in the directory where `poky` resides,
 i.e. the top level of the Yocto Project build tree, and run these commands:
 
-<!--AUTOVERSION: "-b % git://github.com/mendersoftware/meta-mender"/meta-mender-->
+<!--AUTOVERSION: "-b % git://github.com/"/meta-mender-->
 ```bash
 git clone -b master git://github.com/mendersoftware/meta-mender
 ```

--- a/06.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -69,10 +69,10 @@ Note specifically that in this case we are creating a *module-image*, using the 
 
 #### Update Modules generation script
 
-<!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
+<!--AUTOVERSION: "/mender/blob/%/support"/mender-->
 You can see the above example in the [single file Update Module](https://hub.mender.io/t/single-file/486?target=_blank). You can also see how simple it is to [write a custom Update Module.](https://github.com/mendersoftware/mender/blob/master/support/modules/single-file?target=_blank)
 
-<!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
+<!--AUTOVERSION: "/mender/blob/%/support"/mender-->
 Also note that most of the Update Modules come with a [script to simplify the Artifact creation](https://github.com/mendersoftware/mender/blob/master/support/modules-artifact-gen/single-file-artifact-gen?target=_blank), but generally these are wrappers around `mender-artifact` utility to hide the complexity and make it easy to generate artifacts.
 
 #### Server side Artifact generation
@@ -82,5 +82,5 @@ Update Module. You can test it by uploading any file to the [releases page](http
 will carry the file you have uploaded, the destination
 directory, the filename, and permissions, exactly as we saw above.
 
-<!--AUTOVERSION: "mendersoftware/mender/blob/%/Documentation"/mender-->
+<!--AUTOVERSION: "/mender/blob/%/Documentation"/mender-->
 For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/master/Documentation/update-modules-v3-file-api.md?target=_blank).

--- a/README-autoversion.markdown
+++ b/README-autoversion.markdown
@@ -57,6 +57,31 @@ updated, `autoversion.py --update` will turn it into this:
 Joe User uses mender-artifact version 2.3.0, and likes it!
 ```
 
+#### Versions for Mender Docker images
+
+By default, the version substituted by the tool is the "git" version or, in other words, the
+Git repository branch or tag.
+
+However when the string `mendersoftware/` is found in the AUTOVERSION expression, then instead the "docker" version
+is used or, in other words, the tag of the corresponding Docker image.
+
+For example:
+
+<!--AUTOVERSION: "mendersoftware/deployments:%"/ignore-->
+```
+<!--AUTOVERSION: "mendersoftware/deployments:%"/deployments-->
+Here I want to get a Docker version to do:
+docker pull mendersoftware/deployments:mender-3.1.0
+```
+
+Or:
+
+<!--AUTOVERSION: "-b % https://github.com/"/ignore-->
+```
+<!--AUTOVERSION: "-b % https://github.com/"/deployments-->
+But now I want the Git version to do:
+git clone -b 4.0.0 https://github.com/mendersoftware/deployments.git
+```
 
 ### Version numbers of other software
 

--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ Mender documentation, please read our guide on how to best get started
 
 ## License
 
-<!--AUTOVERSION: "mendersoftware/mender/blob/%/LICENSE"/ignore-->
+<!--AUTOVERSION: "/mender/blob/%/LICENSE"/ignore-->
 Mender is licensed under the Apache License, Version 2.0. See
 [LICENSE](https://github.com/mendersoftware/mender/blob/master/LICENSE?target=_blank) for the
 full license text.

--- a/autoversion.py
+++ b/autoversion.py
@@ -41,7 +41,7 @@ VERSION_CACHE = {}
 ERRORS_FOUND = False
 
 
-def get_version_of(repo):
+def get_version_of(repo, version_type):
     global VERSION_CACHE
 
     version = VERSION_CACHE.get(repo)
@@ -57,7 +57,7 @@ def get_version_of(repo):
                     "--version-of",
                     repo,
                     "--version-type",
-                    "docker",
+                    version_type,
                     "--in-integration-version",
                     INTEGRATION_VERSION,
                 ]
@@ -317,7 +317,15 @@ def do_replacements(line, replacements, just_remove):
         else:
             if repo == "ignore":
                 continue
-            version = get_version_of(repo)
+
+            if "mendersoftware/" in search:
+                version_type = "docker"
+                # Docker versions are rare and possibly included by mistake, better verbose than sorry
+                print(f"Using Docker version on expression {search}")
+            else:
+                version_type = "git"
+
+            version = get_version_of(repo, version_type)
             if version is None:
                 continue
             if complain:


### PR DESCRIPTION
With our latest release_tool we cannot anymore use the "trick" of
querying docker versions to pure git components (like mender-artifact,
mender, etc) and expect it to fallback to git version and work.

By default the tool will now use the git versions, unless an special
string is used for in the AUTOVERSION expression to trigger the switch
to docker version. See updated README.