### PR TITLE
chore: pinned helm chart version for the 3.3 mender versions

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/03.Mender-server/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/03.Mender-server/docs.md
@@ -60,7 +60,7 @@ You can now install the Mender Server running:
 [ui-tabs position="top-left" active="0" theme="default" ]
 [ui-tab title="Open Source"]
 <!--AUTOVERSION: "export MENDER_VERSION_TAG=\"mender-%\""/ignore -->
-<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender -f mender-%.yml"/integration -->
+<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender --version % -f mender-%.yml"/integration -->
 ```bash
 export MENDER_SERVER_DOMAIN="mender.example.com"
 export MENDER_SERVER_URL="https://${MENDER_SERVER_DOMAIN}"
@@ -111,7 +111,7 @@ useradm:
 $(cat useradm.key | sed -e 's/^/      /g')
 EOF
 
-helm upgrade --install mender mender/mender -f mender-3.3.2.yml
+helm upgrade --install mender mender/mender --version 5.0.1 -f mender-3.3.2.yml
 ```
 [/ui-tab]
 [ui-tab title="Enterprise"]
@@ -122,7 +122,7 @@ helm upgrade --install mender mender/mender -f mender-3.3.2.yml
 !!!!! receive an evaluation account.
 
 <!--AUTOVERSION: "export MENDER_VERSION_TAG=\"mender-%\""/ignore -->
-<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender -f mender-%.yml"/integration -->
+<!--AUTOVERSION: "cat >mender-%.yml <<EOF"/integration "helm upgrade --install mender mender/mender --version % -f mender-%.yml"/integration -->
 ```bash
 export MENDER_REGISTRY_USERNAME="replace-with-your-username"
 export MENDER_REGISTRY_PASSWORD="replace-with-your-password"
@@ -182,7 +182,7 @@ useradm:
 $(cat useradm.key | sed -e 's/^/      /g')
 EOF
 
-helm upgrade --install mender mender/mender -f mender-3.3.2.yml
+helm upgrade --install mender mender/mender --version 5.0.1 -f mender-3.3.2.yml
 ```
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
Ticket: MC-6911


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

<!-- AUTOVERSION: "/mendertesting/blob/%"/ignore -->
- [x] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: pinned the helm chart version for the older mender versions

Starting from the 3.6 release, the helm chart contains new breaking changes.
To avoid disrupting old 3.3 and 3.4 setups, we added the latest supported helm chart version
in the setup documentation.

Changelog: Pinned the helm chart version for the older mender versions
Ticket: MC-6911
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Starting from the 3.6 release, the helm chart contains new breaking changes.
To avoid disrupting old 3.3 and 3.4 setups, we added the latest supported helm chart version
in the setup documentation.