### PR TITLE
Fix incorrect reference to mender-convert version and grub.d support.

### DIFF
--- a/04.Operating-System-updates-Debian-family/01.Overview/docs.md
+++ b/04.Operating-System-updates-Debian-family/01.Overview/docs.md
@@ -5,11 +5,11 @@ taxonomy:
 ---
 
 
-<!--AUTOVERSION: "mender-convert version %"/mender-convert-->
+<!--AUTOVERSION: "from mender-convert %"/ignore-->
 <!-- See MEN-4983 -->
 !! Be careful when running `apt upgrade` on a device with Mender Operating System updates enabled. Integration
-!! with `apt upgrade` (through the `grub.d` framework) is only implemented for x86 as of
-!! mender-convert version 4.2.0. For ARM and other non-x86 architectures, always update single
+!! with `apt upgrade` (through the `grub.d` framework) is implemented from mender-convert 3.0.0
+!! and onwards, but only for x86. For ARM and other non-x86 architectures, always update single
 !! applications only, because running `apt upgrade` may brick your device!. If you need to run `apt
 !! upgrade`, do it on a pristine system without Mender installed, and then [convert it to a Mender
 !! image](../../04.Operating-System-updates-Debian-family/02.Convert-a-Mender-Debian-image/docs.md)


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 3a0612bd6025d565d54bebea594a0c226a370073)
