### PR TITLE
chore: Update monitor-client versions to 1.4.2

### DIFF
--- a/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md
+++ b/05.Operating-System-updates-Yocto-Project/05.Customize-Mender/docs.md
@@ -259,7 +259,7 @@ Replace <DIRECTORY-WITH-MENDER-CONNECT-CONF> with the path to the `mender-connec
 
 <!--AUTOVERSION: "/mender-monitor/yocto/%/"/monitor-client "/mender-monitor-%.tar.gz"/monitor-client -->
 Download the Mender Monitor add-on from
-https://downloads.customer.mender.io/content/hosted/mender-monitor/yocto/1.4.1/mender-monitor-1.4.1.tar.gz
+https://downloads.customer.mender.io/content/hosted/mender-monitor/yocto/1.4.2/mender-monitor-1.4.2.tar.gz
 and download the tarball to a known location on your local system using your hosted
 Mender username and password:
 
@@ -268,14 +268,14 @@ Mender username and password:
 <!--AUTOVERSION: "/mender-monitor/yocto/%/"/monitor-client "/mender-monitor-%.tar.gz"/monitor-client -->
 ```bash
 HOSTED_MENDER_EMAIL=<your.email@example.com>
-curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-monitor-1.4.1.tar.gz https://downloads.customer.mender.io/content/hosted/mender-monitor/yocto/1.4.1/mender-monitor-1.4.1.tar.gz
+curl --fail -u $HOSTED_MENDER_EMAIL -o ${HOME}/mender-monitor-1.4.2.tar.gz https://downloads.customer.mender.io/content/hosted/mender-monitor/yocto/1.4.2/mender-monitor-1.4.2.tar.gz
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
 <!--AUTOVERSION: "/mender-monitor/yocto/%/"/monitor-client "/mender-monitor-%.tar.gz"/monitor-client -->
 ```bash
 MENDER_ENTERPRISE_USER=<your.user>
-curl --fail -u $MENDER_ENTERPRISE_USER -o ${HOME}/mender-monitor-1.4.1.tar.gz https://downloads.customer.mender.io/content/on-prem/mender-monitor/yocto/1.4.1/mender-monitor-1.4.1.tar.gz
+curl --fail -u $MENDER_ENTERPRISE_USER -o ${HOME}/mender-monitor-1.4.2.tar.gz https://downloads.customer.mender.io/content/on-prem/mender-monitor/yocto/1.4.2/mender-monitor-1.4.2.tar.gz
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -297,7 +297,7 @@ Give the `mender-monitor` recipe the path to the local source code just download
 
 <!--AUTOVERSION: "/mender-monitor-%.tar.gz"/monitor-client -->
 ```bash
-SRC_URI:pn-mender-monitor = "file://${HOME}/mender-monitor-1.4.1.tar.gz"
+SRC_URI:pn-mender-monitor = "file://${HOME}/mender-monitor-1.4.2.tar.gz"
 ```
 
 Then make Mender monitor a part of your image with:
@@ -311,7 +311,7 @@ Which means your `local.conf` should now contain the following lines:
 <!--AUTOVERSION: "/mender-monitor-%.tar.gz"/monitor-client -->
 ```bash
 LICENSE_FLAGS_ACCEPTED:append = " commercial_mender-yocto-layer-license"
-SRC_URI:pn-mender-monitor = "file://${HOME}/mender-monitor-1.4.1.tar.gz"
+SRC_URI:pn-mender-monitor = "file://${HOME}/mender-monitor-1.4.2.tar.gz"
 IMAGE_INSTALL:append = " mender-monitor"
 ```
 

--- a/12.Downloads/docs.md
+++ b/12.Downloads/docs.md
@@ -524,7 +524,7 @@ HOSTED_MENDER_PASSWORD=<yoursecurepassword>
 And download it with:
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/1.4.1/mender-monitor_1.4.1-1%2Bdebian%2Bbullseye_all.deb
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/1.4.2/mender-monitor_1.4.2-1%2Bdebian%2Bbullseye_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
@@ -538,7 +538,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.4.1/mender-monitor_1.4.1-1%2Bdebian%2Bbullseye_all.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.4.2/mender-monitor_1.4.2-1%2Bdebian%2Bbullseye_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -548,7 +548,7 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-monitor_%-1"/monitor-client -->
 ```bash
-sudo dpkg -i mender-monitor_1.4.1-1+debian+bullseye_all.deb || sudo apt --fix-broken -y install
+sudo dpkg -i mender-monitor_1.4.2-1+debian+bullseye_all.deb || sudo apt --fix-broken -y install
 ```
 
 ### Demo monitors
@@ -568,7 +568,7 @@ HOSTED_MENDER_PASSWORD=<yoursecurepassword>
 And download it with:
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/1.4.1/mender-monitor-demo_1.4.1-1%2Bdebian%2Bbullseye_all.deb
+wget --auth-no-challenge --user "$HOSTED_MENDER_EMAIL" --password "$HOSTED_MENDER_PASSWORD" https://downloads.customer.mender.io/content/hosted/mender-monitor/debian/1.4.2/mender-monitor-demo_1.4.2-1%2Bdebian%2Bbullseye_all.deb
 ```
 [/ui-tab]
 [ui-tab title="enterprise"]
@@ -583,7 +583,7 @@ And download it with:
 <!--AUTOMATION: ignore -->
 <!--AUTOVERSION: "/mender-monitor-demo_%-1"/monitor-client "/mender-monitor/debian/%/"/monitor-client -->
 ```bash
-wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.4.1/mender-monitor-demo_1.4.1-1%2Bdebian%2Bbullseye_all.deb
+wget --auth-no-challenge --user "$MENDER_ENTERPRISE_USER" --password "$MENDER_ENTERPRISE_PASSWORD" https://downloads.customer.mender.io/content/on-prem/mender-monitor/debian/1.4.2/mender-monitor-demo_1.4.2-1%2Bdebian%2Bbullseye_all.deb
 ```
 [/ui-tab]
 [/ui-tabs]
@@ -593,7 +593,7 @@ Then install the package with:
 
 <!--AUTOVERSION: "mender-monitor-demo_%-1"/monitor-client -->
 ```bash
-sudo dpkg -i mender-monitor-demo_1.4.1-1+debian+bullseye_all.deb
+sudo dpkg -i mender-monitor-demo_1.4.2-1+debian+bullseye_all.deb
 ```
 
 ## Mender Gateway


### PR DESCRIPTION
This should have been done in 71164006a7a4027e1c11af31e252d5044336c19c, but autoversion was run with 1.4.1 rather than 1.4.2

Updated with ./autoversion.py --update --component monitor-client --version 1.4.2