### PR TITLE
Switch from curl to wget for commercial packages download

### DIFF
--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -385,14 +385,16 @@ download it by running:
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
-curl --fail -u "$HOSTED_MENDER_EMAIL" -O https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
+ HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -O https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
+ MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -417,14 +419,16 @@ through the package:
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
-curl --fail -u "$HOSTED_MENDER_EMAIL" -O https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
+ HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -O https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
+ MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
wget renames the files correctly. This way also the download commands
are consist with the OS packages.