### PR TITLE
fix: add missing docker build for mender-convert

### DIFF
--- a/04.Operating-System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
+++ b/04.Operating-System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
@@ -136,7 +136,12 @@ mv <PATH_TO_MY_GOLDEN_IMAGE> input/golden-image-1.img
 
 ### Use the mender-convert container image
 
-We strongly recommend using mender-convert with docker.
+We strongly recommend using mender-convert with docker. Before the first run,
+build the required containers:
+
+```bash
+./docker-build
+```
 
 Run mender-convert from inside the container with your desired options, e.g.
 


### PR DESCRIPTION
In order to use the containerized version of mender-convert, the containers must be built. This is documented in the README, but missing here.

Changelog: Title
Ticket: None


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
