### PR TITLE
test: Update expected packages count in Downloads page

### DIFF
--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -1027,7 +1027,7 @@ Then install the package with:
 sudo dpkg -i mender-gateway_*.deb
 ```
 
-<!--AUTOMATION: test=test $(ls mender-gateway_*.deb | wc -l) -eq 12 -->
+<!--AUTOMATION: test=test $(ls mender-gateway_*.deb | wc -l) -eq 15 -->
 <!--AUTOMATION: execute=dpkg -i mender-gateway_*-1+ubuntu+focal_amd64.deb -->
 
 ### Examples package


### PR DESCRIPTION
After adding Ubuntu Jammy, we have three more packages (one per each architecture).