### PR TITLE
chore: critical fix for server installation.

### DIFF
--- a/07.Server-installation/06.Storage-of-the-artifacts/docs.md
+++ b/07.Server-installation/06.Storage-of-the-artifacts/docs.md
@@ -69,7 +69,7 @@ install a CDN in front of your Minio instance, and in this case you can use your
 
 Default: `https://s3.amazonaws.com`
 
-### `DEPLOYMENTS_AWS_ACCESS_KEY_ID` and `DEPLOYMENTS_AWS_AUTH_SECRET` (`aws.auth.key` and `aws.auth.secret`)
+### `DEPLOYMENTS_AWS_AUTH_KEY` and `DEPLOYMENTS_AWS_AUTH_SECRET` (`aws.auth.key` and `aws.auth.secret`)
 
 The credentials to access the S3 storage service.
 


### PR DESCRIPTION
With the setting as it was you get the most criptic error:

```
main: failed to setup storage client: s3: failed to check bucket preconditions: operation error S3: HeadBucket, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, canceled, context deadline exceeded
```

Due to AWS SDK in deployments going into uncharted code segments.

Ticket: None