### PR TITLE
doc: Update path to correct log file

### DIFF
--- a/01.Get-started/05.Monitor/docs.md
+++ b/01.Get-started/05.Monitor/docs.md
@@ -266,7 +266,7 @@ First, create a check for the `log` monitoring subsystem named `auth_root_sessio
 the following command:
 
 ```bash
-sudo mender-monitorctl create log auth_root_session "Started User Manager for UID 0" /var/log/auth.log
+sudo mender-monitorctl create log auth_root_session "Started User Manager for UID 0" "@journalctl --follow"
 sudo mender-monitorctl enable log auth_root_session
 ```
 


### PR DESCRIPTION
For log processing we use to use `/var/log/auth.log` file, which is not presented on Debian Bookworm. Instead journalctl shall be used for processing the logs.

Ticket: MEN-8618


