### PR TITLE
test: Update expected number of packages after adding new distro

### DIFF
--- a/10.Downloads/docs.md
+++ b/10.Downloads/docs.md
@@ -1101,7 +1101,7 @@ Then install the package with:
 sudo dpkg -i mender-gateway_*.deb
 ```
 
-<!--AUTOMATION: test=test $(ls mender-gateway_*.deb | wc -l) -eq 12 -->
+<!--AUTOMATION: test=test $(ls mender-gateway_*.deb | wc -l) -eq 15 -->
 <!--AUTOMATION: execute=dpkg -i mender-gateway_*-1+ubuntu+focal_amd64.deb -->
 
 ### Examples package


### PR DESCRIPTION
Missing from 84600922dd9fe13abd92a8795f4042219a28e3ce.

This test only runs on protected branches (master) so the mistake went unnoticed in the PR.