### PR TITLE
QA-365: Add the conventional commit spec to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,20 @@
 <!-- AUTOVERSION: "/mender/blob/%"/ignore -->
 🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.
 
+- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.
+
+The majority of our contributions are fixes, which means your commit should have
+the form below:
+
+```
+fix: <SHORT DESCRIPTION OF FIX>
+
+<OPTIONAL LONGER DESCRIPTION>
+
+Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
+Ticket: <TICKET NUMBER> or <None>
+```
+
 - [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.
 
 ### Description


### PR DESCRIPTION
Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
