### PR TITLE
fix: Redacted mention of specific Yocto LTS releases

### DIFF
--- a/302.Release-information/01.Release-schedule/docs.md
+++ b/302.Release-information/01.Release-schedule/docs.md
@@ -51,4 +51,4 @@ Under the version of the Product bundle, there are multiple different components
 
 ##### Yocto LTS support
 
-Our [meta-mender Yocto layer](https://github.com/mendersoftware/meta-mender) supports the latest two Yocto LTS releases, which at this time are Kirkstone (4.0) and Dunfell (3.1).
+Our [meta-mender Yocto layer](https://github.com/mendersoftware/meta-mender) supports the latest two [Yocto LTS releases](https://wiki.yoctoproject.org/wiki/Releases).


### PR DESCRIPTION
We support the two latest (at any given time), and this already seems out-dated.

Ticket: Men-7484
Changelog: None
(cherry picked from commit 5bb69024486d56c2b785a182cbdfed8bde7e3740)