### PR TITLE
fix: replace MENDER_ENTERPRISE_EMAIL with MENDER_ENTERPRISE_USER

### DIFF
--- a/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
@@ -37,8 +37,8 @@ command:
 
 <!--AUTOVERSION: "mender-binary-delta/%/mender-binary-delta-%.tar"/mender-binary-delta-->
 ```bash
-MENDER_ENTERPRISE_EMAIL="myusername@example.com"
-curl -u $MENDER_ENTERPRISE_EMAIL -O https://downloads.customer.mender.io/content/on-prem/mender-binary-delta/1.4.1/mender-binary-delta-1.4.1.tar.xz
+MENDER_ENTERPRISE_USER=<your.user>
+curl -u $MENDER_ENTERPRISE_USER -O https://downloads.customer.mender.io/content/on-prem/mender-binary-delta/1.4.1/mender-binary-delta-1.4.1.tar.xz
 ```
 
 

--- a/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -274,8 +274,8 @@ curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-monitor-1.2.1.tar.gz https
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-monitor/yocto/%/"/monitor-client "/mender-monitor-%.tar.gz"/monitor-client -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -o ${HOME}/mender-monitor-1.2.1.tar.gz https://downloads.customer.mender.io/content/on-prem/mender-monitor/yocto/1.2.1/mender-monitor-1.2.1.tar.gz
+MENDER_ENTERPRISE_USER=<your.user>
+curl --fail -u $MENDER_ENTERPRISE_USER -o ${HOME}/mender-monitor-1.2.1.tar.gz https://downloads.customer.mender.io/content/on-prem/mender-monitor/yocto/1.2.1/mender-monitor-1.2.1.tar.gz
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -338,8 +338,8 @@ curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-gateway-1.0.1.tar.xz https
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-gateway/yocto/%/"/mender-gateway "/mender-gateway-%.tar.xz"/mender-gateway -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
-curl --fail -u $MENDER_ENTERPRISE_EMAIL -o ${HOME}/mender-gateway-1.0.1.tar.xz https://downloads.customer.mender.io/content/on-prem/mender-gateway/yocto/1.0.1/mender-gateway-1.0.1.tar.xz
+MENDER_ENTERPRISE_USER=<your.user>
+curl --fail -u $MENDER_ENTERPRISE_USER -o ${HOME}/mender-gateway-1.0.1.tar.xz https://downloads.customer.mender.io/content/on-prem/mender-gateway/yocto/1.0.1/mender-gateway-1.0.1.tar.xz
 ```
 [/ui-tab]
 [/ui-tabs]

--- a/09.Downloads/docs.md
+++ b/09.Downloads/docs.md
@@ -410,14 +410,14 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.2.1/mender-monitor_1.2.1-1%2Bdebian%2Bbuster_all.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.2.1/mender-monitor_1.2.1-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -454,7 +454,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
  MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -462,7 +462,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.2.1/mender-monitor-demo_1.2.1-1%2Bdebian%2Bbuster_all.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.2.1/mender-monitor-demo_1.2.1-1%2Bdebian%2Bbuster_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -684,7 +684,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -692,14 +692,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_armhf.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -707,14 +707,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_arm64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -722,7 +722,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_amd64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbullseye_amd64.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -735,7 +735,7 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -743,14 +743,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_armhf.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -758,14 +758,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_arm64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -773,7 +773,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_amd64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bdebian%2Bbuster_amd64.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -786,7 +786,7 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -794,14 +794,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_armhf.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -809,14 +809,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_arm64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -824,7 +824,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_amd64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bbionic_amd64.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -837,7 +837,7 @@ wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_E
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -845,14 +845,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_armhf.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_armhf.deb
 ```
 [/ui-tab]
 [ui-tab title="arm64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -860,14 +860,14 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_arm64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_arm64.deb
 ```
 [/ui-tab]
 [ui-tab title="amd64"]
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -875,7 +875,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway_%-1"/mender-gateway "/mender-gateway/debian/%/"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_amd64.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/debian/1.0.1/mender-gateway_1.0.1-1%2Bubuntu%2Bfocal_amd64.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -932,7 +932,7 @@ wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDE
 Set the following variables with your credentials:
 <!--AUTOMATION: ignore -->
 ```bash
-MENDER_ENTERPRISE_EMAIL=<your.email@example.com>
+MENDER_ENTERPRISE_USER=<your.user>
 MENDER_ENTERPRISE_PASSWORD=<yoursecurepassword>
 ```
 And download it with:
@@ -940,7 +940,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-gateway/examples/%/"/mender-gateway "/mender-gateway-examples-%.tar"/mender-gateway -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_EMAIL" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/1.0.1/mender-gateway-examples-1.0.1.tar
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-gateway/examples/1.0.1/mender-gateway-examples-1.0.1.tar
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
Enterprise user names are not emails. Rename the bash variable to avoid confusion to Enterprise customers downloading software with their Enterprise credentials.

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit 1c2cfc630e2eb00b88910667f1fc9943630ab2a2)
