### PR TITLE
MEN-6774: Remove limitation of delta not working on UBIFS

### DIFF
--- a/06.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
+++ b/06.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
@@ -10,7 +10,8 @@ Generation of the delta is something you would execute on a command line of a ma
 
 For a step by step working example please check the [mender hub post](https://hub.mender.io/t/robust-delta-update-rootfs/1144).
 
-!! Delta updates aren't supported with devices running UBIFS. If this is your use case please contact us at support@mender.io
+<!--AUTOVERSION: " version %"/ignore-->
+!!! Delta updates for UBIFS are supported from `mender-binary-delta` version 1.5.0.
 
 ### Prerequisites
 


### PR DESCRIPTION
Replacing it with an info tip about the version implementing it.

It was implemented one year ago.