### PR TITLE
chore: implicitly using latest version with master

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -48,14 +48,18 @@ You can now install the Mender Server running:
 
 [ui-tabs position="top-left" active="0" theme="default" ]
 [ui-tab title="Open Source"]
-<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender --version % -f mender-%.yml"/integration -->
+<!--AUTOVERSION: "export MENDER_VERSION_TAG=\"mender-%\""/ignore -->
+<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender -f mender-%.yml"/integration -->
 ```bash
 export MENDER_SERVER_DOMAIN="mender.example.com"
 export MENDER_SERVER_URL="https://${MENDER_SERVER_DOMAIN}"
+export MENDER_VERSION_TAG="mender-3.4"
 
 cat >mender-master.yml <<EOF
 global:
   enterprise: false
+  image:
+    tag: ${MENDER_VERSION_TAG}
   mongodb:
     URL: "mongodb://root:${MONGODB_ROOT_PASSWORD}@mongodb-0.mongodb-headless.default.svc.cluster.local:27017,mongodb-1.mongodb-headless.default.svc.cluster.local:27017"
   nats:
@@ -82,7 +86,7 @@ useradm:
 $(cat useradm.key | sed -e 's/^/      /g')
 EOF
 
-helm upgrade --install mender mender/mender --version master -f mender-master.yml
+helm upgrade --install mender mender/mender -f mender-master.yml
 ```
 [/ui-tab]
 [ui-tab title="Enterprise"]
@@ -92,13 +96,14 @@ helm upgrade --install mender mender/mender --version master -f mender-master.ym
 !!!!! Container Registry. Please email [contact@mender.io](mailto:contact@mender.io) to
 !!!!! receive an evaluation account.
 
-
-<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender --version % -f mender-%.yml"/integration -->
+<!--AUTOVERSION: "export MENDER_VERSION_TAG=\"mender-%\""/ignore -->
+<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender -f mender-%.yml"/integration -->
 ```bash
 export MENDER_REGISTRY_USERNAME="replace-with-your-username"
 export MENDER_REGISTRY_PASSWORD="replace-with-your-password"
 export MENDER_SERVER_DOMAIN="mender.example.com"
 export MENDER_SERVER_URL="https://${MENDER_SERVER_DOMAIN}"
+export MENDER_VERSION_TAG="mender-3.4"
 
 cat >mender-master.yml <<EOF
 global:
@@ -106,6 +111,7 @@ global:
   image:
     username: "${MENDER_REGISTRY_USERNAME}"
     password: "${MENDER_REGISTRY_PASSWORD}"
+    tag: ${MENDER_VERSION_TAG}
   mongodb:
     URL: "mongodb://root:${MONGODB_ROOT_PASSWORD}@mongodb-0.mongodb-headless.default.svc.cluster.local:27017,mongodb-1.mongodb-headless.default.svc.cluster.local:27017"
   nats:
@@ -137,7 +143,7 @@ useradm:
 $(cat useradm.key | sed -e 's/^/      /g')
 EOF
 
-helm upgrade --install mender mender/mender --version master -f mender-master.yml
+helm upgrade --install mender mender/mender -f mender-master.yml
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: implicitly use the latest Helm Chart version

Mender Helm Chart is an independent project with its own versioning.  
To select the right Mender version a new variable was added:
```
export MENDER_VERSION_TAG="mender-3.4"
```
Besides, the `helm upgrade` command will not specify a `--version`, so I'll take the last published chart.

Changelog: implicitly use the latest Helm Chart version
Ticket: MC-6798
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

fix: implicitly use the latest Helm Chart version

Mender Helm Chart is an independent project with its own versioning.  
To select the right Mender version a new variable was added:
```
export MENDER_VERSION_TAG="mender-3.4"
```
Besides, the `helm upgrade` command will not specify a `--version`, so I'll take the last published chart.

