### PR TITLE
fix: canonical URL for the 3.6-only page about upgrading from 3.3

### DIFF
--- a/07.Server-installation/02.Upgrading-from-previous-versions/090.Upgrading-from-3.3-to-3.6/docs.md
+++ b/07.Server-installation/02.Upgrading-from-previous-versions/090.Upgrading-from-3.3-to-3.6/docs.md
@@ -3,6 +3,8 @@ title: Upgrading to Mender 3.6
 taxonomy:
 category: docs
 label: tutorial
+routes:
+  canonical: '/3.6/server-installation/upgrading-from-previous-versions/upgrading-from-3.3-to-3.6'
 ---
 
 This is a tutorial for upgrading the Mender Server from version 3.3 and 3.4 to


### PR DESCRIPTION
Changelog: None
Ticket: None