### PR TITLE
fix: Prevent automation from running `brew install`

### DIFF
--- a/01.Get-started/03.Deploy-an-operating-system-update/docs.md
+++ b/01.Get-started/03.Deploy-an-operating-system-update/docs.md
@@ -40,6 +40,7 @@ sudo dpkg --install mender-artifact_4.1.0-1+$(. /etc/os-release; echo $ID)+$(. /
 
 On MacOS, install `mender-artifact` from `brew` using:
 
+<!--AUTOMATION: ignore -->
 ```bash
 brew install mender-artifact
 ```

--- a/11.Downloads/docs.md
+++ b/11.Downloads/docs.md
@@ -80,6 +80,7 @@ repositories](#install-using-the-apt-repository).
 
 Use `brew` to install `mender-artifact` from [the Homebrew repository](https://brew.sh/):
 
+<!--AUTOMATION: ignore -->
 ```bash
 brew install mender-artifact
 ```
@@ -471,6 +472,7 @@ Please refer to your host Operating System documentation for more details.
 
 Use `brew` to install `mender-cli` from [the Homebrew repository](https://brew.sh/):
 
+<!--AUTOMATION: ignore -->
 ```bash
 brew install mender-cli
 ```


### PR DESCRIPTION
`brew` is not available in the environment testing the commands.

Ticket: MEN-8333
Changelog: none
