### PR TITLE
chore: add "mender-prepopulate-inactive-partition" feature

### DIFF
--- a/05.Operating-System-updates-Yocto-Project/04.Image-customization/01.Features/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/04.Image-customization/01.Features/docs.md
@@ -108,6 +108,9 @@ only. The behaviour can be modified at any time.
 
 * `mender-testing-enabled` - *internal* - Enable the testing/* layers and functionality.
 
+* `mender-prepopulate-inactive-partition` - Populate the inactive partition with the
+  same contents of the active one, primarily for testing purposes.
+
 ## Default features
 
 By default, no features are enabled, but it is common to include a top level


### PR DESCRIPTION
The "mender-prepopulate-inactive-partition" feature has been added as MENDER_FEATURE to meta-mender, respectively Yocto. This adds the corresponding entry to the image customization features list.


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

<!-- AUTOVERSION: "/mendertesting/blob/%"/ignore -->
- [ ] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
