### PR TITLE
On prem gateway eval

### DIFF
--- a/10.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/01.Keys-and-certificates/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/01.Keys-and-certificates/docs.md
@@ -15,8 +15,7 @@ Not all the variables are needed for all commands, but just setting them all eve
 
 We suggest copying these to a temporary text file, filling them with your values and keeping them at hand while going through evaluation.
 
-
-<!--AUTOVERSION: "mender-gateway:saas-v%"/ignore-->
+<!--AUTOVERSION: "mender-gateway:%"/mender-gateway-->
 ```bash
 # For evaluation, define an arbitrary domain for the mtls server (we will modify `/etc/hosts` on the device).
 # No external registration will take place.
@@ -36,10 +35,12 @@ export MENDER_GATEWAY_IP=
 export MENDER_USERNAME=
 export MENDER_PASSWORD=
 
-# Set the URL of the mender server 
-# i.e 
+# Set the URL of the mender server
+# i.e
 # export UPSTREAM_SERVER_URL="https://eu.hosted.mender.io"
 # export UPSTREAM_SERVER_URL="https://hosted.mender.io"
+# For evaluation with an on-prem server:
+# export UPSTREAM_SERVER_URL="https://your-mender-server.example.com"
 export UPSTREAM_SERVER_URL=
 
 # Set the tenant/organization token for your account
@@ -53,8 +54,36 @@ export DOCKER_REGISTRY_PASSWORD=
 
 # The name and version of the mtls server container
 # The defaults have been set, you rarely need to change this.
-export MENDER_GATEWAY_IMAGE="${DOCKER_REGISTRY_URL}/mendersoftware/mender-gateway:saas-v2024.08.19"
+export MENDER_GATEWAY_IMAGE="${DOCKER_REGISTRY_URL}/mendersoftware/mender-gateway:2.0.0"
 ```
+
+
+## Confirm upstream server accessibility
+
+The Mender Gateway proxies device traffic to the upstream Mender server.
+Before proceeding, confirm that the server is reachable and its TLS certificate is signed by a trusted CA.
+This applies equally to hosted Mender and a custom on-prem instance.
+
+!!! Set the [environment variables](#environment-variables) before executing this command.
+
+```bash
+openssl s_client -connect $(echo $UPSTREAM_SERVER_URL | sed -E 's|https?://||; s|/.*||'):443 < /dev/null
+```
+
+In the success case you will see output ending with lines similar to:
+
+```text
+SSL handshake has read 4680 bytes and written 369 bytes
+Verification: OK
+...
+Verify return code: 0 (ok)
+```
+
+If the command fails, resolve DNS, firewall, or certificate trust issues on the server side before continuing.
+
+
+!!! **Note:** This guide does not cover evaluation in isolated networks with private DNS or custom root CA chains. 
+!!! Those environments require the gateway to trust the Mender server for which the steps are not described here.                                                                                           
 
 
 ## Access to the Mender Gateway container

--- a/10.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/02.Evaluation-with-docker-compose/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/02.Evaluation-with-docker-compose/docs.md
@@ -69,17 +69,30 @@ docker rm mender-gateway
 
 ### Confirm communication with the proxy
 
-Assuming you run the docker image on your host, the container will start listening to the host port 443.
+From a different terminal, send a fake HTTP request through the gateway to confirm that the mTLS handshake completes and the gateway proxies the request upstream.
 
-! Set the [env variables](../01.Keys-and-certificates/docs.md#environment-variables) executing the commands below.
-From a different terminal execute the command below:
+! Set the [env variables](../01.Keys-and-certificates/docs.md#environment-variables) and make sure you're in the directory where you [generated the keys](../01.Keys-and-certificates/docs.md#generating-the-keys).
 
-``` bash
-openssl s_client -connect $MENDER_GATEWAY_IP:8443
+```bash
+printf "GET / HTTP/1.0\r\n\r\n" | openssl s_client -connect $MENDER_GATEWAY_IP:8443 \
+  -CAfile ca.crt \
+  -cert device-cert.pem \
+  -key device-private.key
+```
 
-# In the mender-gateway terminal look for a line similar to:
-# 2023/08/18 15:51:21 http: TLS handshake error from 192.168.88.249:46612: tls: client didn't provide a certificate
-# This means you can communicate with the server correctly
+A successful run will show `Verification: OK` and `Verify return code: 0 (ok)`, confirming that both sides of the mTLS handshake completed and the gateway certificate is trusted:
+
+```text
+SSL handshake has read 1135 bytes and written 1703 bytes
+Verification: OK
+---
+Verify return code: 0 (ok)
+```
+
+Simultaneously, the gateway will log a `404` for the request, confirming it was received and forwarded upstream:
+
+```text
+time="..." level=warning method=GET path=/ status=404 type=HTTP/1.0
 ```
 
 ## Configure the device to use the proxy
@@ -92,8 +105,8 @@ Start the virtual client in daemon mode and confirm it's working:
 
 ! Set the [environment variables](../01.Keys-and-certificates/docs.md#environment-variables) and make sure you're in the directory where you [generated the keys](../01.Keys-and-certificates/docs.md#generating-the-keys).
 
-! On a Linux device with kvm support you will get a much faster devices with `--privileged`.
-! Do note that that comes with all the risks of running docker in privileged mode.
+
+! On Linux with KVM support you will get a much faster virtual device. Add your user to the `kvm` group and pass `--device /dev/kvm` to the docker run command and ensure kvm is accessible `sudo usermod -aG kvm $(whoami)`. Log out and back in for it to take effect or run `newgrp kvm`
 
 ```bash
 printf "\n\n"
@@ -116,10 +129,6 @@ If something doesn't end up working with the above command you can return to the
 docker kill mender-client
 docker rm mender-client
 ```
-
-
-! For versions prior Mender Client 4 replace `mender-authd` with `mender-client`
-
 
 Update the device with new certificates: 
 


### PR DESCRIPTION
Update gateway eval docs to cover publicly accessible on-prem serves.

Rendered pieces:
<img width="963" height="586" alt="image" src="https://github.com/user-attachments/assets/619a8bda-0efe-421e-90df-2fc178eaad3e" />


<img width="917" height="630" alt="image" src="https://github.com/user-attachments/assets/7c4ccd19-0344-4f7e-88b6-328c9c01386b" />
