### PR TITLE
chore: bump app-update-module to 1.1.0

### DIFF
--- a/06.Artifact-creation/01.Create-an-Artifact/10.Docker-Compose/docs.md
+++ b/06.Artifact-creation/01.Create-an-Artifact/10.Docker-Compose/docs.md
@@ -45,18 +45,18 @@ devices:
 ```bash
 # Install Application Update Module
 mkdir -p /usr/share/mender/modules/v3
-wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/src/app \
+wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app \
         -O /usr/share/mender/modules/v3/app \
         && chmod +x /usr/share/mender/modules/v3/app
 # Install Docker Compose module
 mkdir -p /usr/share/mender/app-modules/v1
-wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/src/app-modules/docker-compose \
+wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/src/app-modules/docker-compose \
         -O /usr/share/mender/app-modules/v1/docker-compose \
         && chmod +x /usr/share/mender/app-modules/v1/docker-compose
 # Install the Configuration files
-wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/conf/mender-app.conf \
+wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app.conf \
         -O /etc/mender/mender-app.conf
-wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/conf/mender-app-docker-compose.conf \
+wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/conf/mender-app-docker-compose.conf \
         -O /etc/mender/mender-app-docker-compose.conf
 ```
 
@@ -75,7 +75,7 @@ on your workstation, then install the Application Update Artifact Generator:
 BINDIR=$HOME/bin
 mkdir -p $BINDIR
 export PATH=$BINDIR:$PATH
-wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/gen/app-gen \
+wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/gen/app-gen \
         -O $BINDIR/app-gen
 chmod +x $BINDIR/app-gen
 ```


### PR DESCRIPTION
Bump app-update-module reference from 1.0.0 to 1.1.0.

Ticket: MEN-7477


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

<!-- AUTOVERSION: "/mendertesting/blob/%"/ignore -->
- [x] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Bump app-update-module reference from 1.0.0 to 1.1.0
