### PR TITLE
fix: corrects misleading configuration for s3 buckets

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -148,7 +148,6 @@ helm upgrade --install mender mender/mender --version master -f mender-master.ym
 > global:
 >   s3:
 >     AWS_URI: "https://<name-of-your-bucket>.s3.<your-aws-region>.amazonaws.com"
->     AWS_BUCKET: "<name-of-your-bucket>"
 >     AWS_REGION: "<your-aws-region>"
 >     AWS_ACCESS_KEY_ID: "<your-access-key-id>"
 >     AWS_SECRET_ACCESS_KEY: "<your-secret-access-key>"


### PR DESCRIPTION
Documentation is misleading. Including the bucket name of an S3 bucket in both AWS_URI and AWS_BUCKET causes the deployments container to look for “https://<AWS_BUCKET>.<name-of-your-bucket>.s3.<your-aws-region>.amazonaws.com” which is not valid. It is prepending the AWS_BUCKET to the front of the url.

Simply including the name in the AWS_URI is sufficient.

Changelog: None
Ticket: None

# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
