### PR TITLE
chore: remove the unsafe update module and make migration ent only

### DIFF
--- a/301.Troubleshoot/10.Hosted-Mender-migration/docs.md
+++ b/301.Troubleshoot/10.Hosted-Mender-migration/docs.md
@@ -9,7 +9,7 @@ Historically we have only had a single instance in the US.
 Hosted Mender instances are now available in [multiple regions](../../11.General/00.Hosted-Mender-regions/docs.md) as a result of our expansion.
 This document will describe the migration process if you currently have a fleet of devices operating in one instance and would like to move them to another one.
 
-!! Migration between instances without risks requires support assistance and is a payed service.
+!! Migration between instances without risks requires support assistance and is a payed service available only to the Enterprise plan.
 !! If you wish to migrate your account please contact us on [support@mender.io](mailto:support@mender.io?subject=Tenant%20migration) with the subject **Tenant migration**.
 
 !! Please note that this method only applies for HM mender instances and isn't applicable for on-prem migrations.
@@ -77,8 +77,6 @@ Please check bellow for different approaches on how to achieve this:
 
 * [Yocto](#yocto)
 * [Debian](#debian)
-* [Custom update module](#custom-update-module)
-
 
 !! If you deploy a config file with a badly formatted json, `mender-client` on the device won't start correctly after the update.
 !! The device will roll back to the previous version only after the device is restarted by other means.
@@ -155,94 +153,3 @@ At the end of the process you should have two mender artifacts:
 * one containing the config for both Old and New server
 * one containing the config for the New server only
 
-
-### Custom Update Module
-
-It is also possible do the migration without having to do a full rootfs update.
-This can be done by deploying a custom Update Module just for this case.
-
-!! Please note that the Update Module is provided as an example only.
-!! It is not part of our internal testing pipelines.
-
-
-
-``` bash
-#!/bin/sh
-
-set -e
-
-STATE="$1"
-FILES="$2"
-
-case "$STATE" in
-    ArtifactInstall)
-        # Backup of current conf file
-        cp /etc/mender/mender.conf /etc/mender/mender.old.conf
-
-        # Modify current conf file
-        cat /etc/mender/mender.conf | jq '
-.ServerURL = "" |   # Blank existing ServerURL
-.Servers = [        # Set Servers array of ServerURL(s)
-  {ServerURL: "https://hosted.mender.io"},
-  {ServerURL: "https://eu.hosted.mender.io"}
-]' > /etc/mender/mender.new.conf
-
-        # Set the new configuration
-        cp -f /etc/mender/mender.new.conf /etc/mender/mender.conf
-        ;;
-
-    NeedsArtifactReboot)
-        echo "Automatic"
-        ;;
-
-    SupportsRollback)
-        echo "Yes"
-        ;;
-
-    ArtifactRollback)
-        cp -f /etc/mender/mender.old.conf /etc/mender/mender.conf
-        ;;
-
-    Cleanup)
-        # Delete used files
-        rm /etc/mender/mender.old.conf /etc/mender/mender.new.conf
-        ;;
-esac
-exit 0
-```
-
-The example includes a way to rollback if the configuration ended up unable to connect to the server (ArtifactRollback).
-After the update is perform a reboot is requested (NeedsArtifactReboot) to ensure the Mender services restarts and load the new configuration.
-
-
-In order to use the Update Module, it needs to be installed in the device filesystem.
-To generate the artifact that installs the `migration-um-a` Update Module, the `single-artifact` Update Module can be used.
-
-<!--AUTOVERSION: "github.com/mendersoftware/mender/blob/%/"/mender-->
-Using the script [single-file-artifact-gen](https://github.com/mendersoftware/mender/blob/master/support/modules-artifact-gen/single-file-artifact-gen) makes this process easier.
-
-
-### Create the Mender Artifact
-
-Now create an Artifact with the updated `mender.conf` using the your current workflow to create
-
-For this example, the following command will generate the artifact:
-
-```bash
-ARTIFACT_NAME="eu-migration-a"
-DEVICE_TYPE="qemux86-64"
-OUTPUT_PATH="eu-migration-a.mender"
-DEST_DIR="/usr/share/mender/modules/v3/"
-FILE="migration-um-a"
-single-file-artifact-gen -n ${ARTIFACT_NAME} -t ${DEVICE_TYPE} -d ${DEST_DIR} -o ${OUTPUT_PATH} ${FILE}
-```
-
-Additionally, to trigger the `migration-um-a` Update Module, an additional artifact needs to be created. For this new artifact, the [mender-artifact](https://docs.mender.io/downloads#mender-artifact) cli tool will be used:
-
-```bash
-ARTIFACT_NAME="trigger-eu-mig-a"
-DEVICE_TYPE="qemux86-64"
-UPDATE_MODULE="migration-um-a"
-FILE="migration-a.mender"
-mender-artifact write module-image -t $DEVICE_TYPE -o $FILE -T $UPDATE_MODULE -n $ARTIFACT_NAME
-````


### PR DESCRIPTION
Suggesting an unsafe update module in the docs is unsafe, even with the note.
We promise brick free devices, so suggesting risky steps in the docs doesn't align with that message.

Ticket: None
Changelog: None
