### PR TITLE
fix: disk image compression is none by default

### DIFF
--- a/04.System-updates-Debian-family/99.Variables/docs.md
+++ b/04.System-updates-Debian-family/99.Variables/docs.md
@@ -160,7 +160,7 @@ The version of the Mender Configure add-on to include in the update.
 
 #### `MENDER_COMPRESS_DISK_IMAGE`
 
-> Values: gzip(default)/lzma/none
+> Values: gzip/lzma/none(default)
 
 This is useful when you have large disk images, compressing them makes it easier
 to transfer them between a build server and a local machine, and saves space.


### PR DESCRIPTION
In mender-convert config (configs/mender_convert_config) default value for MENDER_COMPRESS_DISK_IMAGE is gzip but because it is missing quotation marks the default behavior corresponds to the same as "none" meaning the mender-convert by default leaves the disk image uncompressed.

It would be better to change the default value to "none" in mender-convert repository in addition to this PR but I leave it for you to decide what to do.


