### PR TITLE
chore: Update download page docs

### DIFF
--- a/01.Get-started/03.Deploy-an-operating-system-update/docs.md
+++ b/01.Get-started/03.Deploy-an-operating-system-update/docs.md
@@ -27,7 +27,7 @@ You should:
 ## Step 1 - Download the mender-artifact utility on your workstation
 
 On Linux, `mender-artifact` is available via a package repository for Debian based operating systems.
-For the repo setup and package installation please follow instructions at [Downloads page](../../12.Downloads/docs.md#mender-artifact)
+For the repo setup and package installation please follow instructions at [Downloads page](../../12.Downloads/01.Workstation-tools/docs.md#set-up-the-apt-repository)
 
 On MacOS, install `mender-artifact` from `brew` using:
 

--- a/01.Get-started/05.Monitor/docs.md
+++ b/01.Get-started/05.Monitor/docs.md
@@ -17,7 +17,7 @@ Mender. We will be using the [Monitor Add-on](../../11.Add-ons/20.Monitor/docs.m
 
 ## Prerequisites
 
-To follow this tutorial and perform the examples, you will need to install the [Monitor Add-on package](../../11.Add-ons/20.Monitor/10.Installation/docs.md) and the [Demo monitors package](../../12.Downloads/docs.md#demo-monitors) on your device. 
+To follow this tutorial and perform the examples, you will need to install the [Monitor Add-on package](../../11.Add-ons/20.Monitor/10.Installation/docs.md) and the [Demo monitors package](../../12.Downloads/02.Device-components/docs.md#demo-monitors) on your device.
 If you have followed the [get started tutorial](../01.Preparation/docs.md) to prepare your device, the Monitor Add-on, and Demo packages should already be installed.
 
 Verify installed dependencies on your device with:
@@ -59,7 +59,7 @@ Verify existence of check definitions with:
 ## Demo Checks
 
 
-Demo Checks for the Mender Monitor Add-on, found in the [Demo monitors package](../../12.Downloads/docs.md#demo-monitors) (Debian package) or in the `examples` directory for [Yocto](../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#monitor) serve as a starting point for quick evaluation.
+Demo Checks for the Mender Monitor Add-on, found in the [Demo monitors package](../../12.Downloads/02.Device-components/docs.md#demo-monitors) (Debian package) or in the `examples` directory for [Yocto](../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#monitor) serve as a starting point for quick evaluation.
 Once ready, you can customize and define your own [Checks](../../11.Add-ons/20.Monitor/20.Concepts/docs.md#creating-custom-checks).
 
 By default both mail notifications and UI alerts occur once a monitored event happens.

--- a/01.Get-started/06.Mender-Gateway/docs.md
+++ b/01.Get-started/06.Mender-Gateway/docs.md
@@ -57,7 +57,7 @@ will use to authenticate to the server when downloading the Mender Gateway binar
 [/ui-tab]
 [ui-tab title="enterprise"]
 
-You can find download and installation instructions for on-premise environments on [downloads](../../12.Downloads/docs.md#mender-gateway) page.
+You can find download and installation instructions for on-premise environments on [downloads](../../12.Downloads/02.Device-components/docs.md#mender-gateway) page.
 
 [/ui-tab]
 [/ui-tabs]

--- a/02.Overview/02.Device-Support/docs.md
+++ b/02.Overview/02.Device-Support/docs.md
@@ -50,7 +50,7 @@ Debian family OSes, such as Debian, Ubuntu and Raspberry Pi OS are officially su
 
 #### Board integrations
 
-A board integration for Raspberry Pi OS is available in [the downloads section](../../12.Downloads/docs.md).
+A board integration for Raspberry Pi OS is available in [the downloads section](../../12.Downloads/chapter.md).
 
 To find board integrations for other Debian family OSes,
 go to the [Debian family in the Mender Hub community](https://hub.mender.io/c/board-integrations/debian-family?target=_blank).

--- a/02.Overview/03.Artifact/docs.md
+++ b/02.Overview/03.Artifact/docs.md
@@ -114,7 +114,7 @@ by which Mender Client versions.
 The command-line utility `mender-artifact` is the best way to work directly with
 Mender Artifacts. It allows you to view, create, modify and sign all types of
 Mender Artifacts. Get it in the
-[Downloads section](../../12.Downloads/docs.md#mender-artifact).
+[Downloads section](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact).
 
 Mender also has OS-level integrations for creating Operating System updates as part of
 your existing OS build process. Learn more by reading the following sections:

--- a/03.Client-installation/02.Install-with-Debian-package/01.Upgrading/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/01.Upgrading/docs.md
@@ -145,9 +145,9 @@ gets installed as part of the Mender Client to serve the needs of the external r
 
 #### Upgrade using Debian packages
 
-In the [Mender APT repositories](../../../12.Downloads/docs.md#install-using-the-apt-repository) `mender-client`
+In the [Mender APT repositories](../../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository) `mender-client`
 package corresponds to the Mender Client written in Go (version 3.x.y). This package is installed by default
-from our [Express installation script](../../../12.Downloads/docs.md#express-installation). To upgrade from the
+from our [Express installation script](../../../12.Downloads/02.Device-components/docs.md#express-installation). To upgrade from the
 legacy Mender Client to the 4.x series on Debian and Ubuntu, you can install the `mender-client4` running:
 
 <!--AUTOMATION: ignore -->

--- a/03.Client-installation/02.Install-with-Debian-package/docs.md
+++ b/03.Client-installation/02.Install-with-Debian-package/docs.md
@@ -21,7 +21,7 @@ Mender provides a Debian package (`.deb`) for convenience to install on e.g
 Debian, Ubuntu or Raspberry Pi OS.
 
 See the instructions in our [downloads
-section](../../12.Downloads/docs.md#install-using-the-apt-repository) for the
+section](../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository) for the
 explicit steps required.
 
 ### Configure the Mender Client

--- a/04.Operating-System-updates-Debian-family/03.Customize-Mender/01.Delta-update-support/docs.md
+++ b/04.Operating-System-updates-Debian-family/03.Customize-Mender/01.Delta-update-support/docs.md
@@ -24,7 +24,7 @@ For additional troubleshooting, you can check the [Delta updates troubleshooting
 
 ## Download
 
-Download the `mender-binary-delta` binaries following the [instructions](../../../12.Downloads/docs.md#mender-binary-delta).
+Download the `mender-binary-delta` binaries following the [instructions](../../../12.Downloads/02.Device-components/docs.md#mender-binary-delta).
 
 ## Integrate `mender-binary-delta` into your image
 

--- a/04.Operating-System-updates-Debian-family/03.Customize-Mender/02.Mender-monitor-support/docs.md
+++ b/04.Operating-System-updates-Debian-family/03.Customize-Mender/02.Mender-monitor-support/docs.md
@@ -11,7 +11,7 @@ taxonomy:
 
 ## Download
 
-Download the Mender Monitor Debian package following the [instructions](../../../12.Downloads/docs.md#monitor).
+Download the Mender Monitor Debian package following the [instructions](../../../12.Downloads/02.Device-components/docs.md#monitor).
 
 ## Installing `mender-monitor` in the converted image
 

--- a/05.Operating-System-updates-Yocto-Project/03.Build-for-demo/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/03.Build-for-demo/docs.md
@@ -14,7 +14,7 @@ The build output will most notably include:
 
 !!! If you do not want to build your own images for testing purposes, the 
 !!! [Get started](../../01.Get-started/chapter.md) tutorials provide links to
-!!! several [prebuilt images](../../12.Downloads/docs.md#disk-images).
+!!! several [prebuilt images](../../12.Downloads/00.Disk-images/docs.md#disk-images).
 
 ## What is *meta-mender*?
 

--- a/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md
@@ -19,7 +19,7 @@ filesystem](../../04.Image-customization/02.Read-only-root-filesystem/) section.
 
 ## Download
 
-Download the `mender-binary-delta` binaries following the [instructions](../../../12.Downloads/docs.md#mender-binary-delta).
+Download the `mender-binary-delta` binaries following the [instructions](../../../12.Downloads/02.Device-components/docs.md#mender-binary-delta).
 
 ## Integrate `mender-binary-delta` into the Yocto environment
 

--- a/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -399,7 +399,7 @@ Replace <DIRECTORY-WITH-MENDER-GATEWAY-CONF> with the path to the `mender-gatewa
 
 !!!!! You should not use this package on production devices.
 
-See [Downloads](../../12.Downloads/docs.md#examples-package) for download links for this package.
+See [Downloads](../../12.Downloads/02.Device-components/docs.md#examples-package) for download links for this package.
 
 To integrate it on your Yocto build, add the `meta-mender` demo layer to your build layers:
 

--- a/08.Artifact-creation/01.Create-an-Artifact/09.Kubernetes/docs.md
+++ b/08.Artifact-creation/01.Create-an-Artifact/09.Kubernetes/docs.md
@@ -65,7 +65,7 @@ wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.0.0/co
 ##### Prepare the workstation
 Once your devices are ready, return to your workstation and install the
 Application Update Artifact Generator. First, make sure that you have
-[mender-artifact](../../../12.Downloads/docs.md#mender-artifact) (version >= 3.0) installed
+[mender-artifact](../../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) (version >= 3.0) installed
 on your workstation, then install the Application Update Artifact Generator:
 <!--AUTOVERSION: "app-update-module/%/"/ignore-->
 ```bash
@@ -79,7 +79,7 @@ chmod +x $BINDIR/app-gen
 
 ### Create a deployment
 The `app-gen` script we installed previously extends the
-[mender-artifact](../../../12.Downloads/docs.md#mender-artifact) tool to create
+[mender-artifact](../../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) tool to create
 Artifacts for container updates. We will use this tool to create a Mender
 Artifact containing the Kubernetes manifest and the images used by
 the composition.

--- a/08.Artifact-creation/01.Create-an-Artifact/10.Docker-Compose/docs.md
+++ b/08.Artifact-creation/01.Create-an-Artifact/10.Docker-Compose/docs.md
@@ -68,7 +68,7 @@ wget https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0/co
 ##### Prepare the workstation
 Once your devices are ready, return to your workstation and install the
 Application Update Artifact Generator. First, make sure that you have
-[mender-artifact](../../../12.Downloads/docs.md#mender-artifact) (version >= 3.0) installed
+[mender-artifact](../../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) (version >= 3.0) installed
 on your workstation, then install the Application Update Artifact Generator:
 <!--AUTOVERSION: "app-update-module/%/"/ignore-->
 ```bash
@@ -82,7 +82,7 @@ chmod +x $BINDIR/app-gen
 
 ### Create a deployment
 The `app-gen` script we installed previously extends the
-[mender-artifact](../../../12.Downloads/docs.md#mender-artifact) tool to create
+[mender-artifact](../../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) tool to create
 Artifacts for container updates. We will use this tool to create a Mender
 Artifact containing the Docker Compose manifest and the Docker images used by
 the composition. Including the Docker images is optional, excluding the images
@@ -158,7 +158,7 @@ Once deployed, the device will start serving a simple server on port 8080. You
 can test the application by sending a request to path `/whoami` and the server
 will echo the request.
 To this end, we will leverage the Troubleshoot add-on and start a port-forward
-session using the [mender-cli](../../../12.Downloads/docs.md#mender-cli).
+session using the [mender-cli](../../../12.Downloads/01.Workstation-tools/docs.md#mender-cli).
 ```bash
 mender-cli port-forward <device_id> 8080:8080
 ```

--- a/08.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
+++ b/08.Artifact-creation/02.Create-an-Artifact-with-system-snapshot/docs.md
@@ -21,7 +21,7 @@ image and Mender Artifact that can be deployed to the rest of the device fleet.
 There is support for creating a snapshot Artifact directly from a workstation
 with `mender-artifact` installed, which is usually the easiest approach.
 First, make sure your workstation has the [latest version of
-mender-artifact installed](../../12.Downloads/docs.md#mender-artifact).
+mender-artifact installed](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact).
 
 This approach requires that the golden device
 is reachable and has *ssh* and *sudo* installed. `mender-artifact` accepts a
@@ -125,7 +125,7 @@ mender-snapshot dump --compression gzip > /mnt/root-part.ext4.gz
 !!! image as input.
 
 In this case, passing `root-part.ext4` as the file-parameter to
-[mender-artifact](../../12.Downloads/docs.md#mender-artifact) produces a
+[mender-artifact](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) produces a
 deployment ready Mender Artifact:
 ```bash
 mender-artifact write rootfs-image -f /mnt/root-part.ext4 \

--- a/08.Artifact-creation/03.Modify-an-Artifact/docs.md
+++ b/08.Artifact-creation/03.Modify-an-Artifact/docs.md
@@ -12,7 +12,7 @@ Artifact types, while content modification is only supported for `rootfs-image` 
 ## Prerequisites
 
 All modifications require the `mender-artifact` tool. If you do not yet have this tool, it can be
-downloaded from our [Downloads section](../../12.Downloads/docs.md).
+downloaded from our [Downloads section](../../12.Downloads/chapter.md).
 
 ## Header modification
 

--- a/08.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
+++ b/08.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md
@@ -20,7 +20,7 @@ This tutorial assumes:
 <!-- TODO: Add Debian reference after PR#2240 has been merged -->
 * You have completed the [integration of the mender-binary-delta](../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/01.Delta-update-support/docs.md) into your Yocto built process
   * `mender-binary-delta-generator` is available in `PATH`
-* You have installed [mender-artifact](../../12.Downloads/docs.md#mender-artifact) which is a dependency for `mender-binary-delta-generator`
+* You have installed [mender-artifact](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact) which is a dependency for `mender-binary-delta-generator`
 * You have two Operating System artifacts available to work with
 
 ### Generating the delta - default case

--- a/08.Artifact-creation/05.Server-side-generation-of-Delta-Artifacts/docs.md
+++ b/08.Artifact-creation/05.Server-side-generation-of-Delta-Artifacts/docs.md
@@ -154,6 +154,6 @@ There are many combinations of values, and the resulting delta sizes heavily dep
 and size of the rootfs images in the Artifacts, and resources on the devices. In case you changed the default values 
 of the parameters, it may cause the generation to fail.
 You can always reset them to default values in the settings.
-We suggest testing the values with the [mender-binary-delta-generator](../../12.Downloads/docs.md#mender-binary-delta) 
+We suggest testing the values with the [mender-binary-delta-generator](../../12.Downloads/02.Device-components/docs.md#mender-binary-delta) 
 CLI tool to find a combination that performs well in your Artifacts. Once you want to make these permanent, go to Settings
 and supply the desired values.

--- a/08.Artifact-creation/07.Sign-and-verify/docs.md
+++ b/08.Artifact-creation/07.Sign-and-verify/docs.md
@@ -71,7 +71,7 @@ The resulting `private.key` and `public.key` files are the private and public ke
 
 We use the `mender-artifact` tool to create a signed Artifact. Download the
 prebuilt `mender-artifact` binary for your platform following the links in
-[Downloads section](../../12.Downloads/docs.md#mender-artifact).
+[Downloads section](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact).
 
 There are two ways to sign an Artifact: while creating it with the `write`
 command or for existing artifacts using the `sign` command.

--- a/08.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
+++ b/08.Artifact-creation/08.Create-a-custom-Update-Module/docs.md
@@ -88,7 +88,7 @@ To install the Mender Client on your device, follow the instructions in the [Ins
 
 We will use the `mender-artifact` tool to create the payloads required for Update Modules to work.
 
-First you need to download a prebuilt `mender-artifact` binary for your platform following the links in [Downloads section](../../12.Downloads/docs.md#mender-artifact).
+First you need to download a prebuilt `mender-artifact` binary for your platform following the links in [Downloads section](../../12.Downloads/01.Workstation-tools/docs.md#mender-artifact).
 
 ## Basic example: File copy Update Module
 

--- a/09.Server-installation/09.Direct-upload/docs.md
+++ b/09.Server-installation/09.Direct-upload/docs.md
@@ -17,7 +17,7 @@ This feature drastically reduces the time to upload the Mender artifact to the M
 <!--AUTOVERSION: "version %"/ignore-->
 !!! This feature is available starting from the Mender Server version 3.6.3
 
-* The `mender-cli` tool. You can find information about how to download it and the installation steps in the [Downloads section](../../12.Downloads/docs.md#mender-cli) from this documentation.
+* The `mender-cli` tool. You can find information about how to download it and the installation steps in the [Downloads section](../../12.Downloads/01.Workstation-tools/docs.md#mender-cli) from this documentation.
 
 * To use the direct upload feature, the user must have at least the Deployments Manager and Releases Manager roles.
 

--- a/10.Server-integration/01.Using-the-apis/docs.md
+++ b/10.Server-integration/01.Using-the-apis/docs.md
@@ -152,7 +152,7 @@ It supports use cases for cloud systems, like uploading an Artifact to the Mende
 
 Over time the functionality of `mender-cli` will be extended to simplify the most common use cases for integrating the Mender Server into other backend and cloud systems. If you need to cover other use cases today, follow the [tutorial for cURL instead](#install-curl-and-jq-and-set-up-the-shell-variables).
 
-First install the `mender-cli` tool as described in the [Downloads page](../../12.Downloads/docs.md#mender-cli).
+First install the `mender-cli` tool as described in the [Downloads page](../../12.Downloads/01.Workstation-tools/docs.md#mender-cli).
 
 Then open a terminal and run the following command to log in to your Mender Server.
 

--- a/10.Server-integration/02.Preauthorizing-devices/docs.md
+++ b/10.Server-integration/02.Preauthorizing-devices/docs.md
@@ -48,7 +48,7 @@ Follow the steps in [set up shell variables for cURL](../01.Using-the-apis/docs.
 
 ### Mender-Artifact tool
 
-Download the `mender-artifact` tool from the [Downloads section](../../12.Downloads/docs.md).
+Download the `mender-artifact` tool from the [Downloads section](../../12.Downloads/chapter.md).
 
 ## Generate a client key pair
 

--- a/11.Add-ons/00.Overview/docs.md
+++ b/11.Add-ons/00.Overview/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 
 The add-ons are independent applications grouped in packages. Please consult the below table
 for the complete list of all supported add-ons. You do not need to install any additional components,
-besides [Mender Connect](../../12.Downloads/docs.md#mender-connect) for Troubleshoot package.
+besides [Mender Connect](../../12.Downloads/02.Device-components/docs.md#mender-connect) for Troubleshoot package.
 
 | Add-on name     | Description | Available in add-on package | `mender-connect` required |
 | --------------- | ----------- | ------------ | ------------ |

--- a/11.Add-ons/20.Monitor/10.Installation/docs.md
+++ b/11.Add-ons/20.Monitor/10.Installation/docs.md
@@ -8,6 +8,6 @@ Mender Monitor is a commercial add-on for the Mender project.
 You can install the Mender Monitor add-on into your device image:
 
 * [With Yocto](../../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#monitor)
-* [With a Debian package](../../../12.Downloads/docs.md#monitor)
+* [With a Debian package](../../../12.Downloads/02.Device-components/docs.md#monitor)
 
 For the fastest way to a working example, go to the [getting started section](../../../01.Get-started/05.Monitor/docs.md).

--- a/11.Add-ons/30.File-Transfer/20.Installation/docs.md
+++ b/11.Add-ons/30.File-Transfer/20.Installation/docs.md
@@ -11,7 +11,7 @@ The main requirements are: `mender-auth` and `mender-connect`; please refer
 to the below sections for the details:
 * [mender-convert integration](../../../04.Operating-System-updates-Debian-family/99.Variables/docs.md#mender_addon_connect_install) for installation in the existing images
 * [Yocto projects](../../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#mender-connect) for the installation in a Yocto Project environment
-* [installation with a deb](../../../12.Downloads/docs.md#remote-terminal-add-on) for the installation from the Debian package
+* [installation with a deb](../../../12.Downloads/02.Device-components/docs.md#remote-terminal-add-on) for the installation from the Debian package
 
 Please consult the [configuration section](../../90.Mender-Connect/docs.md#configuration) 
 for the available configuration options.

--- a/11.Add-ons/40.Port-Forward/docs.md
+++ b/11.Add-ons/40.Port-Forward/docs.md
@@ -20,7 +20,7 @@ local port on the device without opening any additional ports.
 
 To enable port forwarding, you will need to install and configure the necessary
 software on the device and your workstation.
-* Install [mender-connect](../../12.Downloads/docs.md#mender-connect) on the
+* Install [mender-connect](../../12.Downloads/02.Device-components/docs.md#mender-connect) on the
   device.
   * Enable port forwarding for [mender-connect
     configuration](../90.Mender-Connect/docs.md#port-forward-configuration). 
@@ -28,7 +28,7 @@ software on the device and your workstation.
   device.
   * [Accept](../../01.Get-started/01.Preparation/01.Prepare-a-Raspberry-Pi-device/docs.md#step-7-accept-the-device)
     the device on the Mender Server.
-* Install [mender-cli](../../12.Downloads/docs.md#mender-cli) on your workstation.
+* Install [mender-cli](../../12.Downloads/01.Workstation-tools/docs.md#mender-cli) on your workstation.
   
 
 ## Port forwarding

--- a/11.Add-ons/50.Remote-Terminal/20.Installation/docs.md
+++ b/11.Add-ons/50.Remote-Terminal/20.Installation/docs.md
@@ -11,7 +11,7 @@ The main requirements are: `mender-auth` and `mender-connect`; please refer
 to the below sections for the details:
 * [mender-convert integration](../../../04.Operating-System-updates-Debian-family/99.Variables/docs.md#mender_addon_connect_install) for installation in the existing images
 * [Yocto projects](../../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#mender-connect) for the installation in a Yocto Project environment
-* [installation with a deb](../../../12.Downloads/docs.md#remote-terminal-add-on) for the installation from the Debian package
+* [installation with a deb](../../../12.Downloads/02.Device-components/docs.md#remote-terminal-add-on) for the installation from the Debian package
 
 Please consult the [configuration section](../../90.Mender-Connect/docs.md#configuration) 
 for the available configuration options.

--- a/11.Add-ons/50.Remote-Terminal/docs.md
+++ b/11.Add-ons/50.Remote-Terminal/docs.md
@@ -13,7 +13,7 @@ device by navigating to Troubleshooting in the device information, and clicking
 ![Troubleshooting Remote terminal](troubleshoot-remote-terminal.png)
 
 All you need is 
-[mender-connect](../../12.Downloads/docs.md#remote-terminal-add-on)
+[mender-connect](../../12.Downloads/02.Device-components/docs.md#remote-terminal-add-on)
 configured and running alongside `mender-auth`, and you can
 get a live terminal where you can freely type commands.
 
@@ -88,7 +88,7 @@ the terminal output which users can later inspect from the
 ## Using your own terminal
 
 It is possible to use the remote terminal feature from you own terminal instead of the UI.
-To achieve this please download the [mender-cli](../../12.Downloads/docs.md#mender-cli) tool.
+To achieve this please download the [mender-cli](../../12.Downloads/01.Workstation-tools/docs.md#mender-cli) tool.
 
 You will need the Device ID and the access token, both accessible from the UI.
 Device ID is available under the UI under `DEVICES -> select device -> Identity -> ID`.

--- a/11.Add-ons/90.Mender-Connect/docs.md
+++ b/11.Add-ons/90.Mender-Connect/docs.md
@@ -24,7 +24,7 @@ portable.
 Please refer to the following sections for the Mender Connect installation:
 * [mender-convert integration](../../04.Operating-System-updates-Debian-family/99.Variables/docs.md#mender_addon_connect_install) for installation in the existing images
 * [Yocto projects](../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#mender-connect) for the installation in a Yocto Project environment
-* [installation with a deb](../../12.Downloads/docs.md#remote-terminal-add-on) for the installation from the Debian package
+* [installation with a deb](../../12.Downloads/02.Device-components/docs.md#remote-terminal-add-on) for the installation from the Debian package
 
 After installation, please refer to the [add-ons subsections](../../11.Add-ons/chapter.md) for the configuration options,
 including the enabling and disabling of the features.

--- a/12.Downloads/00.Disk-images/docs.md
+++ b/12.Downloads/00.Disk-images/docs.md
@@ -1,0 +1,46 @@
+---
+title: Disk images
+taxonomy:
+    category: docs
+markdown:
+    extra: true
+process:
+    twig: true
+---
+
+<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -ne 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
+
+# Disk images
+
+These disk images (`*.img` or `*.sdimg`) are based on images provided by board
+manufacturers and are ready to install the Mender Client. They are used to
+provision the device storage for devices without Mender running already.
+
+Mender provides images based on the following distributions:
+
+* Images for **Raspberry Pi 3** and **Raspberry Pi 4**, which are based on the
+  [Raspberry Pi OS Linux
+  distribution](https://www.raspberrypi.com/software/operating-systems/?target=_blank)
+
+!! Note that we do not offer commercial support for these images. They are based
+!! on images supported by board manufacturers, like the Raspberry Pi Foundation,
+!! and provide the same software and configuration options as the original
+!! images. Please use the support resources available from the board
+!! manufacturer, or [contact us](mailto:contact@mender.io) if you have any
+!! questions on the Mender integration.
+
+| Board                         | OS                              | Disk image                                                                                         | Storage size |
+|-------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------|--------------|
+| Raspberry Pi 3 Model B and B+ | Raspberry Pi OS Bookworm Lite 2024-10-22 | [raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz][raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz] | 8 GB         |
+| Raspberry Pi 4 Model B        | Raspberry Pi OS Bookworm Lite 2024-10-22 | [raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz][raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz] | 8 GB         |
+
+<!--AUTOVERSION: "mender-convert-%.img.xz"/mender-convert -->
+[raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2024-10-22-raspios-lite/arm/2024-10-22-raspios-lite-raspberrypi3_bookworm_64bit-mender-convert-5.0.0.img.xz
+[raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2024-10-22-raspios-lite/arm/2024-10-22-raspios-lite-raspberrypi4_bookworm_64bit-mender-convert-5.0.0.img.xz
+
+You can find images for other devices in our Mender Hub community forum, see
+[Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11?target=_blank) or
+[Yocto Project](https://hub.mender.io/c/board-integrations/yocto-project/10?target=_blank)
+integration posts.
+
+

--- a/12.Downloads/01.Workstation-tools/docs.md
+++ b/12.Downloads/01.Workstation-tools/docs.md
@@ -1,0 +1,195 @@
+---
+title: Workstation tools
+taxonomy:
+    category: docs
+markdown:
+    extra: true
+process:
+    twig: true
+---
+
+# Workstation tools
+
+## Set up the APT repository
+
+Right now we support two package repositories: `workstation-tools` and `device-components`.
+
+Workstation tools repo contains:
+* mender-artifact
+* mender-cli
+
+!!! If you want the bleeding edge version of software, you can use our
+!!! `experimental` repository by replacing `stable` with `experimental` in
+!!! the above command. Do not use the `experimental` repository in production
+!!! as these releases are not fully tested.
+
+<!--AUTOVERSION: "Mender %"/ignore -->
+!!! As of Mender 3.2.1 we deprecated the previous stable repository and stopped updating it. As of Mender 3.3 we removed it.
+
+!!! With APT repo method, you will always install the latest released Mender components. If you need to install a specific version,
+!!! or you want to stick to a specific minor release (e.g., to the latest LTS version), you can manually download the
+!!! Debian packages from the [workstation tools repository](https://downloads.mender.io/repos/workstation-tools/pool/main).
+
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata -->
+
+1. Update the `apt` package index and install required dependencies.
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install --assume-yes \
+    		apt-transport-https \
+    		ca-certificates \
+    		curl \
+    		gnupg \
+            jq
+    ```
+
+2. Add the official Mender GPG key to your trusted `apt` keychain:
+
+    ```bash
+    curl -fsSL https://downloads.mender.io/repos/debian/gpg | sudo tee /etc/apt/trusted.gpg.d/mender.asc
+    ```
+
+    Inspect the GPG key fingerprint and verify that it matches
+    `E6C8 5734 5575 F921 8396  5662 2407 2B80 A1B2 9B00`.
+
+    <!--AUTOMATION: ignore -->
+    ```bash
+    gpg --show-keys --with-fingerprint /etc/apt/trusted.gpg.d/mender.asc
+    ```
+    ```
+    pub   rsa3072 2020-11-13 [SC] [expires: 2026-10-01]
+          E6C8 5734 5575 F921 8396  5662 2407 2B80 A1B2 9B00
+    uid                      Mender Team <mender@northern.tech>
+    sub   rsa3072 2020-11-13 [E] [expires: 2026-10-01]
+    ```
+
+3. Add the Mender repository to your sources list by selecting the architecture
+matching your device.
+
+    First, in order to make sure that there are no mender sources in
+    '/etc/apt/sources.list' lingering from a previous install, run
+
+    <!--AUTOMATION: ignore -->
+    ```bash
+    sudo sed -i.bak -e "\,https://downloads.mender.io/repos/workstation-tools,d" /etc/apt/sources.list
+    ```
+
+    Then add the sources according to your Linux distribution
+
+    !!! For Raspberry OS, use Debian distributions. To know which version is your device running,
+    !!! do `(. /etc/os-release && echo $VERSION_CODENAME)`
+
+    [ui-tabs position="top-left" active="0" theme="lite" ]
+    [ui-tab title="Debian 13"]
+    <!--AUTOMATION: ignore -->
+    ```bash
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/trixie/stable main" \
+     | sudo tee /etc/apt/sources.list.d/mender.list
+    ```
+    [/ui-tab]
+    [ui-tab title="Debian 12"]
+    <!--AUTOMATION: ignore -->
+    ```bash
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/bookworm/stable main" \
+     | sudo tee /etc/apt/sources.list.d/mender.list
+    ```
+    [/ui-tab]
+    [ui-tab title="Debian 11"]
+    <!--AUTOMATION: ignore -->
+    ```bash
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/bullseye/stable main" \
+     | sudo tee /etc/apt/sources.list.d/mender.list
+    ```
+    [/ui-tab]
+    [ui-tab title="Ubuntu 24.04"]
+    <!--AUTOMATION: ignore -->
+    ```bash
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools ubuntu/noble/stable main" \
+     | sudo tee /etc/apt/sources.list.d/mender.list
+    ```
+    [/ui-tab]
+    [ui-tab title="Ubuntu 22.04"]
+    <!--AUTOMATION: ignore -->
+    ```bash
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools ubuntu/jammy/stable main" \
+     | sudo tee /etc/apt/sources.list.d/mender.list
+    ```
+    [/ui-tab]
+    [/ui-tabs]
+
+
+## mender-artifact
+
+The `mender-artifact` utility is used to work with Mender Artifacts,
+which are files with the `.mender` suffix and contain software to be deployed.
+See [Artifact creation](../../08.Artifact-creation/chapter.md) for more information on how to
+use this utility.
+
+### Install using the APT repository
+
+`mender-artifact` is available in the APT repository.
+Follow the steps in [Set up the APT repository](#set-up-the-apt-repository) chapter to enable the repository and install `mender-artifact`.
+
+Update the package index and install the Mender Artifact:
+
+<!--AUTOMATION: ignore -->
+```bash
+sudo apt-get update
+sudo apt-get install mender-artifact
+```
+<!-- AUTOMATION: execute=apt-get update -->
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-client4 -->
+
+### Mac OS X
+
+Use `brew` to install `mender-artifact` from [the Homebrew repository](https://brew.sh/):
+
+<!--AUTOMATION: ignore -->
+```bash
+brew install mender-artifact
+```
+
+! Note that using `mender-artifact` on MacOS with disk image files (e.g.: `*.sdimg`,
+! `*.img`, or others holding the storage partitions) has limited functionality. Commands
+! like `mender-artifact cat` or `mender-artifact cp` will not work due to lack of support
+! for certain utilities on the Mac platform.
+
+
+!!! `mender-artifact` binary is shipped also in [mender-ci-tools Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools). More information [here](../../08.Artifact-creation/10.CI-CD/docs.md#mender-ci-workflows-docker-image).
+
+
+## mender-cli
+
+The `mender-cli` utility enables an easy interface to key use cases
+of the Mender Server API, such as uploading a Mender Artifact, from
+the command line. See [Server integration](../../10.Server-integration/chapter.md) for
+more information.
+
+### Install using the APT repository
+
+`mender-cli` is available in the APT repository.
+Follow the steps in [Set up the APT repository](#set-up-the-apt-repository) chapter to enable the repository and install `mender-cli`.
+
+Update the package index and install the Mender CLI:
+
+<!--AUTOMATION: ignore -->
+```bash
+sudo apt-get update
+sudo apt-get install mender-cli
+```
+<!-- AUTOMATION: execute=apt-get update -->
+<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-client4 -->
+
+### Mac OS X
+
+Use `brew` to install `mender-cli` from [the Homebrew repository](https://brew.sh/):
+
+<!--AUTOMATION: ignore -->
+```bash
+brew install mender-cli
+```
+
+!!! `mender-cli` binary is shipped also in [Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools). More information [here](../../08.Artifact-creation/10.CI-CD/docs.md#mender-ci-workflows-docker-image).
+
+

--- a/12.Downloads/02.Device-components/docs.md
+++ b/12.Downloads/02.Device-components/docs.md
@@ -1,5 +1,5 @@
 ---
-title: Downloads
+title: Device components
 taxonomy:
     category: docs
 markdown:
@@ -7,227 +7,6 @@ markdown:
 process:
     twig: true
 ---
-
-<!-- AUTOMATION: execute=if [ "$TEST_ENTERPRISE" -ne 1 ]; then echo "TEST_ENTERPRISE must be set to 1!"; exit 1; fi -->
-
-# Disk images
-
-These disk images (`*.img` or `*.sdimg`) are based on images provided by board
-manufacturers and are ready to install the Mender Client. They are used to
-provision the device storage for devices without Mender running already.
-
-Mender provides images based on the following distributions:
-
-* Images for **Raspberry Pi 3** and **Raspberry Pi 4**, which are based on the
-  [Raspberry Pi OS Linux
-  distribution](https://www.raspberrypi.com/software/operating-systems/?target=_blank)
-
-!! Note that we do not offer commercial support for these images. They are based
-!! on images supported by board manufacturers, like the Raspberry Pi Foundation,
-!! and provide the same software and configuration options as the original
-!! images. Please use the support resources available from the board
-!! manufacturer, or [contact us](mailto:contact@mender.io) if you have any
-!! questions on the Mender integration.
-
-| Board                         | OS                              | Disk image                                                                                         | Storage size |
-|-------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------|--------------|
-| Raspberry Pi 3 Model B and B+ | Raspberry Pi OS Bookworm Lite 2024-10-22 | [raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz][raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz] | 8 GB         |
-| Raspberry Pi 4 Model B        | Raspberry Pi OS Bookworm Lite 2024-10-22 | [raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz][raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz] | 8 GB         |
-
-<!--AUTOVERSION: "mender-convert-%.img.xz"/mender-convert -->
-[raspios-lite-raspberrypi3_bookworm_64bit-mender-convert.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2024-10-22-raspios-lite/arm/2024-10-22-raspios-lite-raspberrypi3_bookworm_64bit-mender-convert-5.0.0.img.xz
-[raspios-lite-raspberrypi4_bookworm_64bit-mender-convert.img.xz]: https://d4o6e0uccgv40.cloudfront.net/2024-10-22-raspios-lite/arm/2024-10-22-raspios-lite-raspberrypi4_bookworm_64bit-mender-convert-5.0.0.img.xz
-
-You can find images for other devices in our Mender Hub community forum, see
-[Debian Family](https://hub.mender.io/c/board-integrations/debian-family/11?target=_blank) or
-[Yocto Project](https://hub.mender.io/c/board-integrations/yocto-project/10?target=_blank)
-integration posts.
-
-
-# Workstation tools
-
-## Set up the APT repository
-
-Right now we support two package repositories: `workstation-tools` and `device-components`.
-
-Workstation tools repo contains:
-* mender-artifact
-* mender-cli
-
-!!! If you want the bleeding edge version of software, you can use our
-!!! `experimental` repository by replacing `stable` with `experimental` in
-!!! the above command. Do not use the `experimental` repository in production
-!!! as these releases are not fully tested.
-
-<!--AUTOVERSION: "Mender %"/ignore -->
-!!! As of Mender 3.2.1 we deprecated the previous stable repository and stopped updating it. As of Mender 3.3 we removed it.
-
-!!! With APT repo method, you will always install the latest released Mender components. If you need to install a specific version,
-!!! or you want to stick to a specific minor release (e.g., to the latest LTS version), you can manually download the
-!!! Debian packages from the [workstation tools repository](https://downloads.mender.io/repos/workstation-tools/pool/main).
-
-<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata -->
-
-1. Update the `apt` package index and install required dependencies.
-
-    ```bash
-    sudo apt-get update
-    sudo apt-get install --assume-yes --no-install-recommends \
-    		apt-transport-https \
-    		ca-certificates \
-    		curl \
-    		gnupg \
-            jq
-    ```
-
-2. Add the official Mender GPG key to your trusted `apt` keychain:
-
-    ```bash
-    curl -fsSL https://downloads.mender.io/repos/debian/gpg | sudo tee /etc/apt/trusted.gpg.d/mender.asc
-    ```
-
-    Inspect the GPG key fingerprint and verify that it matches
-    `E6C8 5734 5575 F921 8396  5662 2407 2B80 A1B2 9B00`.
-
-    <!--AUTOMATION: ignore -->
-    ```bash
-    gpg --show-keys --with-fingerprint /etc/apt/trusted.gpg.d/mender.asc
-    ```
-    ```
-    pub   rsa3072 2020-11-13 [SC] [expires: 2026-10-01]
-          E6C8 5734 5575 F921 8396  5662 2407 2B80 A1B2 9B00
-    uid                      Mender Team <mender@northern.tech>
-    sub   rsa3072 2020-11-13 [E] [expires: 2026-10-01]
-    ```
-
-3. Add the Mender repository to your sources list by selecting the architecture
-matching your device.
-
-    First, in order to make sure that there are no mender sources in
-    '/etc/apt/sources.list' lingering from a previous install, run
-
-    <!--AUTOMATION: ignore -->
-    ```bash
-    sudo sed -i.bak -e "\,https://downloads.mender.io/repos/workstation-tools,d" /etc/apt/sources.list
-    ```
-
-    Then add the sources according to your Linux distribution
-
-    !!! For Raspberry OS, use Debian distributions. To know which version is your device running,
-    !!! do `(. /etc/os-release && echo $VERSION_CODENAME)`
-
-    [ui-tabs position="top-left" active="0" theme="lite" ]
-    [ui-tab title="Debian 13"]
-    <!--AUTOMATION: ignore -->
-    ```bash
-    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/trixie/stable main" \
-     | sudo tee /etc/apt/sources.list.d/mender.list
-    ```
-    [/ui-tab]
-    [ui-tab title="Debian 12"]
-    <!--AUTOMATION: ignore -->
-    ```bash
-    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/bookworm/stable main" \
-     | sudo tee /etc/apt/sources.list.d/mender.list
-    ```
-    [/ui-tab]
-    [ui-tab title="Debian 11"]
-    <!--AUTOMATION: ignore -->
-    ```bash
-    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/bullseye/stable main" \
-     | sudo tee /etc/apt/sources.list.d/mender.list
-    ```
-    [/ui-tab]
-    [ui-tab title="Ubuntu 24.04"]
-    <!--AUTOMATION: ignore -->
-    ```bash
-    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools ubuntu/noble/stable main" \
-     | sudo tee /etc/apt/sources.list.d/mender.list
-    ```
-    [/ui-tab]
-    [ui-tab title="Ubuntu 22.04"]
-    <!--AUTOMATION: ignore -->
-    ```bash
-    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools ubuntu/jammy/stable main" \
-     | sudo tee /etc/apt/sources.list.d/mender.list
-    ```
-    [/ui-tab]
-    [/ui-tabs]
-
-
-## mender-artifact
-
-The `mender-artifact` utility is used to work with Mender Artifacts,
-which are files with the `.mender` suffix and contain software to be deployed.
-See [Artifact creation](../08.Artifact-creation/chapter.md) for more information on how to
-use this utility.
-
-### Install using the APT repository
-
-`mender-artifact` is available in the APT repository.
-Follow the steps in [Set up the APT repository](#set-up-the-apt-repository) chapter to enable the repository and install `mender-artifact`.
-
-Update the package index and install the Mender Artifact:
-
-<!--AUTOMATION: ignore -->
-```bash
-sudo apt-get update
-sudo apt-get install mender-artifact
-```
-<!-- AUTOMATION: execute=apt-get update -->
-<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-client4 -->
-
-### Mac OS X
-
-Use `brew` to install `mender-artifact` from [the Homebrew repository](https://brew.sh/):
-
-<!--AUTOMATION: ignore -->
-```bash
-brew install mender-artifact
-```
-
-! Note that using `mender-artifact` on MacOS with disk image files (e.g.: `*.sdimg`,
-! `*.img`, or others holding the storage partitions) has limited functionality. Commands
-! like `mender-artifact cat` or `mender-artifact cp` will not work due to lack of support
-! for certain utilities on the Mac platform.
-
-
-!!! `mender-artifact` binary is shipped also in [mender-ci-tools Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools). More information [here](../08.Artifact-creation/10.CI-CD/docs.md#mender-ci-workflows-docker-image).
-
-
-## mender-cli
-
-The `mender-cli` utility enables an easy interface to key use cases
-of the Mender Server API, such as uploading a Mender Artifact, from
-the command line. See [Server integration](../10.Server-integration/chapter.md) for
-more information.
-
-### Install using the APT repository
-
-`mender-cli` is available in the APT repository.
-Follow the steps in [Set up the APT repository](#set-up-the-apt-repository) chapter to enable the repository and install `mender-cli`.
-
-Update the package index and install the Mender CLI:
-
-<!--AUTOMATION: ignore -->
-```bash
-sudo apt-get update
-sudo apt-get install mender-cli
-```
-<!-- AUTOMATION: execute=apt-get update -->
-<!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-client4 -->
-
-### Mac OS X
-
-Use `brew` to install `mender-cli` from [the Homebrew repository](https://brew.sh/):
-
-<!--AUTOMATION: ignore -->
-```bash
-brew install mender-cli
-```
-
-!!! `mender-cli` binary is shipped also in [Docker image](https://hub.docker.com/r/mendersoftware/mender-ci-tools). More information [here](../08.Artifact-creation/10.CI-CD/docs.md#mender-ci-workflows-docker-image).
-
 
 # Device components
 
@@ -348,7 +127,7 @@ matching your device.
 
 The Mender Client runs on the device, checks for and installs
 software updates packaged as Mender Artifacts.
-See [Client installation](../03.Client-installation/chapter.md) for more information
+See [Client installation](../../03.Client-installation/chapter.md) for more information
 about how to configure and use the Mender Client.
 
 The `mender-client` Debian package includes the legacy Mender Client written in Go (version 3.x.y),
@@ -356,9 +135,9 @@ and it installs:
 
 * the binary,
 * a systemd service,
-* the default [identity script](../03.Client-installation/03.Identity/docs.md)
-* the default [inventory scripts](../03.Client-installation/04.Inventory/docs.md)
-* and the default [update modules](../03.Client-installation/05.Use-an-updatemodule/docs.md)
+* the default [identity script](../../03.Client-installation/03.Identity/docs.md)
+* the default [inventory scripts](../../03.Client-installation/04.Inventory/docs.md)
+* and the default [update modules](../../03.Client-installation/05.Use-an-updatemodule/docs.md)
   (and its generators).
 
 The `mender-client4` Debian package includes the 4.x series of the client, which has slightly
@@ -368,9 +147,9 @@ different components than the legacy one. The `mender-client4` Debian package in
 * a `mender-update` package, for doing updates
 * two binaries, `mender-auth` and `mender-update`
 * two systemd services, `mender-authd` and `mender-updated`
-* the default [identity script](../03.Client-installation/03.Identity/docs.md)
-* the default [inventory scripts](../03.Client-installation/04.Inventory/docs.md)
-* and the default [update modules](../03.Client-installation/05.Use-an-updatemodule/docs.md)
+* the default [identity script](../../03.Client-installation/03.Identity/docs.md)
+* the default [inventory scripts](../../03.Client-installation/04.Inventory/docs.md)
+* and the default [update modules](../../03.Client-installation/05.Use-an-updatemodule/docs.md)
   (and its generators).
 * the `mender-flash` tool
 * the `mender-setup` tool
@@ -445,7 +224,7 @@ sudo apt-get upgrade
 ### Install using the APT repository
 
 `mender-client` is available in the APT repository.
-Follow the steps in [Set up the APT repository](#set-up-the-apt-repository-1) chapter to enable the repository and install `mender-client`.
+Follow the steps in [Set up the APT repository](#set-up-the-apt-repository) chapter to enable the repository and install `mender-client`.
 
 Update the package index and install the Mender Client:
 
@@ -461,10 +240,10 @@ sudo apt-get install mender-client4
 ## mender-connect
 
 The easiest way to install Mender Connect on an existing device is by using the
-[Set up the APT repository](#set-up-the-apt-repository-1). The other alternatives include: 
-[mender-convert integration](../04.Operating-System-updates-Debian-family/99.Variables/docs.md#mender_addon_connect_install)
+[Set up the APT repository](#set-up-the-apt-repository). The other alternatives include: 
+[mender-convert integration](../../04.Operating-System-updates-Debian-family/99.Variables/docs.md#mender_addon_connect_install)
 for installation in the existing images,
-and [Yocto projects](../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#mender-connect)
+and [Yocto projects](../../05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md#mender-connect)
 for the installation in a Yocto Project environment.
 
 To install `mender-connect` using Mender APT repository, follow the instructions
@@ -478,8 +257,8 @@ sudo apt-get install mender-connect
 ```
 <!-- AUTOMATION: execute=DEBIAN_FRONTEND=noninteractive apt-get install -y mender-connect -->
 
-!!! You need two applications for any add-on to function: [`mender-auth`](../02.Overview/16.Taxonomy/docs.md),
-!!! one of the components of the Mender Client, and [Mender Connect](../02.Overview/16.Taxonomy/docs.md).
+!!! You need two applications for any add-on to function: [`mender-auth`](../../02.Overview/16.Taxonomy/docs.md),
+!!! one of the components of the Mender Client, and [Mender Connect](../../02.Overview/16.Taxonomy/docs.md).
 !!! If you have used the [express installation](#express-installation) script, you already have both installed.
 
 
@@ -497,12 +276,12 @@ and Mender Connect.
 
 Mender offers a configure extension (`mender-configure`) to the `mender-update` client
 that enables managing device configuration. See the
-[add-on page for Mender Configure](../11.Add-ons/10.Configure/docs.md) for
+[add-on page for Mender Configure](../../11.Add-ons/10.Configure/docs.md) for
 more information.
 
 The easiest way to install Configure on an existing device is by using the
 Mender APT repository. See the [add-on page for Mender
-Configure](../11.Add-ons/10.Configure/docs.md) for more information for other
+Configure](../../11.Add-ons/10.Configure/docs.md) for more information for other
 installation alternatives.
 
 To install `mender-configure` using Mender APT repository, follow the
@@ -520,7 +299,7 @@ sudo apt-get install mender-configure
 !!! Note: The Mender Monitor add-on package is required. See the [Mender features page](https://mender.io/product/features?target=_blank) for an overview of all Mender plans and features.
 
 
-Mender offers a [Monitor](../11.Add-ons/20.Monitor/docs.md) add-on which
+Mender offers a [Monitor](../../11.Add-ons/20.Monitor/docs.md) add-on which
 enables monitoring your devices for events and anomalies.
 
 To install `mender-monitor` using the Mender Monitor Debian package, first
@@ -618,7 +397,7 @@ sudo dpkg -i mender-monitor-demo_1.4.2-1+debian+trixie_all.deb
 !!!!! See [the Mender plans page](https://mender.io/pricing/plans?target=_blank)
 !!!!! for an overview of all Mender plans and features.
 
-Mender offers [Mender Gateway](../10.Server-integration/04.Mender-Gateway/docs.md) which enables
+Mender offers [Mender Gateway](../../10.Server-integration/04.Mender-Gateway/docs.md) which enables
 managing and deploying OTA updates to devices on the local network from a gateway device.
 
 To install `mender-gateway` using the Mender Gateway Debian package, first
@@ -1255,9 +1034,9 @@ The file structure should look like this:
 
 ### The `mender-binary-delta-generator`
 
-You will need this binary on the host to [create a delta between two artifacts](../08.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md) locally.
+You will need this binary on the host to [create a delta between two artifacts](../../08.Artifact-creation/05.Create-a-Delta-update-Artifact/docs.md) locally.
 
-!!! The enterprise plan allows auto generation of [delta images directly on the mender server](../08.Artifact-creation/05.Server-side-generation-of-Delta-Artifacts/docs.md).
+!!! The enterprise plan allows auto generation of [delta images directly on the mender server](../../08.Artifact-creation/05.Server-side-generation-of-Delta-Artifacts/docs.md).
 
 Copy the generator compatible with your workstation architecture to `/usr/bin`; for a `x86_64` one, it should look like this:
 
@@ -1265,6 +1044,5 @@ Copy the generator compatible with your workstation architecture to `/usr/bin`; 
 ```bash
 sudo cp mender-binary-delta-1.5.1/x86_64/mender-binary-delta-generator /usr/bin
 ```
-
 
 

--- a/12.Downloads/chapter.md
+++ b/12.Downloads/chapter.md
@@ -1,0 +1,11 @@
+---
+title: Download
+taxonomy:
+    category: docs
+---
+
+### Chapter 11
+
+# General
+
+Download and install Mender components for the device or tools for your workstation.

--- a/301.Troubleshoot/03.Mender-Client/docs.md
+++ b/301.Troubleshoot/03.Mender-Client/docs.md
@@ -20,7 +20,7 @@ This is caused by using an outdated version of the `mender-artifact` tool (e.g f
 Ubuntu APT repositories) which cannot detect which version of the Mender Client the device is running.
 
 To solve this issue, install `mender-artifact` from the Mender APT repository following the instructons in
-the [downloads section](../../12.Downloads/docs.md#mender-artifact).
+the [downloads section](../../12.Downloads/01.Workstation-tools/docs.md#set-up-the-apt-repository).
 
 ## `fsck` error when creating a Mender Artifact using the snapshot feature
 
@@ -70,11 +70,11 @@ it to the 3.5.2 version by default.
 
 To solve the issue, either:
 * Run `apt-get install mender-client`
-* Run again the [express installation script](../../12.Downloads/docs.md#Express-installation)
+* Run again the [express installation script](../../12.Downloads/02.Device-components/docs.md#Express-installation)
 
 ## Removed previous stable APT repositories
 
-We [removed](../../12.Downloads/docs.md#Set-up-the-APT-repository) the previously deprecated stable APT repository:
+We [removed](../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository) the previously deprecated stable APT repository:
 
 ```
 deb [arch=your-arch] https://downloads.mender.io/repos/debian stable main
@@ -87,7 +87,7 @@ Err:3 https://downloads.mender.io/repos/debian stable InRelease
   403  Forbidden [IP: 52.222.214.71 443]
 ```
 
-it means you are using the old repository, please update to the current one (see [Set up the APT repository](../../12.Downloads/docs.md#Set-up-the-APT-repository) section).
+it means you are using the old repository, please update to the current one (see [Set up the APT repository](../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository) section).
 
 In order to remove the obsolete repository `deb [arch=your-arch] https://downloads.mender.io/repos/debian stable main`
 you can use the following command:
@@ -96,7 +96,7 @@ you can use the following command:
 add-apt-repository -r "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian stable main"
 ```
 
-and then re-add the new one by following the insturcion in [Set up the APT repository](../../12.Downloads/docs.md#Set-up-the-APT-repository)
+and then re-add the new one by following the insturcion in [Set up the APT repository](../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository)
 
 
 ## Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
@@ -142,7 +142,7 @@ The mender-client version 3.2.0 Debian package is deprecated. If you are
 getting installation errors, with a missing
 [libffi6](https://sourceware.org/libffi/) dependency, then please install the
 new Debian package, as per the installation instructions in
-[downloads](../../12.Downloads/docs.md#mender-client)
+[downloads](../../12.Downloads/02.Device-components/docs.md#set-up-the-apt-repository)
 
 
 ## Obtaining client logs


### PR DESCRIPTION
This commit splits download page documentation into separated files.


