### PR TITLE
CE-1074: Clarified Mender Client 4 EOL date

### DIFF
--- a/302.Release-information/01.Supported-releases/docs.md
+++ b/302.Release-information/01.Supported-releases/docs.md
@@ -18,6 +18,7 @@ in the table below:
 |-----------------------|---------------|-------------------------|
 | Mender Client 6.0     | 2026-03       | Supported               |
 | Mender Client 5.0     | 2025-01       | Supported               |
+| Mender Client 4.0     | 2024-01       | EOL (since 2025-07)     |
 | Mender MCU Client 1.0 | 2026-04       | Supported               |
 | Mender Gateway 2.0    | 2025-01       | Supported               |
 | Mender Server 4.1     | 2026-01       | Supported               |


### PR DESCRIPTION
Client 4.0 (released 2024-01) reached end-of-life in 2025-07,
six months after Client 5.0 GA. This was missing from the table,
leaving a gap for customers checking on older clients.

Ticket: CE-1074
