### PR TITLE
3.2.x: Downloads: mender-client: Update URLs for direct downloads

### DIFF
--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -258,21 +258,21 @@ airtight systems with limited access to the Internet, or when running
 Mender in [standalone
 mode](../02.Overview/01.Introduction/docs.md#client-modes-of-operation).
 
-<!--AUTOVERSION: "mender-client_%-1"/mender -->
+<!--AUTOVERSION: "mender-client_%_a"/mender "mender-client_%-1"/mender -->
 | Architecture   | Devices                                                                                        | Download link                                                       | Download link                                                                      |
 |----------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|------------------------------------------------------------------------------------|
-| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_3.2.1-1_armhf.deb][mender-client_x.x.x-1_armhf.deb] | [mender-client_3.2.1-1_armhf.deb][mender-client_3.2.1-1_armhf.deb] (Pre-release) |
-| arm64          | ARM 64bit processors, for example Debian for Asus Tinker Board                                 | [mender-client_3.2.1-1_arm64.deb][mender-client_x.x.x-1_arm64.deb] | [mender-client_3.2.1-1_arm64.deb][mender-client_3.2.1-1_arm64.deb] (Pre-release) |
-| amd64          | Generic 64-bit x86 processors, the most popular among workstations                             | [mender-client_3.2.1-1_amd64.deb][mender-client_x.x.x-1_amd64.deb] | [mender-client_3.2.1-1_amd64.deb][mender-client_3.2.1-1_amd64.deb] (Pre-release) |
+| armhf (ARM-v6) | ARM 32bit distributions, for example Raspberry Pi OS for Raspberry Pi or Debian for BeagleBone | [mender-client_3.2.1-1+debian+buster_armhf.deb][mender-client_x.x.x_armhf.deb] | [mender-client_master-1+debian+buster_armhf.deb][mender-client_master_armhf.deb] (Pre-release) |
+| arm64          | ARM 64bit processors, for example Debian for Asus Tinker Board                                 | [mender-client_3.2.1-1+debian+buster_arm64.deb][mender-client_x.x.x_arm64.deb] | [mender-client_master-1+debian+buster_arm64.deb][mender-client_master_arm64.deb] (Pre-release) |
+| amd64          | Generic 64-bit x86 processors, the most popular among workstations                             | [mender-client_3.2.1-1+debian+buster_amd64.deb][mender-client_x.x.x_amd64.deb] | [mender-client_master-1+debian+buster_amd64.deb][mender-client_master_amd64.deb] (Pre-release) |
 
-<!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1_"/mender -->
-[mender-client_x.x.x-1_armhf.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/armhf/mender-client_3.2.1-1_armhf.deb
-[mender-client_x.x.x-1_arm64.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/arm64/mender-client_3.2.1-1_arm64.deb
-[mender-client_x.x.x-1_amd64.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/amd64/mender-client_3.2.1-1_amd64.deb
-<!--AUTOVERSION: "downloads.mender.io/%/"/ignore "mender-client_%-1_"/ignore -->
-[mender-client_master-1_armhf.deb]: https://downloads.mender.io/master/dist-packages/debian/armhf/mender-client_master-1_armhf.deb
-[mender-client_master-1_arm64.deb]: https://downloads.mender.io/master/dist-packages/debian/arm64/mender-client_master-1_arm64.deb
-[mender-client_master-1_amd64.deb]: https://downloads.mender.io/master/dist-packages/debian/amd64/mender-client_master-1_amd64.deb
+<!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
+[mender-client_x.x.x_armhf.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/armhf/mender-client_3.2.1-1%2Bdebian%2Bbuster_armhf.deb
+[mender-client_x.x.x_arm64.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/arm64/mender-client_3.2.1-1%2Bdebian%2Bbuster_arm64.deb
+[mender-client_x.x.x_amd64.deb]: https://downloads.mender.io/3.2.1/dist-packages/debian/amd64/mender-client_3.2.1-1%2Bdebian%2Bbuster_amd64.deb
+<!--AUTOVERSION: "mender-client_%_a"/mender "downloads.mender.io/%/"/ignore "mender-client_%-1"/ignore -->
+[mender-client_master_armhf.deb]: https://downloads.mender.io/master/dist-packages/debian/armhf/mender-client_master-1%2Bdebian%2Bbuster_armhf.deb
+[mender-client_master_arm64.deb]: https://downloads.mender.io/master/dist-packages/debian/arm64/mender-client_master-1%2Bdebian%2Bbuster_arm64.deb
+[mender-client_master_amd64.deb]: https://downloads.mender.io/master/dist-packages/debian/amd64/mender-client_master-1%2Bdebian%2Bbuster_amd64.deb
 
 
 ## Mender add-ons


### PR DESCRIPTION
Following packages names updates from MEN-5410.

(cherry picked from commit 8f0345f7d1992b24bf09e2bc393a011dd92c099c)

Setting client version to 3.2.1 while resolving merge conflict.
