### PR TITLE
fix: add -traditional flag when using openssl3

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -19,15 +19,17 @@ required keys:
 [ui-tabs position="top-left" active="0" theme="default" ]
 [ui-tab title="Open Source"]
 ```bash
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa -out device_auth.key
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa -out useradm.key
+TRADITIONAL_FLAG="" test $(openssl version | cut -f2 -d' ' | cut -f1 -d'.') -eq 3 && TRADITIONAL_FLAG="-traditional"
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa ${TRADITIONAL_FLAG} -out device_auth.key
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa ${TRADITIONAL_FLAG} -out useradm.key
 ```
 [/ui-tab]
 [ui-tab title="Enterprise"]
 ```bash
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa -out device_auth.key
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa -out useradm.key
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa -out tenantadm.key
+TRADITIONAL_FLAG="" test $(openssl version | cut -f2 -d' ' | cut -f1 -d'.') -eq 3 && TRADITIONAL_FLAG="-traditional"
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa ${TRADITIONAL_FLAG} -out device_auth.key
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa ${TRADITIONAL_FLAG} -out useradm.key
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 | openssl rsa ${TRADITIONAL_FLAG} -out tenantadm.key
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
Signed-off-by: Roberto Giovanardi <rob.giovanardi@gmail.com>


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: handling PKCS#1 format when using openssl3

Openssl3 by default handles PKCS#8 format only, but it can convert a key to PKCS#1 format with `openssl rsa -traditional` flag.

Changelog: Handling PKCS#1 keys with openssl3
Ticket: None
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Openssl3 by default handles PKCS#8 format only, but it can convert a key to PKCS#1 format with `openssl rsa -traditional` flag.

I chose a bash script for checking which openssl version the user is using and consequently set the flag:
```
TRADITIONAL_FLAG="" test $(openssl version | cut -f2 -d' ' | cut -f1 -d'.') -eq 3 && TRADITIONAL_FLAG="-traditional"
```

Without this fix, `device-auth` and `useradm` won't deploy because of errors like this:
```
failed to read rsa private key: unknown server private key type; got: PRIVATE KEY, want: RSA PRIVATE KEY
```

