### PR TITLE
Small fix python example for mender configure

### DIFF
--- a/09.Add-ons/10.Configure/01.Device-integration/docs.md
+++ b/09.Add-ons/10.Configure/01.Device-integration/docs.md
@@ -149,11 +149,11 @@ import sys
 2. Input parameter verification
 
 ```
-if len(sys.argv) != 1:
+if len(sys.argv) != 2:
     print("Must be invoked with exactly one argument: The JSON configuration.", file=sys.stderr)
     sys.exit(1)
 
-config=sys.argv[0]
+config=sys.argv[1]
 
 if not os.path.exists(config):
     print(f"Error: {config} does not exist.", file=sys.stderr)
@@ -166,7 +166,7 @@ if not os.path.exists(config):
 try:
     configJSON = json.load(config)
     timezone = configJSON["timezone"]
-    subprocess.run("timedatectl", "set-timezone", timezone, check=True)
+    subprocess.run(["timedatectl", "set-timezone", timezone], check=True)
 except json.JSONDecodeError as e:
     print(f"Failed to parse the configuration JSON, error: {e}")
     sys.exit(1)


### PR DESCRIPTION
As you can see from logs created inside the same file on the device this is the value of sys.argv. 

14:41:02,820 root INFO ['/usr/lib/mender-configure/apply-device-config.d/example_script.py', '/var/lib/mender-configure/device-config.json'

Also run into troubles with the arguments of subprocess.run so I prefered to let all the command inside a list.


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
