### PR TITLE
chore: Change the root session monitor example match string

### DIFF
--- a/01.Get-started/05.Monitor/docs.md
+++ b/01.Get-started/05.Monitor/docs.md
@@ -269,7 +269,7 @@ First, create a check for the `log` monitoring subsystem named `auth_root_sessio
 the following command:
 
 ```bash
-sudo mender-monitorctl create log auth_root_session "Started User Manager for UID 0" "@journalctl --follow"
+sudo mender-monitorctl create log auth_root_session "session opened for user root" "@journalctl --follow"
 sudo mender-monitorctl enable log auth_root_session
 sudo systemctl restart mender-monitor
 ```


### PR DESCRIPTION
`session opened for user root` is what journal contains when someone runs `sudo su` (or any other command with `sudo`)

Ticket: none
Changelog: none
