### PR TITLE
chore: Consistently use autoversion for mender-ci-workflows references

### DIFF
--- a/06.Artifact-creation/10.CI-CD/01.GitHub-Actions/docs.md
+++ b/06.Artifact-creation/10.CI-CD/01.GitHub-Actions/docs.md
@@ -30,19 +30,19 @@ The actions requires the following secret is set in a repository settings:
 * [Build and deploy Mender Artifact to a single device](#build-and-deploy-mender-artifact-to-a-single-device)
 
 ### Build and deploy Mender Artifact
-<!--AUTOVERSION: "tree/%/examples"/ignore-->
+<!--AUTOVERSION: "tree/%/examples"/mender-ci-workflows-->
 ```bash
 @build-and-deploy-mender-artifact.yml@ # https://github.com/mendersoftware/mender-ci-workflows/tree/master/examples/github/build-and-deploy-mender-artifact.yml
 ```
 
 ### Build and deploy multiple Mender Artifacts
-<!--AUTOVERSION: "tree/%/examples"/ignore-->
+<!--AUTOVERSION: "tree/%/examples"/mender-ci-workflows-->
 ```bash
 @build-and-deploy-multiple-artifacts.yml@ # https://github.com/mendersoftware/mender-ci-workflows/tree/master/examples/github/build-and-deploy-multiple-artifacts.yml
 ```
 
 ### Build and deploy Mender Artifact to a single device
-<!--AUTOVERSION: "tree/%/examples"/ignore-->
+<!--AUTOVERSION: "tree/%/examples"/mender-ci-workflows-->
 ```bash
 @deploy-to-a-single-device.yml@ # https://github.com/mendersoftware/mender-ci-workflows/tree/master/examples/github/deploy-to-a-single-device.yml
 ```

--- a/06.Artifact-creation/10.CI-CD/docs.md
+++ b/06.Artifact-creation/10.CI-CD/docs.md
@@ -13,7 +13,7 @@ Mender provides support for application updates in the form of CI/CD pipelines t
 To help you in creating CI/CD pipelines, we created [GitHub repository](https://github.com/mendersoftware/mender-ci-workflows/) containing ready to use, battle-tested CI/CD pipeline code snippets that can be used in your workflows. Additionally, we provide [mender-ci-tools Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools) based on Alpine Linux and providing command-line utilities,`mender-artifact` and `mender-cli` installed.
 
 To locally inspect the Docker image, pull it with the following command:
-<!--AUTOVERSION: "mendersoftware/mender-ci-tools:%"/ignore-->
+<!--AUTOVERSION: "mendersoftware/mender-ci-tools:%"/mender-ci-workflows-->
 ```
 docker pull mendersoftware/mender-ci-tools:master
 ```


### PR DESCRIPTION
For the other CIs pages (GitLab and Azure DevOps) it is correctly set, but we missed it on GitHub Actions and the parent page.