### PR TITLE
docs: update Mender Client version note for mender-orchestrator

### DIFF
--- a/07.Orchestrate-updates/05.Installation/01.Yocto-Project/docs.md
+++ b/07.Orchestrate-updates/05.Installation/01.Yocto-Project/docs.md
@@ -20,8 +20,8 @@ Before integrating Mender Orchestrator into your Yocto build, ensure you have a 
 Yocto build environment with meta-mender layers and the Mender Orchestrator sources downloaded through
 the links below.
 
-<!--AUTOVERSION: "% recipe"/ignore -->
-!!! Mender Orchestrator requires the master recipe of the Mender Client. Support for Mender Orchestrator will be released in the next feature release. See the [Yocto Project documentation](../../../05.Operating-System-updates-Yocto-Project/03.Build-for-demo/docs.md#configuring-the-build) for information on using bleeding edge versions.
+<!--AUTOVERSION: "Mender Client % or newer"/ignore-->
+!!! Mender Orchestrator requires Mender Client 6.0.0 or newer.
 
 ### Download
 

--- a/07.Orchestrate-updates/05.Installation/02.Debian-family/docs.md
+++ b/07.Orchestrate-updates/05.Installation/02.Debian-family/docs.md
@@ -10,7 +10,8 @@ taxonomy:
 
 !!! Mender Orchestrator requires DeviceTier to be set to "system" for proper operation.
 
-!!! Mender Orchestrator requires the experimental package of the Mender Client. Support for Mender Orchestrator will be released in the next feature release. See the [Download section](../../../12.Downloads/02.Device-components/docs.md) for information on bleeding edge versions.
+<!--AUTOVERSION: "Mender Client % or newer"/ignore-->
+!!! Mender Orchestrator requires Mender Client 6.0.0 or newer.
 
 This page provides instructions for downloading and installing the Mender Orchestrator Debian packages.
 


### PR DESCRIPTION
Mender Client 6.0.0 is released and contains the initial features required for mender-orchestrator.

Ticket: MEN-8876
