### PR TITLE
chore: Add a warning about temp space when creating a snapshot

### DIFF
--- a/01.Get-started/03.Deploy-an-operating-system-update/docs.md
+++ b/01.Get-started/03.Deploy-an-operating-system-update/docs.md
@@ -83,6 +83,11 @@ Run the following command on your workstation to generate a **snapshot**
 [Mender Artifact](../../02.Overview/03.Artifact/docs.md) from your
 device:
 
+!!! The snapshot process requires a lot of temporary space (depending on the
+!!! device being snapshot), using `/tmp` by default. The `--tmp` option can be
+!!! added to the command below to specify a different directory for temporary
+!!! files.
+
 ```bash
 mender-artifact write rootfs-image \
     -f ssh://"${USER}@${IP_ADDRESS}" \


### PR DESCRIPTION
Doing a device snapshot with `mender-artifact` requires a lot of temporary space. On systems where `/tmp` is a tmpfs mount point this can easily result in crashes or OOM situations. Since it's a common setup we should warn users and tell them they can use the new `--tmp` option to tell `mender-artifact` to use a different directory for temporary files.

Ticket: MEN-8479
Changelog: none

