### PR TITLE
fix: specify region for hosted configuration

### DIFF
--- a/04.Operating-System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
+++ b/04.Operating-System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md
@@ -117,8 +117,11 @@ The easiest, and most straight-forward way, is to integrate the client with
 
 ```bash
 mkdir -p input
+
+# choose Hosted Mender region, between 'eu' and 'us' ('us' if nothing is specified)
 $MENDER_CONVERT_LOCATION/scripts/bootstrap-rootfs-overlay-hosted-server.sh \
     --output-dir ${PWD}/input/rootfs_overlay_demo \
+    --region us \
     --tenant-token "Paste token from https://hosted.mender.io/ui/settings/organization-and-billing"
 ```
 


### PR DESCRIPTION
This comes with the pull request https://github.com/mendersoftware/mender-convert/pull/594

If there is any other place in the docs where `mender-convert/scripts/bootstrap-rootfs-overlay-hosted-server.sh` is used, please let me know!