### PR TITLE
fix: add missing space to mount with grep command

### DIFF
--- a/03.Client-installation/08.Integration-checklist/docs.md
+++ b/03.Client-installation/08.Integration-checklist/docs.md
@@ -215,7 +215,7 @@ reboot
 After the device boots up verify that you are indeed running on the expected partition:
 
 ``` bash
-mount | grep 'on /'
+mount | grep 'on / '
 # Output:
 #/dev/nvme0n1p3 on / type ext4 ... ...
 ```


### PR DESCRIPTION
Add a space after a slash in grep command to fix mountpoints filtering in _Confirm OS switch using bootloader variables_ section.

Changelog: Title
Ticket: None

Other instances of the same command already have a space after the slash.
The following console dump show the difference between the two commands.

```console
root@testmender:~# mount | grep 'on /'
/dev/mmcblk0p4 on / type ext4 (rw,noatime)
devtmpfs on /dev type devtmpfs (rw,relatime,size=986560k,nr_inodes=246640,mode=755)
proc on /proc type proc (rw,relatime)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
devpts on /dev/pts type devpts (rw,relatime,gid=5,mode=620,ptmxmode=666)
tmpfs on /run type tmpfs (rw,nosuid,nodev,size=408040k,nr_inodes=819200,mode=755)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,size=4096k,nr_inodes=1024,mode=755)
cgroup2 on /sys/fs/cgroup/unified type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate)
cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,name=systemd)
cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
hugetlbfs on /dev/hugepages type hugetlbfs (rw,nosuid,nodev,relatime,pagesize=2M)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
debugfs on /sys/kernel/debug type debugfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,size=1020100k,nr_inodes=1048576)
configfs on /sys/kernel/config type configfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /var/volatile type tmpfs (rw,relatime)
/dev/mmcblk0p1 on /config type ext4 (rw,noatime)
/dev/mmcblk0p5 on /data type ext4 (rw,noatime)
/dev/mmcblk0p3 on /run/media/rootfs_a-mmcblk0p3 type ext4 (rw,relatime)
root@testmender:~# mount | grep 'on / '
/dev/mmcblk0p4 on / type ext4 (rw,noatime)
```