### PR TITLE
Fix typo in golden image generation

### DIFF
--- a/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
+++ b/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
@@ -103,7 +103,7 @@ file `root-part.ext4` in the user's home directory on the remote machine:
 USER="user"
 HOST="host-ip"
 
-mender snapshot dump | ssh $USER@$HOST /bin/sh -c 'cat > $HOME/root-part.ext4`
+mender snapshot dump | ssh $USER@$HOST /bin/sh -c 'cat > $HOME/root-part.ext4'
 ```
 
 If `ssh` is not available, you can attach a removable storage device (e.g.


### PR DESCRIPTION
fix: typo in command that dumps golden image from target

Signed-off-by: Luis Ramirez <luis.ramirez@northern.tech>

Changelog: None


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
