### PR TITLE
Clarify that an uncompressed image must be given to mender-artifact.

### DIFF
--- a/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
+++ b/06.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
@@ -119,11 +119,14 @@ mount /dev/(...) /mnt
 mender-snapshot dump --compression gzip > /mnt/root-part.ext4.gz
 ```
 
-!!! Don't forget the `.gz` extension in the target filename.
+!!! Note that if you used compression while creating the snapshot, after
+!!! transferring the image to the build host, you need to uncompress it again
+!!! with `gunzip root-part.ext4.gz`. Mender-artifact cannot use a compressed
+!!! image as input.
 
-In this case, passing `root-part.ext4` (or `root-part.ext4.gz`) as the 
-file-parameter to [mender-artifact](../../10.Downloads/docs.md#mender-artifact)
-produces a deployment ready Mender Artifact:
+In this case, passing `root-part.ext4` as the file-parameter to
+[mender-artifact](../../10.Downloads/docs.md#mender-artifact) produces a
+deployment ready Mender Artifact:
 ```bash
 mender-artifact write rootfs-image -f /mnt/root-part.ext4 \
                                    -n artifact-name \


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 5fe775b60e9097e44afb85d064799ecc308d3acd)
