### PR TITLE
docs: add orchestrator configuration documentation

### DIFF
--- a/07.Orchestrate-updates/07.Artifacts handling/01.Caching/docs.md
+++ b/07.Orchestrate-updates/07.Artifacts handling/01.Caching/docs.md
@@ -22,7 +22,7 @@ To prevent the cache from growing indefinitely, the Orchestrator performs a clea
 
 ### Storage and Fallback
 
-The filesystem hosting the cache must have sufficient free space to store the full Artifact. However, the caching mechanism is designed to be non-blocking. If the Orchestrator cannot cache an Artifact - for example, if the destination filesystem has reached its capacity - it will skip the caching process. The deployment will continue to function normally, ensuring that storage issues do not cause update failures.
+The filesystem hosting the cache must have sufficient free space to store the full Artifact. If the Orchestrator cannot cache an Artifact - for example, if the destination filesystem has reached its capacity - it will fail the deployment.
 
 ### Configuration
 
@@ -32,12 +32,19 @@ Artifact caching is configured in the Mender Orchestrator configuration file, lo
 {
   "ArtifactsCache": {
     "Enabled": true,
-    "Path": "/var/cache/mender-orchestrator"
+    "Path": "/var/cache/mender-orchestrator",
+    "MaxSizeBytes": 2147483648
   }
 }
 ```
 
 * `Enabled`: Set to true to activate caching. Defaults to false.
 * `Path`: The directory where the cached Artifacts are stored.
+* `MaxSizeBytes`: The maximum size in bytes for the cache. `0` means no limit.
+  Defaults to `0`.
 
-!!! Note: The path configured for the cache must exist on the filesystem before the Orchestrator starts. The service will not attempt to create the directory structure if it is missing. In this case the deployments will work normally but without the cache.
+!!! Note: The path configured for the cache must exist on the filesystem before the Orchestrator starts. The service will not attempt to create the directory structure if it is missing.
+
+For a full description of all cache-related options, see the [ArtifactsCache
+configuration
+reference](../../08.Configuration/50.Configuration-options/docs.md#artifactscache).

--- a/07.Orchestrate-updates/08.Configuration/50.Configuration-options/docs.md
+++ b/07.Orchestrate-updates/08.Configuration/50.Configuration-options/docs.md
@@ -1,0 +1,127 @@
+---
+title: Configuration options
+taxonomy:
+    category: docs
+---
+
+This section lists all the available configuration options in the
+`mender-orchestrator.conf` file.
+
+#### ArtifactVerifyKey
+
+There are two options for specifying verification keys:
+
+* `ArtifactVerifyKey` is a single path to a key.
+* `ArtifactVerifyKeys` is a list of paths to keys. When multiple keys are
+  specified, the keys are tried in order, and the first key that verifies an
+  Artifact signature is used. This is useful for key rotation or signing
+  different types of Artifacts.
+
+Only one of `ArtifactVerifyKey` or `ArtifactVerifyKeys` may be specified.
+
+When set, Mender Orchestrator verifies the following:
+
+* All Artifact installs contain a signature. If a signature is not provided,
+  then the Orchestrator rejects the update.
+* The provided public key verifies the signature of the update.
+
+See also the section about [signing and
+verification](../../../08.Artifact-creation/09.Sign-and-verify/docs.md).
+
+#### ArtifactsCache
+
+Configures Artifacts caching behavior. When enabled, Mender Orchestrator caches
+downloaded Artifacts locally so that Components sharing the same Artifact do not
+cause redundant downloads.
+
+##### Enabled
+
+Set to `true` to activate caching. Defaults to `false`.
+
+##### Path
+
+The directory where cached Artifacts are stored. Defaults to
+`{datastore}/artifacts` (typically `/var/lib/mender-orchestrator/artifacts`).
+
+!!! Note: The path configured for the cache must exist on the filesystem before the Orchestrator starts. The service will not attempt to create the directory structure if it is missing.
+
+##### MaxSizeBytes
+
+The maximum size in bytes for the Artifacts cache. When the cache exceeds this
+limit, the oldest cached Artifacts are removed to make room for new ones. A
+value of `0` means no limit. Defaults to `0`.
+
+Example:
+
+```json
+{
+  "ArtifactsCache": {
+    "Enabled": true,
+    "Path": "/var/cache/mender-orchestrator",
+    "MaxSizeBytes": 2147483648
+  }
+}
+```
+
+See also the section about [Artifacts
+caching](../../07.Artifacts%20handling/01.Caching/docs.md).
+
+#### HttpsClient
+
+Allows you to configure the certificate, private key, and SSL Engine id to use
+during the SSL handshake. If you provide the certificate and private key as
+locally accessible files you don't have to specify SSLEngine.
+
+If you want to use a Hardware Security Module (HSM) you can provide the private
+key as a [PKCS#11 URI](https://tools.ietf.org/html/rfc7512).
+
+##### Certificate
+
+A path to the file in PEM format holding the client certificate.
+
+##### Key
+
+Either a valid PKCS#11 URI or a path to a file holding the private key.
+
+Example:
+
+```json
+{
+  "HttpsClient": {
+    "Certificate": "/certs/cert.pem",
+    "Key": "/keys/private/key.pem"
+  }
+}
+```
+
+#### InterfaceTimeoutSeconds
+
+An integer that specifies the number of seconds that an update
+[Interface](../../04.Interface-protocol/docs.md) is allowed to run before it is
+considered hung and killed. The default is `14400` (4 hours).
+
+#### LogLevel
+
+The default log level for Mender Orchestrator. Valid values are: `trace`,
+`debug`, `info`, `warning`, `error`, `fatal`.
+
+Note that this option will get overridden by the cli option `--log-level`.
+
+If not set, defaults to `info`.
+
+#### ManifestStore
+
+The directory where manifests are stored. Defaults to `{datastore}/manifests`
+(typically `/var/lib/mender-orchestrator/manifests`).
+
+#### ServerCertificate
+
+The location of the public certificate of the server, if any. If this
+certificate is missing, or the one presented by the server does not match the one
+specified in this setting, the server certificate is validated using standard
+certificate trust chains.
+
+#### TopologyComponents
+
+The file path to the Topology components YAML file. This defines the Components
+present in the System and how they can be updated.

--- a/07.Orchestrate-updates/08.Configuration/docs.md
+++ b/07.Orchestrate-updates/08.Configuration/docs.md
@@ -1,0 +1,59 @@
+---
+title: Configuration
+taxonomy:
+    category: docs
+---
+
+Mender Orchestrator's configuration resides in
+`/etc/mender-orchestrator/mender-orchestrator.conf` on the root filesystem. This
+file is JSON structured and defines various parameters for the Orchestrator's
+operation.
+
+On systems where one or more of the configuration options must survive future
+updates, there is an optional "fallback" configuration file in
+`/var/lib/mender-orchestrator/mender-orchestrator.conf`. Because the directory
+`/var/lib/mender-orchestrator` is on persistent storage, the fallback configuration
+file is not overwritten by system updates.
+
+The fallback configuration file has the same JSON structure as the main
+configuration file. Any value set in the main configuration file
+`/etc/mender-orchestrator/mender-orchestrator.conf` takes precedence, whether or
+not the setting appears in the fallback file
+`/var/lib/mender-orchestrator/mender-orchestrator.conf`. The Orchestrator only uses
+a setting from the fallback file if it does not appear in the main file.
+
+## Example mender-orchestrator.conf file
+
+Here is an example of a `mender-orchestrator.conf` file:
+
+```json
+{
+  "LogLevel": "info",
+  "ArtifactsCache": {
+    "Enabled": true,
+    "Path": "/var/cache/mender-orchestrator",
+    "MaxSizeBytes": 2147483648
+  }
+}
+```
+
+For a full list of available options, see
+[Configuration options](50.Configuration-options/docs.md).
+
+## Environment variables
+
+The following table describes the environment variables Mender Orchestrator
+respects:
+
+| Environment variable                          | Description                                        | Default value                    |
+| --------------------------------------------- | -------------------------------------------------- | -------------------------------- |
+| `MENDER_ORCHESTRATOR_CONF_DIR`                | Configuration directory                            | `/etc/mender-orchestrator`       |
+| `MENDER_ORCHESTRATOR_DATA_DIR`                | Data directory (interfaces, static files)          | `/usr/share/mender-orchestrator` |
+| `MENDER_ORCHESTRATOR_DATASTORE_DIR`           | Persistent datastore directory                     | `/var/lib/mender-orchestrator`   |
+| `MENDER_ORCHESTRATOR_TOPOLOGY_DIR`            | Directory where the Topology is stored             | Value of datastore directory     |
+| `MENDER_ORCHESTRATOR_TOPOLOGY_COMPONENTS_FILE`| Path to the user-provided Topology components YAML | empty                            |
+| `MENDER_ORCHESTRATOR_MANIFEST_STORE_DIR`      | Manifest storage directory                         | `{datastore}/manifests`          |
+| `MENDER_ORCHESTRATOR_ARTIFACTS_CACHE_DIR`     | Artifacts cache directory                          | `{datastore}/artifacts`          |
+| `HTTP_PROXY`                                  | Proxy server to use for HTTP                       | empty                            |
+| `HTTPS_PROXY`                                 | Proxy server to use for HTTPS                      | empty                            |
+| `NO_PROXY`                                    | Hosts that should not go through proxy             | empty                            |


### PR DESCRIPTION
Based on https://docs.mender.io/client-installation/configuration and https://docs.mender.io/client-installation/configuration/configuration-options