### PR TITLE
fix: Do not refer to Releases tab/section

### DIFF
--- a/01.Get-started/02.Deploy-an-application-update/docs.md
+++ b/01.Get-started/02.Deploy-an-application-update/docs.md
@@ -109,7 +109,7 @@ Leave the next prefilled fields as they are and click **UPLOAD ARTIFACT** as bel
 
 ![artifact details 2](artifact_details_2.png)
 
-You will now see a new Release containing this Artifact under the **Releases** tab. View its details, and create a deployment by clicking **Create a deployment for this Release**.
+You will now see a new Release containing this Artifact under the **Software** tab. View its details, and create a deployment by clicking **Create a deployment for this Release**.
 
 ![view release](release_actions.png)
 

--- a/01.Get-started/03.Deploy-an-operating-system-update/docs.md
+++ b/01.Get-started/03.Deploy-an-operating-system-update/docs.md
@@ -102,7 +102,7 @@ reaches 100% it will package the Mender Artifact which will take a few more
 minutes because it will need to compress the snapshot image.
 
 The end result is a file called `system-v1.mender`. Upload this file to
-hosted Mender. You can do that using the UI under the **Releases** tab, as
+hosted Mender. You can do that using the UI under the **Software** tab, as
 demonstrated below.
 
 ![connecting a device](Image_1.png)

--- a/01.Get-started/07.Microcontroller-preview/02.Deploy-a-firmware-update/docs.md
+++ b/01.Get-started/07.Microcontroller-preview/02.Deploy-a-firmware-update/docs.md
@@ -50,7 +50,7 @@ The build system will recompile any changed source files and produce a new `zeph
 
 With our *Artifact* ready, we'll now use the Mender server to deploy it to the device. We'll do this using the hosted Mender web interface:
 
-1. **Upload the *Artifact*:** In the [hosted Mender UI](https://hosted.mender.io?target=_blank), go to the **Releases** tab. Click the **Upload** button. In the dialog, either drag and drop the `zephyr.mender` file or click to browse and select it. You can give the release a name when prompted, but sticking with the default is fine. After uploading, you should see a new release entry (e.g. "release-2") in the Releases list.
+1. **Upload the *Artifact*:** In the [hosted Mender UI](https://hosted.mender.io?target=_blank), go to the **Sofware** tab. Click the **Upload** button. In the dialog, either drag and drop the `zephyr.mender` file or click to browse and select it. You can give the release a name when prompted, but sticking with the default is fine. After uploading, you should see a new release entry (e.g. "release-2") in the Releases list.
 2. **Create a deployment:** Now navigate to the **Devices** section and find your device (it should be in the Accepted Devices list). In the Device information view for the device you just connected, select **Create a deployment for this device** from the **Device actions**.
 
 ![create deployment](create-deployment.png)

--- a/07.Orchestrate-updates/06.Examples/docs.md
+++ b/07.Orchestrate-updates/06.Examples/docs.md
@@ -214,7 +214,7 @@ mender-orchestrator-manifest-gen \
 
 Upload all your created Artifacts to hosted Mender:
 
-1. Go to your hosted Mender **Releases** section
+1. Go to your hosted Mender **Software** section
 2. Upload all the artifacts you just created:
    - `gateway-v1.mender`, `gateway-v2.mender`
    - `rtos-v1.mender`, `rtos-v2.mender`

--- a/08.Artifact-creation/07.Server-side-generation-of-Delta-Artifacts/docs.md
+++ b/08.Artifact-creation/07.Server-side-generation-of-Delta-Artifacts/docs.md
@@ -67,7 +67,7 @@ If the Delta Artifact already exists, the Mender Server selects it and sends the
 Note that the generation may take up to 15 minutes, depending on the binary delta configuration settings (see below)
 and Artifacts sizes and types of data.
 
-A successfully generated Artifact will be visible in the Releases section under the name of the original rootfs Artifact.
+A successfully generated Artifact will be visible in the Software section under the name of the original rootfs Artifact.
 
 Please note that if the Server cannot generate the Delta Artifact, it will automatically fall back to the non-Delta Artifact. Possible reasons are:
 * the Device is not reporting the availability of the Binary Delta Update Module through the `provides` database keys;
@@ -106,7 +106,7 @@ and the device will download a full rootfs-image instead of the delta, as you ca
 As you can see from the above there is a number of reasons for the delta generation to not take place;
 many of which are not signs of errors, but follow from the design of the feature. As the majority of the operations
 take place on the server side and the whole procedure is transparent to the users and devices,
-there is a "Delta Artifacts generation" tab in the Releases section, where you can see all the server-side delta generation
+there is a "Delta Artifacts generation" tab in the Software section, where you can see all the server-side delta generation
 jobs with status, and check each one for more detailed information.
 
 #### rootfs version and checksum


### PR DESCRIPTION
The tab is now called _Software_.

Ticket: none
Changelog: none