### PR TITLE
fix: tenantadm command separated from kubectl command

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -242,7 +242,7 @@ kubectl exec $USERADM_POD -- useradm create-user --username "demo@mender.io" --p
 Create the administrator user using the `tenantadm` pod:
 ```bash
 TENANTADM_POD=$(kubectl get pod -l 'app.kubernetes.io/name=tenantadm' -o name | head -1)
-TENANT_ID=$(kubectl exec $TENANTADM_POD tenantadm create-org --name demo --username "admin@mender.io" --password "adminadmin" --plan enterprise)
+TENANT_ID=$(kubectl exec -- $TENANTADM_POD tenantadm create-org --name demo --username "admin@mender.io" --password "adminadmin" --plan enterprise)
 ```
 
 You can create additional users from the command line of the `useradm` pod:


### PR DESCRIPTION
# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: tenantadm command separated from kubectl command

Added double dash `--` to separate `kubectl` command from the exec `tenantadm` command

Changelog: fix tenantadm command
Ticket: None
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Added double dash `--` to separate `kubectl` command from the exec `tenantadm` command
