### PR TITLE
Update docs.md

### DIFF
--- a/07.Server-installation/04.Production-installation-with-kubernetes/docs.md
+++ b/07.Server-installation/04.Production-installation-with-kubernetes/docs.md
@@ -17,8 +17,7 @@ are highlighted for the latter.
 You will use the [Helm chart](https://github.com/mendersoftware/mender-helm) to
 deploy to production the Mender backend services on a Kubernetes cluster.
 
-Please read the Requirements page to understand what combinations are validated by Northern.tech.Once that is clear please move on the first paragraph [Kubernetes](./01.Kubernetes/docs.md).
-
+Please read the following Requirements and resources section to understand what combinations are validated by Northern.tech.
 
 ## Requirements and resources
 


### PR DESCRIPTION
fix(docs): mentioned of kubernetes before requirements

There was a bit of messy typing here so I thought I'd suggest a fix. Looking at it though I think it is better to not include a link to the place you don't want them to go until they read the following text so I removed the reference and link to the next section: Kubernetes.

Ticket: None
Changelog: None