### PR TITLE
fix: binary name for useradm-enterprise when creating additional users

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -215,7 +215,7 @@ You can create additional users from the command line of the `useradm` pod:
 
 ```bash
 USERADM_POD=$(kubectl get pod -l 'app.kubernetes.io/name=useradm' -o name | head -1)
-kubectl exec $USERADM_POD -- useradm create-user --username "demo@mender.io" --password "demodemo" --tenant-id $TENANT_ID
+kubectl exec $USERADM_POD -- useradm-enterprise create-user --username "demo@mender.io" --password "demodemo" --tenant-id $TENANT_ID
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
Changelog: None
Ticket: MEN-5638

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit 2299b4b1c1dce7ac61090558a3cd0a032e178f07)
