### PR TITLE
Internal MongoDB not ready

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/02.MongoDB/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/02.MongoDB/docs.md
@@ -32,6 +32,10 @@ image:
   tag: "4.4.13-debian-10-r63"
 persistence:
   size: "8Gi"
+livenessProbe:
+  timeoutSeconds: 30
+readinessProbe:
+  timeoutSeconds: 30
 EOF
 
 helm repo add bitnami https://charts.bitnami.com/bitnami


### PR DESCRIPTION
# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: tuning internal MongoDB probes

Bitnami deployed MongoDB chart won't get ready in some conditions (e.g. slow storage).
The Pod never get ready because of timeout.
Fixed by increasing the default timeout in the helm chart

Changelog: modified the default probe timeoutSeconds in bitnami MongoDB Helm Chart
Ticket: None
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Bitnami deployed MongoDB chart won't get ready in some conditions (e.g. slow storage).
The Pod never get ready because of timeout.
Fixed by increasing the default timeout in the helm chart