### PR TITLE
QA-1017: chore(CODEOWNERS): Remove global ownership, add dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
-# Default owners for everything
-* @mendersoftware/qa-dependabot-reviewers
+# Dependency updates
+go.mod @mendersoftware/qa-dependabot-reviewers
+go.sum @mendersoftware/qa-dependabot-reviewers
+Dockerfile* @mendersoftware/qa-dependabot-reviewers
+*requirements*.txt @mendersoftware/qa-dependabot-reviewers
+package.json @mendersoftware/qa-dependabot-reviewers
+package-lock.json @mendersoftware/qa-dependabot-reviewers


### PR DESCRIPTION
In the context of QA-1017, the original motivation was to move away from deprecated
dependabot reviewers but not necessarily enable code reviewers feature across all files. This commit
amends the original work so that only dependency update related PRs are responsibility of the
client-dependabot-reviewers team