### PR TITLE
chore: Add missing `sudo` in sytemctl command

### DIFF
--- a/01.Get-started/05.Monitor/docs.md
+++ b/01.Get-started/05.Monitor/docs.md
@@ -243,7 +243,7 @@ Once the service exits, an alert is sent.
 Restarting the service will send an ok Alert.
 
 ```bash
-systemctl restart countdown
+sudo systemctl restart countdown
 ```
 
 To stop the monitoring, disable and delete the check


### PR DESCRIPTION
The rest of the commands in this tutorial either have `sudo` or an explicit mention to be run as root.