### PR TITLE
wrong version of mtls-ambassador in staging

### DIFF
--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -240,7 +240,7 @@ docker run \
   -v $(pwd)/server-cert.pem:/etc/mtls/certs/server/server.crt \
   -v $(pwd)/server-private.key:/etc/mtls/certs/server/server.key \
   -v $(pwd)/ca-cert.pem:/etc/mtls/certs/tenant-ca/tenant.ca.pem \
-  registry.mender.io/mendersoftware/mtls-ambassador:mender-3.2.0
+  registry.mender.io/mendersoftware/mtls-ambassador:mender-staging
 ```
 <!-- AUTOMATION: execute=} & -->
 


### PR DESCRIPTION
fails the test, hence it's not deploying.