### PR TITLE
docs: Replace libssl1.1 `mender-artifact` with deb packages

### DIFF
--- a/01.Get-started/03.Deploy-an-operating-system-update/docs.md
+++ b/01.Get-started/03.Deploy-an-operating-system-update/docs.md
@@ -22,42 +22,29 @@ You should:
 
 ### Step 1 - Download the mender-artifact utility on your workstation
 
-!!! If you already installed `mender-artifact` on your system, you can skip this step.
+!!! The simplest installation instructions for `mender-artifact` are covered below, see
+!!! [Downloads](../../10.Downloads/docs.md#mender-artifact) for installation alternatives such as
+!!! setting up package repositories.
 
-Prepare destination directory:
+On Linux, download the `mender-artifact` deb package and install it:
 
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+```bash
+wget https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2B$(. /etc/os-release; echo $ID)%2B$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb
+sudo dpkg --install mender-artifact_3.11.3-1+$(. /etc/os-release; echo $ID)+$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb
+```
+
+On MacOS, download the `mender-artifact` binary, give exec permissions, and add it to your path:
+
+<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
 mkdir -p ${HOME}/bin
-```
-
-Download the `mender-artifact` binary. If you're on Linux
-
-<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-```bash
-wget https://downloads.mender.io/mender-artifact/3.11.3/linux/mender-artifact -O ${HOME}/bin/mender-artifact
-```
-
-On MacOS
-
-<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-```bash
 wget https://downloads.mender.io/mender-artifact/3.11.3/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
-```
-
-
-Make the `mender-artifact` binary executable:
-
-```bash
 chmod +x ${HOME}/bin/mender-artifact
-```
-
-Add `${HOME}/bin` to `PATH`:
-
-```bash
 export PATH="${PATH}:${HOME}/bin"
 ```
 
-!!! Add above to `~/.bashrc` or equivalent to make it persistent across multiple
+!!! Add the last line from above to `~/.bashrc` or equivalent to make it persistent across multiple
 !!! terminal sessions.
 
 ## Step 2 - Setup shell variables on your workstation
@@ -201,7 +188,7 @@ order to deploy it to your device.
 
 Once this deployment finishes it will have the effect of restoring your full
 device root filesystem to the same state as when you created the snapshot in Step 3.
-You can verify this by checking if `/greetings.txt` eists after the deployment has finished.
+You can verify this by checking if `/greetings.txt` exists after the deployment has finished.
 It is gone! This is because your device filesystem did not have this file
 at the time you created the snapshot. This works for any change in the filesystem,
 including removing or installing software and changing any configuration.

--- a/01.Get-started/04.Deploy-a-container-update/docs.md
+++ b/01.Get-started/04.Deploy-a-container-update/docs.md
@@ -69,42 +69,29 @@ download an image.
 
 ### Step 2 - Download the mender-artifact utility on your workstation
 
-!!! If you already installed `mender-artifact` on your system, you can skip this step.
+!!! The simplest installation instructions for `mender-artifact` are covered below, see
+!!! [Downloads](../../10.Downloads/docs.md#mender-artifact) for installation alternatives such as
+!!! setting up package repositories.
 
-Prepare destination directory:
+On Linux, download the `mender-artifact` deb package and install it:
 
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+```bash
+wget https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2B$(. /etc/os-release; echo $ID)%2B$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb
+sudo dpkg --install mender-artifact_3.11.3-1+$(. /etc/os-release; echo $ID)+$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb
+```
+
+On MacOS, download the `mender-artifact` binary, give exec permissions, and add it to your path:
+
+<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
 ```bash
 mkdir -p ${HOME}/bin
-```
-
-Download the `mender-artifact` binary. If you're on Linux
-
-<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-```bash
-wget https://downloads.mender.io/mender-artifact/3.11.3/linux/mender-artifact -O ${HOME}/bin/mender-artifact
-```
-
-On MacOS
-
-<!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-```bash
 wget https://downloads.mender.io/mender-artifact/3.11.3/darwin/mender-artifact -O ${HOME}/bin/mender-artifact
-```
-
-
-Make the `mender-artifact` binary executable:
-
-```bash
-chmod +x "${HOME}/bin/mender-artifact"
-```
-
-Add `${HOME}/bin` to `PATH`:
-
-```bash
+chmod +x ${HOME}/bin/mender-artifact
 export PATH="${PATH}:${HOME}/bin"
 ```
 
-!!! Add above to `~/.bashrc` or equivalent to make it persistent across multiple
+!!! Add the last line from above to `~/.bashrc` or equivalent to make it persistent across multiple
 !!! terminal sessions.
 
 
@@ -192,6 +179,6 @@ There is an alternative option for deploying containerized updates:
 
 * *[Docker Compose Update Module](../../06.Artifact-creation/01.Create-an-Artifact/10.Docker-Compose)* provides an interface for deploying container workloads managed by Docker Compose.
 
-You can explore other types of updates available by extending the Mender client
+You can explore other types of updates available by extending the Mender Client
 in the
 [Update Modules category in the Mender Hub community platform](https://hub.mender.io/c/update-modules/13?target=_blank).

--- a/10.Downloads/docs.md
+++ b/10.Downloads/docs.md
@@ -13,7 +13,7 @@ process:
 ## Disk images
 
 These disk images (`*.img` or `*.sdimg`) are based on images provided by board
-manufacturers and are ready to install the Mender client. They are used to
+manufacturers and are ready to install the Mender Client. They are used to
 provision the device storage for devices without Mender running already.
 
 Mender provides images based on the following distributions:
@@ -52,42 +52,33 @@ See [Artifact creation](../06.Artifact-creation/chapter.md) for more information
 use this utility.
 
 Follow the correct link according to your host platform to download
-`mender-artifact` as a standalone utility:
+`mender-artifact` deb package or as an standalone utility:
 
-<!--AUTOVERSION: "keeps \"%\" version"/ignore-->
-<!-- The second column points to pre-release software and keeps "master" version in the name and link -->
-<!--AUTOVERSION: "mender-artifact %][x.x.x_mender-artifact-"/mender-artifact "mender-artifact %][%_mender-artifact-"/ignore-->
-| Platform | Download link                                          |                                                                       |
-|----------|--------------------------------------------------------|-----------------------------------------------------------------------|
-| Linux    | [mender-artifact 3.11.3][x.x.x_mender-artifact-linux]  | [mender-artifact master][master_mender-artifact-linux] (Pre-release)  |
-| Mac OS X | [mender-artifact 3.11.3][x.x.x_mender-artifact-darwin] | [mender-artifact master][master_mender-artifact-darwin] (Pre-release) |
+<!--AUTOVERSION: "mender-artifact %][x.x.x_mender-artifact-"/mender-artifact -->
+| Platform          | Download link                                             |
+|-------------------|-----------------------------------------------------------|
+| Ubuntu 24.04      | [mender-artifact 3.11.3][x.x.x_mender-artifact-debian12]   |
+| Ubuntu 22.04      | [mender-artifact 3.11.3][x.x.x_mender-artifact-debian11]   |
+| Ubuntu 20.04      | [mender-artifact 3.11.3][x.x.x_mender-artifact-ubuntu2404] |
+| Debian 12         | [mender-artifact 3.11.3][x.x.x_mender-artifact-ubuntu2204] |
+| Debian 11         | [mender-artifact 3.11.3][x.x.x_mender-artifact-ubuntu2004] |
+| Mac OS X (x86-64) | [mender-artifact 3.11.3][x.x.x_mender-artifact-darwin]     |
 
-!!! The `mender-artifact` pre-built binaries depend on OpenSSL 1.1 shared library. If you are
-!!! running a system that has already migrated to OpenSSL 3, like Alpine Linux 3.17 or Ubuntu 22.04,
-!!! you cannot run the binary directly. Follow one of these workarounds:
-!!! * For Alpine Linux, install the `openssl1.1-compat` package
-!!! * For Ubuntu 22.04 or newer, the recommended process is to install `mender-artifact` through the
+!!! * For Debian and Ubuntu, you can also install `mender-artifact` through the
 !!! [Mender APT repositories](#install-using-the-apt-repository).
-!!! * For the other cases where the distribution does not provide a compatibility package, build
-!!! `mender-artifact` from the source.
 
-Remember to add execute permission and ensure that the mender-artifact utility is in a directory that is specified in your [PATH environment variable](https://en.wikipedia.org/wiki/PATH_(variable)?target=_blank). Most systems automatically have `/usr/local/bin` in your PATH so the following should allow proper execution and location of this binary.
-
-<!--AUTOMATION: ignore -->
-```bash
-sudo chmod +x mender-artifact
-sudo cp mender-artifact /usr/local/bin/
-```
-
-Please refer to your host Operating System documentation for more details.
-
-
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+[x.x.x_mender-artifact-debian12]: https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2Bdebian%2Bbookworm_amd64.deb
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+[x.x.x_mender-artifact-debian11]: https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2Bdebian%2Bbullseye_amd64.deb
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+[x.x.x_mender-artifact-ubuntu2404]: https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2Bubuntu%2Bnoble_amd64.deb
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+[x.x.x_mender-artifact-ubuntu2204]: https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2Bubuntu%2Bjammy_amd64.deb
+<!--AUTOVERSION: "mender-artifact_%-1"/mender-artifact -->
+[x.x.x_mender-artifact-ubuntu2004]: https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_3.11.3-1%2Bubuntu%2Bfocal_amd64.deb
 <!--AUTOVERSION: "mender-artifact/%/"/mender-artifact -->
-[x.x.x_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/3.11.3/linux/mender-artifact
 [x.x.x_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/3.11.3/darwin/mender-artifact
-<!--AUTOVERSION: "[%_mender-artifact-"/ignore "mender-artifact/%/"/ignore -->
-[master_mender-artifact-linux]: https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
-[master_mender-artifact-darwin]: https://downloads.mender.io/mender-artifact/master/darwin/mender-artifact
 
 ! If you are using Mac OS X, note that using `mender-artifact` with
 ! disk image files (e.g.: `*.sdimg`, `*.img`, or others holding the storage
@@ -98,12 +89,12 @@ Please refer to your host Operating System documentation for more details.
 !!! `mender-artifact` binary is shipped also in [mender-ci-tools Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools). More information [here](../06.Artifact-creation/10.CI-CD/docs.md#mender-ci-workflows-docker-image).
 
 
-## Mender client
+## Mender Client
 
-The Mender client runs on the device, checks for and installs
+The Mender Client runs on the device, checks for and installs
 software updates packaged as Mender Artifacts.
 See [Client installation](../03.Client-installation/chapter.md) for more information
-about how to configure and use the Mender client.
+about how to configure and use the Mender Client.
 
 The `mender-client` Debian package includes the legacy Mender Client written in Go (version 3.x.y),
 and it installs:
@@ -133,7 +124,7 @@ different components than the legacy one. The `mender-client4` Debian package in
 
 ### Installation methods
 
-You can install the Mender client in different ways depending on your preference.
+You can install the Mender Client in different ways depending on your preference.
 
 * Express installation using the [convenience
   script](#express-installation) from [https://get.mender.io](https://get.mender.io).
@@ -143,9 +134,9 @@ You can install the Mender client in different ways depending on your preference
 #### Express installation
 
 Mender provides a convenience script available at [get.mender.io
-](https://get.mender.io) that non-interactively installs the Mender client
+](https://get.mender.io) that non-interactively installs the Mender Client
 [using the package manager](#install-using-the-apt-repository). Users installing
-the Mender client this way, should be aware that:
+the Mender Client this way, should be aware that:
 
 * The script requires `root` privileges to run. Therefore, carefully examine the
   script before executing it.


### PR DESCRIPTION
OpenSSL 1.1 has been replaced in latest Ubuntu and Debian releases and, most importantly, Ubuntu does not provide an openssl1.1 compatibility package, which runs our pre-compiled binary unusable there.

Instead of having two binaries, one per each OpenSSL version, we link now directly into the deb packages as the preferred method to install the tool on Linux.

On Mac the support has not changed, but we add the architecture to make it explicit where the binary is expected to work.

As a side effect of using deb packages, we cannot offer anymore a reliable link to the pre-release version, so we remove these from the table. The master versions are still accessible via APT experimental repositories for the advance users.

Ticket: MEN-7767

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 19890ed3f156e8461829ae8bef6a301881ab43c9)


# External Contributor Checklist

<!-- AUTOVERSION: "/mender/blob/%"/ignore -->
🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

<!-- AUTOVERSION: "/mendertesting/blob/%"/ignore -->
- [ ] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
