### PR TITLE
fix: add missing backslash in command

### DIFF
--- a/01.Get-started/06.Mender-Gateway/docs.md
+++ b/01.Get-started/06.Mender-Gateway/docs.md
@@ -182,7 +182,7 @@ At this point, you can start a virtual device running:
 
 ```bash
 docker run -it -p 85:85 --pull=always \
-    -e SERVER_IP="$SERVER_IP"
+    -e SERVER_IP="$SERVER_IP" \
 	-e SERVER_URL='https://gateway.docker.mender.io' \
 	-e TENANT_TOKEN="$TENANT_TOKEN" \
 	mendersoftware/mender-client-qemu


### PR DESCRIPTION
docker command was failing because a missing character

Changelog: None
Ticket: None

Signed-off-by: Luis Ramirez Vargas <luis.ramirez@northern.tech>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

I fixed a typo in a command

Thank you!
