### PR TITLE
chore: Update versions for Mender Client LTS 5.0

### DIFF
--- a/02.Overview/02.Device-Support/docs.md
+++ b/02.Overview/02.Device-Support/docs.md
@@ -99,7 +99,7 @@ community post for steps to create one.
 
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 You can compile the Mender Client for a wide variety of architectures. Follow the steps in the
-[README.md](https://github.com/mendersoftware/mender/tree/5.0.1?target=_blank#installing-from-source)
+[README.md](https://github.com/mendersoftware/mender/tree/5.0.2?target=_blank#installing-from-source)
 of the Mender Client source repository. This is also the first step to a board integration for other types of Linux OSes.
 
 
@@ -108,7 +108,7 @@ of the Mender Client source repository. This is also the first step to a board i
 <!--AUTOVERSION: "mender/tree/%?target=_blank"/mender -->
 For a POSIX compliant OS it may be possible to compile the Mender Client to run natively,
 as outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/5.0.1?target=_blank#installing-from-source).
+[README.md](https://github.com/mendersoftware/mender/tree/5.0.2?target=_blank#installing-from-source).
 
 For other types of OSes you can either use a nearby Linux system to update it via a
 [proxy deployment](../../02.Overview/01.Introduction/docs.md#proxy-deployments) or

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -123,7 +123,7 @@ sudo systemctl restart mender-updated
 <!--AUTOVERSION: "mender/tree/%#installing-from-source"/mender -->
 As an alternative to using a Debian package, it is possible to install the
 Mender Client from source by following the guidelines outlined in the
-[README.md](https://github.com/mendersoftware/mender/tree/5.0.1#installing-from-source?target=_blank)
+[README.md](https://github.com/mendersoftware/mender/tree/5.0.2#installing-from-source?target=_blank)
 of the Mender Client source repository.
 
 

--- a/03.Client-installation/03.Identity/docs.md
+++ b/03.Client-installation/03.Identity/docs.md
@@ -96,6 +96,6 @@ cpuid=1234123-ABC
 ## Example device identity executables
 
 <!--AUTOVERSION: "mender/tree/%"/mender-->
-Example scripts are provided in the [support directory in the Mender Client source code repository](https://github.com/mendersoftware/mender/tree/5.0.1/support?target=_blank).
+Example scripts are provided in the [support directory in the Mender Client source code repository](https://github.com/mendersoftware/mender/tree/5.0.2/support?target=_blank).
 
 

--- a/03.Client-installation/04.Inventory/docs.md
+++ b/03.Client-installation/04.Inventory/docs.md
@@ -121,7 +121,7 @@ a-country=Poland
 a-city=Krakow
 ```
 <!--AUTOVERSION: "mender/tree/%/support"/mender-->
-You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/5.0.1/support) directory.
+You can find some more useful scripts in [https://github.com/mendersoftware/mender/support](https://github.com/mendersoftware/mender/tree/5.0.2/support) directory.
 
 
 ## Default inventory
@@ -133,7 +133,7 @@ By default, and without any inventory scripts added, the Mender Client sends the
 |:----:|:-------:|:-------------:|
 | `device_type`  | type of the device | "raspberrypi4" |
 | `artifact_name` | name of the currently installed artifact | "release-v1" |
-| `mender_client_version` | client version | "5.0.1" |
+| `mender_client_version` | client version | "5.0.2" |
 
 
 ## Final remarks

--- a/03.Client-installation/08.Integration-checklist/docs.md
+++ b/03.Client-installation/08.Integration-checklist/docs.md
@@ -53,7 +53,7 @@ systemctl is-enabled mender-updated
 ```
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/"/mender-->
-In the remaining verification, we will manually be executing similar steps to what the [rootfs-image update module](https://github.com/mendersoftware/mender/blob/5.0.1/support/modules/rootfs-image) usually does in regular operations to communicate with the bootloader.
+In the remaining verification, we will manually be executing similar steps to what the [rootfs-image update module](https://github.com/mendersoftware/mender/blob/5.0.2/support/modules/rootfs-image) usually does in regular operations to communicate with the bootloader.
 
 To avoid the Mender Client interfering with the manual verification it is recommended to disconnect the device from the internet.
 

--- a/05.Operating-System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -116,11 +116,11 @@ MENDER_ARTIFACT_NAME = "release-1"
 # please uncomment the following and set to the required version. If you want to use the bleeding
 # edge version, specify "master-git%", but keep in mind that these versions may not be stable:
 #
-# PREFERRED_VERSION_mender = "5.0.1"
-# PREFERRED_VERSION_mender-client = "5.0.1"
+# PREFERRED_VERSION_mender = "5.0.2"
+# PREFERRED_VERSION_mender-client = "5.0.2"
 # PREFERRED_VERSION_mender-artifact = "4.1.0"
 # PREFERRED_VERSION_mender-artifact-native = "4.1.0"
-# PREFERRED_VERSION_mender-connect = "2.3.0"
+# PREFERRED_VERSION_mender-connect = "2.3.1"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 
@@ -238,11 +238,11 @@ MACHINE = "<YOUR-MACHINE>"
 # please uncomment the following and set to the required version. If you want to use the bleeding
 # edge version, specify "master-git%", but keep in mind that these versions may not be stable:
 #
-# PREFERRED_VERSION_mender = "5.0.1"
-# PREFERRED_VERSION_mender-client = "5.0.1"
+# PREFERRED_VERSION_mender = "5.0.2"
+# PREFERRED_VERSION_mender-client = "5.0.2"
 # PREFERRED_VERSION_mender-artifact = "4.1.0"
 # PREFERRED_VERSION_mender-artifact-native = "4.1.0"
-# PREFERRED_VERSION_mender-connect = "2.3.0"
+# PREFERRED_VERSION_mender-connect = "2.3.1"
 
 # The following settings to enable systemd are needed for all Yocto
 # releases sumo and older.  Newer releases have these settings conditionally

--- a/07.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/07.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -54,7 +54,7 @@ We will use the [single file](https://hub.mender.io/t/single-file/486/26?target=
 First, download the script to generate the Artifact and make it executable:
 <!--AUTOVERSION: "mendersoftware/mender/%/support"/mender-->
 ```
-curl -O https://raw.githubusercontent.com/mendersoftware/mender/5.0.1/support/modules-artifact-gen/single-file-artifact-gen
+curl -O https://raw.githubusercontent.com/mendersoftware/mender/5.0.2/support/modules-artifact-gen/single-file-artifact-gen
 chmod +x single-file-artifact-gen
 ```
 
@@ -80,7 +80,7 @@ be installed in the *rootfs* partition. The resulting file `artifact.mender` hol
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/support"/mender-->
 Inspect the source code of the
-[single file Update Module](https://github.com/mendersoftware/mender/blob/5.0.1/support/modules/single-file?target=_blank)
+[single file Update Module](https://github.com/mendersoftware/mender/blob/5.0.2/support/modules/single-file?target=_blank)
 to learn about the implementation details of this module.
 
 
@@ -94,4 +94,4 @@ will carry the file you have uploaded, the destination
 directory, the filename, and permissions, exactly as we saw above.
 
 <!--AUTOVERSION: "mendersoftware/mender/blob/%/Documentation"/mender-->
-For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/5.0.1/Documentation/update-modules-v3-file-api.md?target=_blank).
+For more details on how to write Update Modules, visit the [Create a custom Update Module](../08.Create-a-custom-Update-Module/docs.md) section and the [Update Module API specification](https://github.com/mendersoftware/mender/blob/5.0.2/Documentation/update-modules-v3-file-api.md?target=_blank).

--- a/07.Artifact-creation/07.Sign-and-verify/docs.md
+++ b/07.Artifact-creation/07.Sign-and-verify/docs.md
@@ -84,7 +84,7 @@ creating the signature.
 ```bash
 mender-artifact write rootfs-image \
 -t beaglebone \
--n mender-5.0.1 \
+-n mender-5.0.2 \
 -f core-image-base-beaglebone.ext4 \
 -k private.key \
 -o artifact-signed.mender

--- a/07.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/07.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -292,4 +292,4 @@ Because of the possible re-execution described above, you should develop Update 
 ## Further reading
 
 <!--AUTOVERSION: "blob/%/Documentation"/mender -->
-* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/5.0.1/Documentation/update-modules-v3-file-api.md?target=_blank)
+* [Update Modules v3 protocol](https://github.com/mendersoftware/mender/blob/5.0.2/Documentation/update-modules-v3-file-api.md?target=_blank)

--- a/09.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/09.Server-integration/02.Preauthorizing-devices/docs.md
@@ -28,7 +28,7 @@ If you have not yet prepared a device visit one of the following:
 When preauthorizing a device you need to know its [identity](../../02.Overview/07.Identity/docs.md). This is one or more key-value attributes, depending on the identity scheme you are using. If you connect your device so it shows up as pending in the Mender Server, you will see its identity in the Mender Server UI. Note that preauthorization is *not* based on the ID of the device, only on the key-value attributes under Identity.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-By default the Mender Client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/5.0.1/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
+By default the Mender Client uses the [MAC address of the first interface](https://github.com/mendersoftware/mender/blob/5.0.2/support/mender-device-identity?target=_blank) on the device as the device identity, for example `mac=02:12:61:13:6c:42`.
 
 
 ### Mender Client and Mender Server connectivity
@@ -61,11 +61,11 @@ We will generate the keys on a separate system (not on the device), and then pro
 We will use a script to generate a key pair the Mender Client understands; it uses the `openssl` command to generate the keys.
 
 <!--AUTOVERSION: "mender/blob/%"/mender-->
-Download the [keygen-client](https://github.com/mendersoftware/mender/blob/5.0.1/support/keygen-client?target=_blank) script into a directory:
+Download the [keygen-client](https://github.com/mendersoftware/mender/blob/5.0.2/support/keygen-client?target=_blank) script into a directory:
 
 <!--AUTOVERSION: "mender/%"/mender-->
 ```bash
-wget https://raw.githubusercontent.com/mendersoftware/mender/5.0.1/support/keygen-client
+wget https://raw.githubusercontent.com/mendersoftware/mender/5.0.2/support/keygen-client
 ```
 
 Ensure it is executable:

--- a/301.Troubleshoot/01.Yocto-project-build/docs.md
+++ b/301.Troubleshoot/01.Yocto-project-build/docs.md
@@ -11,7 +11,7 @@ taxonomy:
 Mender Client version 4.0.0 and later have been split up into several separate components: `mender-auth` and `mender-update`, plus `mender-snapshot` which is now a separate recipe. This also changes the binary names, and just `mender` by itself is not valid anymore. Because of this it is not completely backwards compatible. On the stable Yocto branches 4.0 (kirkstone) and older, the latest major release is the 3.x series, and therefore 4.0 and later are not built by meta-mender unless requested.
 
 <!--AUTOVERSION: "To request version % of the clients"/mender-->
-To request version 5.0.1 of the clients, add a snippet like the following to `local.conf`:
+To request version 5.0.2 of the clients, add a snippet like the following to `local.conf`:
 
 <!--AUTOVERSION: "PREFERRED_VERSION_mender-client = \"%\""/mender-->
 ```
@@ -334,7 +334,7 @@ A typical error message for this condition is:
 Error:
  Problem: package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon requires u-boot, but none of the providers can be installed
   - package grub-efi-mender-precompiled-2.04-r0.cortexa8hf_neon conflicts with u-boot <= 1:2019.07 provided by u-boot-fork-1:2019.07-r0.beaglebone_yocto
-  - package mender-5.0.1-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
+  - package mender-5.0.2-r0.cortexa8hf_neon requires grub-editenv, but none of the providers can be installed
   - conflicting requests
 ```
 


### PR DESCRIPTION
Update `mender` to 5.0.2
Update `mender-connect` to 2.3.1
Update `monitor-client` to 1.4.1

Updated with 
```
./autoversion.py --update --component mender --version 5.0.2
./autoversion.py --update --component mender-connect --version 2.3.1
./autoversion.py --update --component monitor-client --version 1.4.1
```
