### PR TITLE
docs: fix link to application-update anchor

### DIFF
--- a/06.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -40,7 +40,7 @@ The remaining flags specify the parameters used to [match devices to deployments
 
 ### Create an application update Artifact
 
-Creating an Artifact takes a different form in the case of [application updates](../../02.Overview/01.Introduction/docs.md#Application-updates).
+Creating an Artifact takes a different form in the case of [application updates](../../02.Overview/01.Introduction/docs.md#application-updates).
 
 For example, assume that you want copy a new `authorized_keys` file to the `/home/pi/.ssh`
 directory on your devices. We first store the path to the destination directory and file into two separate files, for packaging purposes:


### PR DESCRIPTION
The link to the 01.Introduction/docs.md#application-update does not work and users end up on the top of this page.