### PR TITLE
Remove dash from commands

### DIFF
--- a/06.Artifact-creation/06.Standalone-deployment/docs.md
+++ b/06.Artifact-creation/06.Standalone-deployment/docs.md
@@ -47,7 +47,7 @@ To deploy the new Artifact to your device, run the following command in the
 device terminal:
 
 ```bash
-mender -install <URI>
+mender install <URI>
 ```
 
 `<URI>` can be any type of file-based storage or an HTTP/HTTPS URL.
@@ -61,7 +61,7 @@ To use HTTPS, simply replace it with a URL like `https://fileserver.example.com/
 If you are happy with the deployment, you can make it permanent by running the following command in your device terminal:
 
 ```bash
-mender -commit
+mender commit
 ```
 
 By running this command, Mender will mark the update as successful and permanent.


### PR DESCRIPTION
It looks like this dashes are deprecated now


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
