### PR TITLE
chore: Remove unsupported option for openssl command in Mac OS

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -85,7 +85,7 @@ USERNAME='' # CHANGE: your desired username
 PASSWORD='' # CHANGE: your desired password
 
 cat << EOF > "$RPI_BOOT"/userconf.txt
-${USERNAME}:$(openssl passwd -6 "$PASSWORD")
+${USERNAME}:$(openssl passwd "$PASSWORD")
 EOF
 ```
 


### PR DESCRIPTION
In Mac OS, the default provider for `openssl` command is LibreSSL (instead of OpenSSL), which does not support the `-6` option to specify SHA512 hash algorithm.

Remove the option and let the command use the default algorithm, which will actually be different for OpenSSL and LibreSSL.