### PR TITLE
fix: add storageclass note for k3s

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/03.NATS/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/03.NATS/docs.md
@@ -29,12 +29,15 @@ nats:
       enabled: true
       size: "2Gi"
       storageDirectory: /data/
+      storageClassName: "local-path"
 EOF
 
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 helm repo update
 helm install nats nats/nats --version 0.8.2 -f nats.yml
 ```
+
+!!! Replace `local-path` with the appropriate storage class name for your Kubernetes cluster.
 
 The connection string to connect to your NATS cluster will be:
 


### PR DESCRIPTION
Signed-off-by: Roberto Giovanardi <rob.giovanardi@gmail.com>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: add storageclass note for k3s

NATS helm chart uses "default" `storageClassName` that doesn't work with k3s. Solved by changing `storageClassName` to `local-path` into the doc. Also added an advice for replacing local-path with the appropriate storage class name.

Changelog: Add storageClassName note for K3S
Ticket: None
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

NATS helm chart uses "default" `storageClassName` that doesn't work with k3s.   
Fixed by changing `storageClassName` to `local-path` into the doc. Also added an advice for replacing local-path with the appropriate storage class name.
