### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/08.Artifact-creation/01.Create-an-Artifact/docs.md
+++ b/08.Artifact-creation/01.Create-an-Artifact/docs.md
@@ -61,7 +61,7 @@ chmod +x single-file-artifact-gen
 Now create the Artifact with:
 ```bash
 ./single-file-artifact-gen \
-  --device-type raspberrypi4 \
+  --compatible-types raspberrypi4 \
   -o artifact.mender \
   -n updated-authorized_keys-1.0 \
   --software-name authorized_keys \

--- a/08.Artifact-creation/05.Create-a-docker-compose-update-Artifact/docs.md
+++ b/08.Artifact-creation/05.Create-a-docker-compose-update-Artifact/docs.md
@@ -74,7 +74,7 @@ Create the Artifact by for your target device by specifying the artifact name, c
 ```bash
 ./gen_docker-compose \
     --artifact-name docker-compose-artifact-v1 \
-    --device-type raspberrypi5 \
+    --compatible-type raspberrypi5 \
     --architecture arm64 \
     --manifests-dir manifests/ \
     --project-name my-webserver \
@@ -169,7 +169,7 @@ Now generate the Artifact using the `--images-dir` option:
 ```bash
 ./gen_docker-compose \
     --artifact-name docker-compose-artifact-v1 \
-    --device-type raspberrypi5 \
+    --compatible-type raspberrypi5 \
     --manifests-dir manifests/ \
     --images-dir images/ \
     --project-name my-webserver \


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344
