### PR TITLE
docs: move example commands to the new command syntax

### DIFF
--- a/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -82,7 +82,7 @@ MENDER_FEATURES_DISABLE_append = " mender-systemd"
 
 Also, you do not need any daemon-related configuration items in your `local.conf` as outlined in [the section on configuring the Yocto Project build](../../05.System-updates-Yocto-Project/03.Build-for-demo/docs.md#configuring-the-build).
 
-! If you disable Mender running as a daemon under `systemd`, you must run all required Mender commands from the CLI or scripts. Most notably, you need to run `mender -commit` after booting into and verifying a successful deployment. When running in managed mode, any pending `mender -commit` will automatically run by the Mender daemon after it starts. See [Modes of operation](../../02.Overview/01.Introduction/docs.md#client-modes-of-operation) for more information about the difference.
+! If you disable Mender running as a daemon under `systemd`, you must run all required Mender commands from the CLI or scripts. Most notably, you need to run `mender commit` after booting into and verifying a successful deployment. When running in managed mode, any pending `mender commit` will automatically run by the Mender daemon after it starts. See [Modes of operation](../../02.Overview/01.Introduction/docs.md#client-modes-of-operation) for more information about the difference.
 
 
 ## Identity

--- a/06.Artifact-creation/06.Standalone-deployment/docs.md
+++ b/06.Artifact-creation/06.Standalone-deployment/docs.md
@@ -30,7 +30,7 @@ pi@raspberrypi:~$ sudo systemctl status mender-client
     Tasks: 9 (limit: 1012)
    Memory: 7.5M
    CGroup: /system.slice/mender-client.service
-           └─320 /usr/bin/mender -daemon
+           └─320 /usr/bin/mender daemon
 ```
 
 The status reported as active indicates that in order to use standalone mode you have to stop and disable Mender running as a daemon.
@@ -47,7 +47,7 @@ To deploy the new Artifact to your device, run the following command in the
 device terminal:
 
 ```bash
-mender -install <URI>
+mender install <URI>
 ```
 
 `<URI>` can be any type of file-based storage or an HTTP/HTTPS URL.
@@ -61,9 +61,9 @@ To use HTTPS, simply replace it with a URL like `https://fileserver.example.com/
 If you are happy with the deployment, you can make it permanent by running the following command in your device terminal:
 
 ```bash
-mender -commit
+mender commit
 ```
 
 By running this command, Mender will mark the update as successful and permanent.
 
-To deploy another update, simply run `mender -install <URI>` again, then reboot and commit.
+To deploy another update, simply run `mender install <URI>` again, then reboot and commit.

--- a/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/06.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -158,7 +158,7 @@ scp web-file-1.mender <username>@<deviceip>:/tmp
 Then install the Mender Artifact on the target device:
 
 ```bash
-mender -install /tmp/web-file-1.mender
+mender install /tmp/web-file-1.mender
 ```
 
 ### Verify the deployment on the device

--- a/301.Troubleshoot/03.Mender-Client/docs.md
+++ b/301.Troubleshoot/03.Mender-Client/docs.md
@@ -206,7 +206,7 @@ until you have upgraded all Mender Clients and can use the corresponding latest 
 You have the Mender binary on your device and try to trigger a rootfs update but you get output similar to the following:
 
 ```bash
-mender -install /media/rootfs-image-mydevice.mender
+mender install /media/rootfs-image-mydevice.mender
 
 ERRO[0000] exit status 1                                 module=partitions
 ERRO[0000] No match between boot and root partitions.    module=main


### PR DESCRIPTION
the `-command` syntax is no longer prefered.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


