### PR TITLE
CE-390: Amend `boot` partition detection for latest Raspberry Pi OS image

### DIFF
--- a/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
+++ b/01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md
@@ -67,13 +67,13 @@ default location:
 [ui-tabs position="top-left" active="0" theme="lite" ]
 [ui-tab title="Linux"]
 ```bash
-RPI_BOOT="/media/$(whoami)/boot"
+RPI_BOOT="$(find /media/$(whoami)/ -name boot -or -name bootfs)"
 [ ! -d "$RPI_BOOT" ] && echo "ERROR: RPI boot directory not found"
 ```
 [/ui-tab]
 [ui-tab title="Mac OS"]
 ```bash
-RPI_BOOT="/Volumes/boot"
+RPI_BOOT="$(find /Volumes/ -name boot -or -name bootfs)"
 [ ! -d "$RPI_BOOT" ] && echo "ERROR: RPI boot directory not found"
 ```
 [/ui-tab]


### PR DESCRIPTION
The snippet now will find either `boot` or `bootfs` mount point.