### PR TITLE
fix: indent call outs in device API version section

### DIFF
--- a/302.Release-information/01.Supported-releases/docs.md
+++ b/302.Release-information/01.Supported-releases/docs.md
@@ -71,12 +71,12 @@ to be available. For all other endpoints it will use v1.
 | API v2     | 3.0    | 1.0     | 3.0    |
 
 !!! Make sure to upgrade the Server first to support a new API version. Next it is
-recommended to update any Gateway components and finally Client.
+!!! recommended to update any Gateway components and finally Client.
 
 !!! So far, Mender Server supports all Device API versions ever released. In other words,
-a current Mender Server will still work with Mender Client v1.0. However, it is good practice
-and required for commercial support to regularly update all your Mender components to
-ensure they all run supported versions. This will prevent issues in the future.
+!!! a current Mender Server will still work with Mender Client v1.0. However, it is good practice
+!!! and required for commercial support to regularly update all your Mender components to
+!!! ensure they all run supported versions. This will prevent issues in the future.
 
 
 ## Mender Client subcomponents


### PR DESCRIPTION
Follow-up on closed https://github.com/mendersoftware/mender-docs/pull/2598 (had problems with CI not recognizing my sign-off)

Attempts to fix the indentation for call-outs in https://docs.mender.io/release-information/supported-releases#mender-client-subcomponents

![image](https://github.com/user-attachments/assets/3dbb1e79-eeb6-4436-8705-8cdec69ceee9)

I am assuming MkDocs is used to generate the documentation and that requires multi-line call-outs to be indented https://squidfunk.github.io/mkdocs-material/reference/admonitions/#usage so they are rendered as one piece.

Tested by locally running  `mender-docs-site`