### PR TITLE
fix: document Raspberry Pi Imager bug

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -43,6 +43,10 @@ to flash the OS image to the device.
 We recommended to use the Raspberry Pi Imager tool, choose "Use custom" and
 browse to the downloaded Mender Raspberry Pi OS image.
 
+!! Do not use the options to pre-configure the written image,
+!! such as SSH, WiFi or user credentials. This is known to be buggy,
+!! causing an infinite reboot loop.
+
 !!! Writing the SD card takes 5-25 minutes,
 !!! mainly depending on your SD card and writer speed.
 

--- a/301.Troubleshoot/03.Mender-Client/docs.md
+++ b/301.Troubleshoot/03.Mender-Client/docs.md
@@ -57,6 +57,18 @@ block on the step `Waiting for root device ${mender_kernel_root}...`.
 This can be mitigated by adding the following line in `config.txt` on the sd cards boot partition, respectively uncommenting if it is already is prepared:
 `arm_64bit=0`.
 
+## Raspberry Pi not booting / infinite reboots after flashing card with Raspberry Pi Imager
+
+The Raspberry Pi Imager can be instructed to pre-configure the flashed image, for example
+- SSH
+- WiFi
+- user credentials
+- ...
+
+This is done by injecting a `firstrun.sh` script together with the statement `systemd.run_success_action=reboot` on the command line. On a menderized image, this will loop forever.
+
+To solve this problem, either reflash the image without adding customizations, or modify the `cmdline.txt` file on the boot partition of the file, removing the above `systemd` parameter.
+
 <!--AUTOVERSION: "mender-client %"/ignore -->
 ## Installation of the mender-client 3.2.0 Debian package on Debian Bullseye and Ubuntu 20.04
 


### PR DESCRIPTION
The Raspberry Pi Imager offers options to pre-customize the image right during flashing to the SD card. This injects a firstrun.sh script, along with a kernel command line that causes an infinite boot loop.
This needs to be documented in the onboarding section as well as the troubleshoot section.

Changelog: Title
Ticket: None


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

<!-- AUTOVERSION: "/mendertesting/blob/%"/ignore -->
- [ ] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
