### PR TITLE
chore: allow autoversion to update tags starting with 0

### DIFF
--- a/09.Server-installation/04.Production-installation-with-kubernetes/03.Mender-server/docs.md
+++ b/09.Server-installation/04.Production-installation-with-kubernetes/03.Mender-server/docs.md
@@ -536,6 +536,7 @@ of them. The following snippet increases the number of replicas to 3.
 
 !!!! Please replace `NATS_URL` in the following snippet with a URL that resolves to any of the NATS pods.
 
+<!--AUTOVERSION: "nats-box:%-nonroot"/ignore-->
 ```bash
 NATS_URL="nats://mender-nats" # REPLACE
 kubectl run --env=NATS_URL=$NATS_URL --image=natsio/nats-box:0.14.5-nonroot \

--- a/autoversion.py
+++ b/autoversion.py
@@ -31,7 +31,7 @@ REPOS_CACHE = []
 
 # Match version strings.
 YOCTO_BRANCHES = r"(?:dora|daisy|dizzy|jethro|krogoth|morty|pyro|rocko|sumo|thud|warrior|zeus|dunfell|gatesgarth|kirkstone|langdale|mickledore|scarthgap)"
-EXACT_VERSION_MATCH = r"(?<![0-9]\.)(?<![0-9])[1-9][0-9]*\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?:-build[0-9]+)?(?![0-9])(?!\.[0-9])(?:-rc\.[0-9]+)?(?![0-9])(?!\.[0-9])"
+EXACT_VERSION_MATCH = r"(?<![0-9]\.)(?<![0-9])[0-9]+\.[0-9]+\.[x0-9]+(?:b[0-9]+)?(?:-build[0-9]+)?(?![0-9])(?!\.[0-9])(?:-rc\.[0-9]+)?(?![0-9])(?!\.[0-9])"
 VERSION_MATCHER = r"(?:%s|(?:mender-%s)|(?<![a-z])(?:%s|master)(?![a-z]))" % (
     EXACT_VERSION_MATCH,
     EXACT_VERSION_MATCH,


### PR DESCRIPTION
Needed when updating mender-orchestrator from 0.4.0