### PR TITLE
[Cherry 3.3.x] :fix: tenantadm command separated from kubectl command

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -210,7 +210,7 @@ kubectl exec $USERADM_POD -- useradm create-user --username "demo@mender.io" --p
 Create the administrator user using the `tenantadm` pod:
 ```bash
 TENANTADM_POD=$(kubectl get pod -l 'app.kubernetes.io/name=tenantadm' -o name | head -1)
-TENANT_ID=$(kubectl exec $TENANTADM_POD tenantadm create-org --name demo --username "admin@mender.io" --password "adminadmin" --plan enterprise)
+TENANT_ID=$(kubectl exec -- $TENANTADM_POD tenantadm create-org --name demo --username "admin@mender.io" --password "adminadmin" --plan enterprise)
 ```
 
 You can create additional users from the command line of the `useradm` pod:


### PR DESCRIPTION
Cherry pick of PR: https://github.com/mendersoftware/mender-docs/pull/2058