### PR TITLE
feat: delta troubleshoot snippet works with busybox dd

### DIFF
--- a/301.Troubleshoot/03.Mender-Client/docs.md
+++ b/301.Troubleshoot/03.Mender-Client/docs.md
@@ -427,7 +427,7 @@ You can identify your active root file system (`$ACTIVE_PARTITION` in the follow
 The payload size of the version running on the device can be obtained from `mender-artifact read delta.mender`, check for the variable `rootfs_file_size` and use it as `$PAYLOAD_SIZE` in the following `dd`.
 
 ```bash
-dd if=/dev/$ACTIVE_PARTITION bs=1M count=$PAYLOAD_SIZE iflag=count_bytes | sha256sum -
+dd if=/dev/"$ACTIVE_PARTITION" bs=1M count=$(expr "$PAYLOAD_SIZE" / 1048576) | sha256sum -
 ```
 
 #### Common root causes for having inconsistent checksums


### PR DESCRIPTION
Makes the snippet to troubleshoot deltas work on devices with busybox dd.

Proof it gives the same results as the previous command:
![image](https://github.com/user-attachments/assets/b08315a9-55eb-4240-bc56-43f489916ead)

