### PR TITLE
Fixed typo in 'Getting started' tutorial

### DIFF
--- a/01.Get-started/03.Deploy-a-system-update/docs.md
+++ b/01.Get-started/03.Deploy-a-system-update/docs.md
@@ -182,7 +182,7 @@ this modification *is not part of your system snapshot* created above.
 !! Be careful when running `apt upgrade` on a device with Mender system updates enabled. Integration
 !! with `apt upgrade` (through the `grub.d` framework) is only implemented for x86 as of
 !! mender-convert version master. For ARM and other non-x86 architectures, always update single
-!! applications only, because running `apt upgrade` may brick your device!. If you need to run `apt
+!! applications only, because running `apt upgrade` may brick your device! If you need to run `apt
 !! upgrade`, do it on a pristine system without Mender installed, and then [convert it to a Mender
 !! image](../../04.System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md)
 !! afterwards. This restriction may be lifted in the future.


### PR DESCRIPTION
Removed '.' after '!'. `s/!./!`