### PR TITLE
3.6.x: Promote Mender 3.7 to LTS

### DIFF
--- a/302.Release-information/01.Release-schedule/docs.md
+++ b/302.Release-information/01.Release-schedule/docs.md
@@ -38,10 +38,11 @@ We publish patch versions for older LTS releases roughly the same time we publis
 
 <!-- the version number includes the patch release here, to get picked up by autoversion, but will be a minor version in the result -->
 <!--AUTOVERSION: "LTS releases: %"/lts -->
-At this time, we support the following LTS releases: 3.6.
+At this time, we support the following LTS releases: 3.6, 3.7.
 
 | LTS         | Supported until |
 | ----------- | --------------- |
+| 3.7         |  2024-07        |
 | 3.6         |  2024-07        |
 
 Mender is versioned and released as a Product bundle, and the versions mentioned here refer to the Product bundle version.

--- a/302.Release-information/01.Release-schedule/docs.md
+++ b/302.Release-information/01.Release-schedule/docs.md
@@ -42,7 +42,7 @@ At this time, we support the following LTS releases: 3.6, 3.7.
 
 | LTS         | Supported until |
 | ----------- | --------------- |
-| 3.7         |  2024-07        |
+| 3.7         |  2025-05        |
 | 3.6         |  2024-07        |
 
 Mender is versioned and released as a Product bundle, and the versions mentioned here refer to the Product bundle version.


### PR DESCRIPTION
Cherry-picking #2388 and #2389.