### PR TITLE
chore: Update build from source page

### DIFF
--- a/12.General/01.Build-from-source/docs.md
+++ b/12.General/01.Build-from-source/docs.md
@@ -15,25 +15,25 @@ and can contain project specific settings.
 
 ## Project repositiories list
 
-| Name                    | Type     | Link                                                      |
-|-------------------------|----------|-----------------------------------------------------------|
-| mender                  | CMake    | https://github.com/mendersoftware/mender                  |
-| mender-artifact         | make     | https://github.com/mendersoftware/mender-artifact         |
-| mender-cli              | make     | https://github.com/mendersoftware/mender-cli              |
-| mender-configure-module | make     | https://github.com/mendersoftware/mender-configure-module |
-| mender-connect          | make     | https://github.com/mendersoftware/mender-connect          |
-| mender-convert          | scripts  | https://github.com/mendersoftware/mender-convert          |
-| mender-dist-packages    | scripts  | https://github.com/mendersoftware/mender-dist-packages    |
-| mender-docs             | scripts  | https://github.com/mendersoftware/mender-docs             |
-| mender-flash            | CMake    | https://github.com/mendersoftware/mender-flash            |
-| mender-mcu              | custom   | https://github.com/mendersoftware/mender-mcu              |
-| mender-mcu-integration  | custom   | https://github.com/mendersoftware/mender-mcu-integration  |
-| mender-qa               | scripts  | https://github.com/mendersoftware/mender-qa               |
-| mender-setup            | make     | https://github.com/mendersoftware/mender-setup            |
-| mender-snapshot         | make     | https://github.com/mendersoftware/mender-snapshot         |
-| mender-test-containers  | scripts  | https://github.com/mendersoftware/mender-test-containers  |
-| mendertesting           | scripts  | https://github.com/mendersoftware/mendertesting           |
-| meta-mender             | scripts  | https://github.com/mendersoftware/meta-mender             |
+| Name                                                                                 | Type    |
+|--------------------------------------------------------------------------------------|---------|
+| [mender](https://github.com/mendersoftware/mender)                                   | CMake   |
+| [mender-artifact](https://github.com/mendersoftware/mender-artifact)                 | make    |
+| [mender-cli](https://github.com/mendersoftware/mender-cli)                           | make    |
+| [mender-configure-module](https://github.com/mendersoftware/mender-configure-module) | make    |
+| [mender-connect](https://github.com/mendersoftware/mender-connect)                   | make    |
+| [mender-convert](https://github.com/mendersoftware/mender-convert)                   | scripts |
+| [mender-dist-packages](https://github.com/mendersoftware/mender-dist-packages)       | scripts |
+| [mender-docs](https://github.com/mendersoftware/mender-docs)                         | scripts |
+| [mender-flash](https://github.com/mendersoftware/mender-flash)                       | CMake   |
+| [mender-mcu](https://github.com/mendersoftware/mender-mcu)                           | custom  |
+| [mender-mcu-integration](https://github.com/mendersoftware/mender-mcu-integration)   | custom  |
+| [mender-qa](https://github.com/mendersoftware/mender-qa)                             | scripts |
+| [mender-setup](https://github.com/mendersoftware/mender-setup)                       | make    |
+| [mender-snapshot](https://github.com/mendersoftware/mender-snapshot)                 | make    |
+| [mender-test-containers](https://github.com/mendersoftware/mender-test-containers)   | scripts |
+| [mendertesting](https://github.com/mendersoftware/mendertesting)                     | scripts |
+| [meta-mender](https://github.com/mendersoftware/meta-mender)                         | scripts |
 
 ## make based project general rules
 


### PR DESCRIPTION
Build from source page aims to the project repositories we are hosting on GitHub. Instead of using plain text for the repo addresses I changed them to direct hyperlinks.

Ticket: None
Changelog: None
