### PR TITLE
docs(pr-template): drop mandatory Changelog/Ticket lines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,7 @@ fix: <SHORT DESCRIPTION OF FIX>
 
 <OPTIONAL LONGER DESCRIPTION>
 
-Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
-Ticket: <TICKET NUMBER> or <None>
+<OPTIONAL Ticket: <TICKET NUMBER>>
 ```
 
 - [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.


### PR DESCRIPTION
The `Ticket:` and `Changelog:` trailers are optional and never CI-gated under the new commit policy; the template now shows only an optional Ticket line, matching the [commit specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) it already links.

Draft until mendersoftware/mendertesting#498 and mendersoftware/mendertesting#499 are merged.

Ticket: [QA-1675](https://northerntech.atlassian.net/browse/QA-1675)

[QA-1675]: https://northerntech.atlassian.net/browse/QA-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ