### PR TITLE
3.7.x: doc: Fix markdown syntax for link

### DIFF
--- a/301.Troubleshoot/03.Mender-Client/docs.md
+++ b/301.Troubleshoot/03.Mender-Client/docs.md
@@ -15,7 +15,7 @@ it to the 3.5.2 version by default.
 
 To solve the issue, either:
 * Run `apt-get install mender-client`
-* Run again the [express installation script(../../10.Downloads/docs.md#Express-installation)
+* Run again the [express installation script](../../10.Downloads/docs.md#Express-installation)
 
 ## Removed previous stable APT repositories
 


### PR DESCRIPTION
Cherry picked from commit 04b8cac8f1fd4062ec9af1d3d1e42bc662dc0b8b