### PR TITLE
fix: set working AWS_URI example

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/05.Mender-server/docs.md
@@ -163,7 +163,7 @@ Mender supports the following Artifact storage types:
 > ```yaml
 > global:
 >   s3:
->     AWS_URI: "https://<name-of-your-bucket>.s3.<your-aws-region>.amazonaws.com"
+>     AWS_URI: "https://s3.<your-aws-region>.amazonaws.com"
 >     AWS_BUCKET: "<name-of-your-bucket>"
 >     AWS_REGION: "<your-aws-region>"
 >     AWS_ACCESS_KEY_ID: "<your-access-key-id>"


### PR DESCRIPTION
Ticket: MC-6809


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: set working AWS_URI example

Changelog: None
Ticket: MC-6809
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

The `AWS_URI` specified in the doc doesn't work with S3. I tested the right URL and updated the example.