### PR TITLE
Add support index

### DIFF
--- a/01.Get-started/01.Preparation/docs.md
+++ b/01.Get-started/01.Preparation/docs.md
@@ -52,8 +52,8 @@ For other device types and OSes, we provide documentation to integrate with Mend
 
 * Learn how to integrate devices with [Debian family](../../04.Operating-System-updates-Debian-family) or 
   [Yocto OSes](../../05.Operating-System-updates-Yocto-Project)
-* Or visit [Board Integrations](https://hub.mender.io/c/board-integrations?target=_blank) on 
-  Mender Hub and search for your device and OS [Community Board Integrations Index](https://hub.mender.io/t/board-support-index/5742/5).
+* Visit [Mender Hub Board Integrations](https://hub.mender.io/c/board-integrations?target=_blank) for community discussions on different board integrations
+* Visit [Mender Hub - Community Board Integrations Index](https://hub.mender.io/t/board-support-index/5742/5)for a list community supported boards
 
 !!! We recommend running through the Get Started guide with a Raspberry Pi or virtual device to 
 !!! learn the basics before diving into other board integrations.

--- a/01.Get-started/01.Preparation/docs.md
+++ b/01.Get-started/01.Preparation/docs.md
@@ -53,7 +53,7 @@ For other device types and OSes, we provide documentation to integrate with Mend
 * Learn how to integrate devices with [Debian family](../../04.Operating-System-updates-Debian-family) or 
   [Yocto OSes](../../05.Operating-System-updates-Yocto-Project)
 * Visit [Mender Hub Board Integrations](https://hub.mender.io/c/board-integrations?target=_blank) for community discussions on different board integrations
-* Visit [Mender Hub - Community Board Integrations Index](https://hub.mender.io/t/board-support-index/5742/5)for a list community supported boards
+* Visit [Mender Hub - Community Board Integrations Index](https://hub.mender.io/t/board-support-index/5742/5)for a list of community contributed boards and their status
 
 !!! We recommend running through the Get Started guide with a Raspberry Pi or virtual device to 
 !!! learn the basics before diving into other board integrations.

--- a/01.Get-started/01.Preparation/docs.md
+++ b/01.Get-started/01.Preparation/docs.md
@@ -53,7 +53,7 @@ For other device types and OSes, we provide documentation to integrate with Mend
 * Learn how to integrate devices with [Debian family](../../04.Operating-System-updates-Debian-family) or 
   [Yocto OSes](../../05.Operating-System-updates-Yocto-Project)
 * Or visit [Board Integrations](https://hub.mender.io/c/board-integrations?target=_blank) on 
-  Mender Hub and search for your device and OS.
+  Mender Hub and search for your device and OS [Community Board Integrations Index](https://hub.mender.io/t/board-support-index/5742/5).
 
 !!! We recommend running through the Get Started guide with a Raspberry Pi or virtual device to 
 !!! learn the basics before diving into other board integrations.


### PR DESCRIPTION

```
fix: Adding support index to prepartaion document

To make is quicker for the user to get to the index of community supported devices
Changelog: Add support index to 01.Get-started/01.Preparation/docs.md
Ticket: ME-490
```
