### PR TITLE
ci: Hard-code mender-ci-workflows-version to 1.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,7 @@ test:latest_versions:
       --update
       --integration-dir $INTEGRATION_REPO_DIR
       --integration-version $INTEGRATION_VERSION
+      --mender-ci-workflows-version 1.0.0
     - git diff HEAD
     # exits with non zero status if not staged for commit files exist
     - git diff-index --quiet HEAD


### PR DESCRIPTION
As this component is out of the release_tool, the ci test has no way to know which is the latest version (for now).

Amends commit 72079d479137940b6afcecf35c2f8271585dc335 and it will be reworked together with the original commit once we have a design for where to store the latest version of independent components.