### PR TITLE
fix: correct dead link in 02.Read-only-root-filesystem docs.md

### DIFF
--- a/05.Operating-System-updates-Yocto-Project/04.Image-customization/02.Read-only-root-filesystem/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/04.Image-customization/02.Read-only-root-filesystem/docs.md
@@ -13,7 +13,7 @@ IMAGE_FEATURES += "read-only-rootfs"
 ```
 
 You can read more about this feature in the [Yocto Documentation for Creating a Read-Only Root
-Filesystem](https://docs.yoctoproject.org/dev-manual/common-tasks.html?target=_blank#creating-a-read-only-root-filesystem)
+Filesystem](https://docs.yoctoproject.org/dev/dev-manual/read-only-rootfs.html)
 
 !!! This feature is highly package dependent and even though Mender works
 !!! correctly with this feature enabled, there might be other packages in your


### PR DESCRIPTION
# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description
This PR corrects a dead url in docs.md file from the 02.Read-only-root-filesystem folder
