### PR TITLE
Removed extra open paren "(" from Hypertext links.

### DIFF
--- a/07.Server-installation/01.Overview/01.Architecture/docs.md
+++ b/07.Server-installation/01.Overview/01.Architecture/docs.md
@@ -102,6 +102,6 @@ The Mender Enterprise Server includes different implementations of some of the s
 Services are delivered as Docker images, available from the official
 [Mender Docker repository](https://hub.docker.com/r/mendersoftware/?target=_blank).
 When required, each service can be built directly from its source code. Consult the
-[mender-server]((https://github.com/mendersoftware/mender-server) and the
-[mender-server-enterprise]((https://github.com/mendersoftware/mender-server-enterprise)
+[mender-server](https://github.com/mendersoftware/mender-server) and the
+[mender-server-enterprise](https://github.com/mendersoftware/mender-server-enterprise)
 repositories for build instructions.


### PR DESCRIPTION
docs: Remove extra parens from Hypertext links

Remove the extra parens present in the Hypertext links for the "mender-server" and "mender-server-enterprise" references at the end of the page.

Changelog: None
Ticket: None

Signed-off-by: BJ Kowalski <BJ.Kowalski@gmail.com>
