### PR TITLE
Fix mtls-ambassador autoversion failure by ignoring it.

### DIFF
--- a/08.Server-integration/03.Mutual-TLS-authentication/docs.md
+++ b/08.Server-integration/03.Mutual-TLS-authentication/docs.md
@@ -229,7 +229,11 @@ You also need to specify a username and password pair. The ambassador will use i
 To start the edge proxy, run the following command:
 
 <!-- AUTOMATION: execute={ -->
-<!--AUTOVERSION: "registry.mender.io/mendersoftware/mtls-ambassador:mender-%"/integration -->
+<!-- mtls-ambassador will have to be updated manually on the hosted branch. mtls-ambassador needs
+     the latest release from the on-prem releases, but this is on a different branch. The
+     autoversion tool has no way to determine this branch and associated version right now, so we
+     need to do it manually. This is a step in our release checklist. -->
+<!--AUTOVERSION: "registry.mender.io/mendersoftware/mtls-ambassador:mender-%"/ignore -->
 ```bash
 docker run \
   -p 443:8080 \


### PR DESCRIPTION
For now we have to do this component manually.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
