### PR TITLE
QA-378: Add AUTOMATION tests for Downloads and mender-client deb install

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,11 +19,20 @@ test:
     variables:
       - $SKIP_TESTS == "true"
   stage: test
-  image: tiangolo/docker-with-compose
+  image: ubuntu:focal
   services:
     - docker:19.03.5-dind
+  tags:
+    - mender-qa-slave
+  variables:
+    # DinD setup in mender-qa-slave
+    DOCKER_HOST: "tcp://docker:2376"
+    DOCKER_CERT_PATH: "/certs/client"
+    DOCKER_TLS_VERIFY: "1"
+    DOCKER_TLS_CERTDIR: "/certs"
   before_script:
-    - apk add --no-cache bash git openssl pwgen python3 jq
+    - apt-get update && apt-get install -y
+      docker.io bash git openssl pwgen python3 jq docker-compose wget sudo
     - git config --global user.name "user"
     - git config --global user.email "user@example.com"
   script:

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -26,18 +26,19 @@ architectures:
 - amd64: Generic 64-bit x86 processors, the most popular among workstations
 
 See [the downloads page](../../09.Downloads/docs.md) for links to download all
-package architectures. We will assume *armhf* in the following instructions as
-this is the most common for users getting starting with Mender.
+package architectures.
 
 
 ### Download the package
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
 ```bash
-wget https://downloads.mender.io/3.1.1/dist-packages/debian/armhf/mender-client_master-1%2Bdebian%2Bbuster_armhf.deb
+wget https://downloads.mender.io/3.1.1/dist-packages/debian/$(dpkg --print-architecture)/mender-client_master-1%2Bdebian%2Bbuster_$(dpkg --print-architecture).deb
 ```
 
-!!! The above link is for *armhf* devices, which is the most common device architecture. See [the downloads page](../../09.Downloads/docs.md) for other architectures, and also make sure to modify the references to the package in commands below.
+!!! The above link will use the native architecture. See [the downloads
+page](../../09.Downloads/docs.md) for other architectures, and also make sure to modify the
+references to the package in commands below.
 
 
 ### Option 1: Attended installation with a wizard
@@ -49,7 +50,7 @@ To install and configure Mender run the following command:
 
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 ```bash
-sudo dpkg -i mender-client_master-1+debian+buster_armhf.deb
+sudo dpkg -i mender-client_master-1+debian+buster_$(dpkg --print-architecture).deb
 ```
 
 After completing the installation wizard, Mender is correctly set up on your
@@ -63,17 +64,29 @@ device is now ready to authenticate with the server and start receiving updates.
 Alternatively, install the package non-interactively. This is suitable for
 scripts or other situations where no user input is desired.
 
+First, to install Mender without configuring it run the following command:
+
+<!--AUTOVERSION: "mender-client_%-1"/mender -->
+```bash
+sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1+debian+buster_$(dpkg --print-architecture).deb
+```
+
 The setup is different depending on your server configuration and the most
 common cases are shown below. Use `mender setup --help` to learn about all
 configuration options.
 
 - Connecting to [hosted Mender](https://hosted.mender.io?target=_blank) using demo settings
 
-<!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
+Set the following variables:
+
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1+debian+buster_armhf.deb
+```
+
+Configure Mender with:
+
+```bash
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
@@ -81,31 +94,40 @@ sudo mender setup \
             --retry-poll 30 \
             --update-poll 5 \
             --inventory-poll 5
-sudo systemctl restart mender-client
 ```
 
 - Connecting to a demo server using demo settings
 
-<!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
+Set the following variables:
+
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1+debian+buster_armhf.deb
+```
+
+Configure Mender with:
+
+```bash
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --demo \
             --server-ip $SERVER_IP_ADDR
-sudo systemctl restart mender-client
 ```
 
 - Connecting to an [Enterprise](https://mender.io/products/mender-enterprise?target=_blank) server
+
+Set the following variables:
 
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_URL="<INSERT YOUR ENTERPRISE SERVER URL>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM YOUR ENTERPRISE SERVER>"
-sudo DEBIAN_FRONTEND=noninteractive dpkg -i mender-client_master-1+debian+buster_armhf.deb
+```
+
+Configure Mender with:
+
+```bash
 sudo mender setup \
             --device-type $DEVICE_TYPE \
             --server-url $SERVER_URL \
@@ -114,6 +136,11 @@ sudo mender setup \
             --retry-poll 30 \
             --update-poll 5 \
             --inventory-poll 5
+```
+
+Finally, to restart the Mender service for the new configuration to take effect run the following command:
+
+```bash
 sudo systemctl restart mender-client
 ```
 

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -83,8 +83,8 @@ configuration options.
 <!--AUTOMATION: execute=SERVER_IP_ADDR=1.2.3.4 -->
 <!--AUTOMATION: execute=SERVER_URL=https://secure.server -->
 
-- Connecting to [hosted Mender](https://hosted.mender.io?target=_blank) using demo settings
-
+[ui-tabs position="top-left" active="0" theme="lite" ]
+[ui-tab title="Hosted Mender"]
 Set the following variables:
 
 <!--AUTOMATION: ignore -->
@@ -102,9 +102,8 @@ sudo mender setup \
             --tenant-token $TENANT_TOKEN \
             --demo-polling
 ```
-
-- Connecting to a demo server using demo settings
-
+[/ui-tab]
+[ui-tab title="Demo server"]
 Set the following variables:
 
 <!--AUTOMATION: ignore -->
@@ -122,9 +121,8 @@ sudo mender setup \
             --server-ip $SERVER_IP_ADDR \
             --demo-polling
 ```
-
-- Connecting to an [Enterprise](https://mender.io/products/mender-enterprise?target=_blank) server
-
+[/ui-tab]
+[ui-tab title="[Enterprise](https://mender.io/products/mender-enterprise?target=_blank) server"]
 Set the following variables:
 
 <!--AUTOMATION: ignore -->
@@ -145,6 +143,8 @@ sudo mender setup \
             --tenant-token $TENANT_TOKEN \
             --demo-polling
 ```
+[/ui-tab]
+[/ui-tabs]
 
 Finally, to restart the Mender service for the new configuration to take effect run the following command:
 

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -91,9 +91,7 @@ sudo mender setup \
             --device-type $DEVICE_TYPE \
             --hosted-mender \
             --tenant-token $TENANT_TOKEN \
-            --retry-poll 30 \
-            --update-poll 5 \
-            --inventory-poll 5
+            --demo-polling
 ```
 
 - Connecting to a demo server using demo settings
@@ -110,8 +108,9 @@ Configure Mender with:
 ```bash
 sudo mender setup \
             --device-type $DEVICE_TYPE \
-            --demo \
-            --server-ip $SERVER_IP_ADDR
+            --demo-server \
+            --server-ip $SERVER_IP_ADDR \
+            --demo-polling
 ```
 
 - Connecting to an [Enterprise](https://mender.io/products/mender-enterprise?target=_blank) server
@@ -133,9 +132,7 @@ sudo mender setup \
             --server-url $SERVER_URL \
             --server-cert="" \
             --tenant-token $TENANT_TOKEN \
-            --retry-poll 30 \
-            --update-poll 5 \
-            --inventory-poll 5
+            --demo-polling
 ```
 
 Finally, to restart the Mender service for the new configuration to take effect run the following command:

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -31,9 +31,11 @@ package architectures.
 
 ### Download the package
 
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y libglib2.0-0 tzdata -->
+
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
 ```bash
-wget https://downloads.mender.io/3.1.1/dist-packages/debian/$(dpkg --print-architecture)/mender-client_master-1%2Bdebian%2Bbuster_$(dpkg --print-architecture).deb
+wget https://downloads.mender.io/master/dist-packages/debian/$(dpkg --print-architecture)/mender-client_master-1%2Bdebian%2Bbuster_$(dpkg --print-architecture).deb
 ```
 
 !!! The above link will use the native architecture. See [the downloads
@@ -48,6 +50,7 @@ customize your installation. This is the recommended option for new users.
 
 To install and configure Mender run the following command:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "mender-client_%-1"/mender -->
 ```bash
 sudo dpkg -i mender-client_master-1+debian+buster_$(dpkg --print-architecture).deb
@@ -75,10 +78,16 @@ The setup is different depending on your server configuration and the most
 common cases are shown below. Use `mender setup --help` to learn about all
 configuration options.
 
+<!--AUTOMATION: execute=DEVICE_TYPE=device-type -->
+<!--AUTOMATION: execute=TENANT_TOKEN=secure-token -->
+<!--AUTOMATION: execute=SERVER_IP_ADDR=1.2.3.4 -->
+<!--AUTOMATION: execute=SERVER_URL=https://secure.server -->
+
 - Connecting to [hosted Mender](https://hosted.mender.io?target=_blank) using demo settings
 
 Set the following variables:
 
+<!--AUTOMATION: ignore -->
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 TENANT_TOKEN="<INSERT YOUR TOKEN FROM https://hosted.mender.io/ui/#/settings/my-organization>"
@@ -98,6 +107,7 @@ sudo mender setup \
 
 Set the following variables:
 
+<!--AUTOMATION: ignore -->
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
 SERVER_IP_ADDR="<INSERT THE IP ADDRESS OF YOUR DEMO SERVER>"
@@ -117,6 +127,7 @@ sudo mender setup \
 
 Set the following variables:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "downloads.mender.io/%/"/mender "mender-client_%-1"/mender -->
 ```bash
 DEVICE_TYPE="<INSERT YOUR DEVICE TYPE>"
@@ -137,6 +148,7 @@ sudo mender setup \
 
 Finally, to restart the Mender service for the new configuration to take effect run the following command:
 
+<!--AUTOMATION: ignore -->
 ```bash
 sudo systemctl restart mender-client
 ```

--- a/07.Server-installation/03.Installation-with-docker-compose/02.Upgrading-from-OS-to-Enterprise/docs.md
+++ b/07.Server-installation/03.Installation-with-docker-compose/02.Upgrading-from-OS-to-Enterprise/docs.md
@@ -13,7 +13,7 @@ taxonomy:
 <!--AUTOMATION: execute=export SLEEP_INTERVAL=4 -->
 <!--AUTOMATION: execute=export MAX_INTERATIONS=11 -->
 
-<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" != 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -ne 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
 
 <!-- Cleanup code -->
 <!-- AUTOMATION: execute=ORIG_DIR=$PWD; function cleanup() { set +e; cd $ORIG_DIR/mender-server/production; ./run down -v; docker volume rm mender-artifacts mender-db mender-artifacts-backup mender-db-backup; cd $ORIG_DIR; rm -rf mender-server; } -->

--- a/07.Server-installation/03.Installation-with-docker-compose/docs.md
+++ b/07.Server-installation/03.Installation-with-docker-compose/docs.md
@@ -11,8 +11,8 @@ taxonomy:
 <!--AUTOMATION: execute=export SLEEP_INTERVAL=4 -->
 <!--AUTOMATION: execute=export MAX_INTERATIONS=11 -->
 
-<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" != 1 ] && [ "$TEST_ENTERPRISE" != 1 ]; then echo "Either TEST_OPEN_SOURCE xor TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
-<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" = 1 ] && [ "$TEST_ENTERPRISE" = 1 ]; then echo "TEST_OPEN_SOURCE and TEST_ENTERPRISE cannot both be 1!"; exit 1; fi -->
+<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" -ne 1 ] && [ "$TEST_ENTERPRISE" -ne 1 ]; then echo "Either TEST_OPEN_SOURCE xor TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" -eq 1 ] && [ "$TEST_ENTERPRISE" -eq 1 ]; then echo "TEST_OPEN_SOURCE and TEST_ENTERPRISE cannot both be 1!"; exit 1; fi -->
 
 <!-- Cleanup code -->
 <!-- AUTOMATION: execute=ORIG_DIR=$PWD; function cleanup() { set +e; cd $ORIG_DIR/mender-server/production; ./run down -v; docker volume rm mender-artifacts mender-db; cd $ORIG_DIR; rm -rf mender-server; } -->
@@ -567,7 +567,7 @@ git log --oneline master..HEAD
 ## Open Source
 
 <!-- Test block for TEST_OPEN_SOURCE=1 -->
-<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" = 1 ]; then -->
+<!-- AUTOMATION: execute=if [ "$TEST_OPEN_SOURCE" -eq 1 ]; then -->
 
 This section deals specifically with setting up an Open Source server. If you
 are setting up an Enterprise server, please proceed to the [Enterprise
@@ -635,7 +635,7 @@ installing an Open Source server, please proceed to
 ## Enterprise
 
 <!-- Test block for TEST_ENTERPRISE=1 -->
-<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" = 1 ]; then -->
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -eq 1 ]; then -->
 
 This section will go through setting up the Enterprise features of the Mender
 server. If you are using the Open Source edition of the Mender server, you can

--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" != 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -ne 1 ];; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
 
 <!-- Cleanup code: stops the mTLS ambassador if running -->
 <!-- AUTOMATION: execute=function cleanup() { -->

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -8,6 +8,8 @@ process:
     twig: true
 ---
 
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" != 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+
 ## Disk images
 
 These disk images (`*.img` or `*.sdimg`) are based on images provided by board
@@ -62,6 +64,7 @@ Follow the correct link according to your host platform to download
 
 Remember to add execute permission and ensure that the mender-artifact utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
 
+<!--AUTOMATION: ignore -->
 ```bash
 sudo chmod +x mender-artifact
 sudo cp mender-artifact /usr/local/bin/
@@ -119,6 +122,7 @@ the Mender client this way, should be aware that:
 !! Always examine scripts downloaded over the Internet before running them
 !! locally.
 
+<!--AUTOMATION: ignore -->
 ```bash
 curl -fLsS https://get.mender.io -o get-mender.sh
 # INSPECT get-mender.sh BEFORE PROCEEDING
@@ -130,6 +134,8 @@ extension](#remote-terminal-add-on) plugin in addition to the client. If you do
 not want this feature you can provide additional arguments to the script
 specifying which packages you want to install. For example, the following will
 only install the Mender client:
+
+<!--AUTOMATION: ignore -->
 ```bash
 curl -fLsS https://get.mender.io -o get-mender.sh
 # INSPECT get-mender.sh BEFORE PROCEEDING
@@ -146,6 +152,8 @@ sudo bash get-mender.sh mender-client
 After installing the Mender client with [get.mender.io](https://get.mender.io),
 the `mender-client` package is maintained by the package manager. To upgrade the
 Mender client, simply run
+
+<!--AUTOMATION: ignore -->
 ```bash
 sudo apt-get update
 sudo apt-get upgrade
@@ -169,9 +177,11 @@ repository. Afterwards, you can install and update the Mender client using the
 !!! With this method the latest released Mender components will be installed
 
 1. Update the `apt` package index and install required dependencies.
+
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata -->
    ```bash
    sudo apt-get update
-   sudo apt-get install \
+   sudo apt-get install --assume-yes \
    		apt-transport-https \
    		ca-certificates \
    		curl \
@@ -180,12 +190,15 @@ repository. Afterwards, you can install and update the Mender client using the
    ```
 
 2. Add the official Mender GPG key to your trusted `apt` keychain:
+
    ```bash
    curl -fLsS https://downloads.mender.io/repos/debian/gpg | sudo apt-key add -
    ```
 
    Inspect the GPG key fingerprint and verify that it matches
    `E6C8 5734 5575 F921 8396  5662 2407 2B80 A1B2 9B00`.
+
+<!--AUTOMATION: ignore -->
    ```bash
    sudo apt-key fingerprint A1B29B00
    ```
@@ -202,6 +215,7 @@ repository. Afterwards, you can install and update the Mender client using the
    First in order to make sure that there are no mender sources in
    '/etc/apt/sources.list' lingering from a previous install, run
 
+<!--AUTOMATION: ignore -->
    ```bash
       sed -i.bak -e "\,https://downloads.mender.io/repos/debian,d" /etc/apt/sources.list
    ```
@@ -213,18 +227,21 @@ repository. Afterwards, you can install and update the Mender client using the
 
    [ui-tabs position="top-left" active="0" theme="lite" ]
    [ui-tab title="Debian Bullseye"]
+<!--AUTOMATION: ignore -->
    ```bash
     echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian debian/bullseye/stable main" \
     | sudo tee /etc/apt/sources.list.d/mender.list > /dev/null
    ```
    [/ui-tab]
    [ui-tab title="Debian Buster"]
+<!--AUTOMATION: ignore -->
    ```bash
     echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian debian/buster/stable main" \
     | sudo tee /etc/apt/sources.list.d/mender.list > /dev/null
    ```
    [/ui-tab]
    [ui-tab title="Ubuntu Bionic"]
+<!--AUTOMATION: ignore -->
    ```bash
     echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/focal/stable main" \
     | sudo tee /etc/apt/sources.list.d/mender.list > /dev/null
@@ -244,10 +261,15 @@ repository. Afterwards, you can install and update the Mender client using the
    !!! as these releases are not fully tested.
 
 4. Update the package index and install the Mender client:
+
+<!--AUTOMATION: ignore -->
    ```bash
    sudo apt-get update
    sudo apt-get install mender-client
    ```
+
+<!-- AUTOMATION: execute=apt-get update -->
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-client -->
 
 !!! To prevent the Mender client from upgrading when upgrading the rest of the
 !!! system, mark it to be held with `sudo apt-mark hold mender-client`.
@@ -351,6 +373,7 @@ Follow the correct link according to your host platform to download `mender-cli`
 
 Remember to add execute permission and ensure that the mender-cli utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
 
+<!--AUTOMATION: ignore -->
 ```bash
 sudo chmod +x mender-cli
 sudo cp mender-cli /usr/local/bin/
@@ -380,9 +403,13 @@ Mender Monitor](../09.Add-ons/20.Monitor/10.Installation/docs.md).
 To install `mender-monitor` using the Mender Monitor Debian package, first
 download it by running:
 
+<!--AUTOMATION: execute=HOSTED_MENDER_EMAIL="$HOSTED_MENDER_IO_USERNAME" -->
+<!--AUTOMATION: execute=HOSTED_MENDER_PASSWORD="$HOSTED_MENDER_IO_PASSWORD" -->
+
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
  HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -395,11 +422,13 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="enterprise"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
@@ -412,8 +441,7 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-monitor_%-1"/monitor-client -->
 ```bash
-sudo dpkg -i mender-monitor_master-1+debian+buster_all.deb
-sudo apt --fix-broken -y install
+sudo dpkg -i mender-monitor_master-1+debian+buster_all.deb || sudo apt --fix-broken -y install
 ```
 
 ### Demo monitors
@@ -425,6 +453,7 @@ through the package:
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
  HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -437,12 +466,14 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="enterprise"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
@@ -479,6 +510,7 @@ download it by running:
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -491,6 +523,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -503,6 +536,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -521,6 +555,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -533,6 +568,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -545,6 +581,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -563,6 +600,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -575,6 +613,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -587,6 +626,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -605,6 +645,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -617,6 +658,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -629,6 +671,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -653,12 +696,14 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_armhf.deb
@@ -666,12 +711,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_arm64.deb
@@ -679,12 +726,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_amd64.deb
@@ -698,12 +747,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_armhf.deb
@@ -711,12 +762,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_arm64.deb
@@ -724,12 +777,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_amd64.deb
@@ -743,12 +798,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_armhf.deb
@@ -756,12 +813,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_arm64.deb
@@ -769,12 +828,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_amd64.deb
@@ -788,12 +849,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_armhf.deb
@@ -801,12 +864,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_arm64.deb
@@ -814,12 +879,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_amd64.deb
@@ -836,10 +903,14 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 
 Then install the package with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "mender-gateway%-1"/mender-gateway -->
 ```bash
 sudo dpkg -i mender-gateway_*.deb
 ```
+
+<!--AUTOMATION: test=test $(ls mender-gateway_*.deb | wc -l) -eq 12 -->
+<!--AUTOMATION: execute=dpkg -i mender-gateway_*-1+ubuntu+focal_amd64.deb -->
 
 ### Examples package
 
@@ -860,6 +931,7 @@ Mender username and password:
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
@@ -872,12 +944,14 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 [/ui-tab]
 [ui-tab title="enterprise"]
 Set the following variables with your credentials:
+<!--AUTOMATION: ignore -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 
+<!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-examples-master.tar
@@ -891,3 +965,6 @@ Then install the contents with:
 ```bash
 sudo tar -C / --strip-components=2 -xvf mender-gateway-examples-master.tar
 ```
+
+<!--AUTOMATION: test=test -d /usr/share/doc/mender-gateway/examples -->
+<!--AUTOMATION: test=grep hosted.mender.io /etc/mender/mender-gateway.conf -->

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -382,18 +382,26 @@ download it by running:
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
-<!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
  HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
-<!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
@@ -416,18 +424,27 @@ through the package:
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
-<!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
  HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
-<!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/master/mender-monitor-demo_master-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
@@ -461,26 +478,38 @@ download it by running:
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_amd64.deb
 ```
 [/ui-tab]
@@ -491,26 +520,38 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_amd64.deb
 ```
 [/ui-tab]
@@ -521,26 +562,38 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_amd64.deb
 ```
 [/ui-tab]
@@ -551,26 +604,38 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_amd64.deb
 ```
 [/ui-tab]
@@ -587,26 +652,41 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_amd64.deb
 ```
 [/ui-tab]
@@ -617,26 +697,41 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_amd64.deb
 ```
 [/ui-tab]
@@ -647,26 +742,41 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bbionic_amd64.deb
 ```
 [/ui-tab]
@@ -677,26 +787,41 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="armhf"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
-<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bubuntu%2Bfocal_amd64.deb
 ```
 [/ui-tab]
@@ -734,18 +859,27 @@ Mender username and password:
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
-<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
-<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
+Set the following variables with your credentials:
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+```
+And download it with:
+
+<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
+```bash
 wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -8,7 +8,7 @@ process:
     twig: true
 ---
 
-<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" != 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -ne 1 ];; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
 
 ## Disk images
 

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -404,8 +404,8 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-monitor_%-1"/monitor-client -->
 ```bash
-dpkg -i mender-monitor_master-1+debian+buster_all.deb
-apt --fix-broken -y install
+sudo dpkg -i mender-monitor_master-1+debian+buster_all.deb
+sudo apt --fix-broken -y install
 ```
 
 ### Demo monitors
@@ -438,7 +438,7 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-monitor-demo_%-1"/monitor-client -->
 ```bash
-dpkg -i mender-monitor-demo_master-1+debian+buster_all.deb
+sudo dpkg -i mender-monitor-demo_master-1+debian+buster_all.deb
 ```
 
 ## Mender Gateway
@@ -713,7 +713,7 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-gateway%-1"/mender-gateway -->
 ```bash
-dpkg -i mender-gateway_*.deb
+sudo dpkg -i mender-gateway_*.deb
 ```
 
 ### Examples package
@@ -753,5 +753,5 @@ Then install the contents with:
 
 <!--AUTOVERSION: "mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
-tar -C / --strip-components=2 -xvf mender-gateway-examples-master.tar
+sudo tar -C / --strip-components=2 -xvf mender-gateway-examples-master.tar
 ```

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -495,7 +495,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
 HOSTED_MENDER_PASSWORD=<yoursecurepassword>
-wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_armhf.deb
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
@@ -621,7 +621,7 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbullseye_armhf.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/master/mender-gateway_master-1%2Bdebian%2Bbuster_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -737,14 +737,16 @@ Mender username and password:
 <!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
-curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/hosted/mender-gateway/examples/master/mender-gateway-examples-master.tar
+HOSTED_MENDER_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-examples-master.tar
+MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]
 [/ui-tabs]

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -734,17 +734,17 @@ Mender username and password:
 
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="hosted"]
-<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-%.tar"/mender-gateway -->
+<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
-curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/hosted/mender-gateway/examples/master/mender-gateway-master.tar
+curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/hosted/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
-<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-%.tar"/mender-gateway -->
+<!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
 MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-master.tar
+curl --fail -u $MENDER_ENTERPRISE_EMAIL -o ${HOME}/mender-gateway-master.tar https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/master/mender-gateway-examples-master.tar
 ```
 [/ui-tab]
 [/ui-tabs]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,10 +4,12 @@ set -ex
 
 ./test_autoversion.py
 ./autoversion.py --check
+./test_docs.py 03.Client-installation/02.Install-with-Debian-package/docs.md
 env TEST_OPEN_SOURCE=1 ./test_docs.py 07.Server-installation/03.Installation-with-docker-compose/docs.md
 if [ -n "$REGISTRY_MENDER_IO_PASSWORD" ]; then
     docker login -u ntadm_menderci -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io
     env TEST_ENTERPRISE=1 ./test_docs.py 07.Server-installation/03.Installation-with-docker-compose/docs.md
     env TEST_ENTERPRISE=1 ./test_docs.py 07.Server-installation/03.Installation-with-docker-compose/02.Upgrading-from-OS-to-Enterprise/docs.md
     env TEST_ENTERPRISE=1 ./test_docs.py 08.Server-integration/03.Mutual-TLS-authentication/docs.md
+    env TEST_ENTERPRISE=1 ./test_docs.py 09.Downloads/docs.md
 fi


### PR DESCRIPTION
* Install with Debian: Use native arch and split download and setup
* Install with Debian: Use new demo flags on mender setup commands
* Downloads: Consistently use sudo in all privileged commands
* Downloads: fix download links for mender-gateway examples package
* Downloads: fix download links for mender-gateway Debian buster armhf
* Downloads: use wget for mender-gateway examples package
* Downloads: Split closed source downloads instructions
* QA-378: Add AUTOMATION tests for Downloads and mender-client deb install