### PR TITLE
chore: pin mender-mcu-integration to zephyr-4.2.0

### DIFF
--- a/01.Get-started/07.Microcontroller-preview/01.Prepare-an-esp32-s3-with-Zephyr/docs.md
+++ b/01.Get-started/07.Microcontroller-preview/01.Prepare-an-esp32-s3-with-Zephyr/docs.md
@@ -22,7 +22,7 @@ We will build and flash a Zephyr firmware for an ESP32-S3-DevKitC board. By the 
 
 ## Step 1 – Set up the project and code
 <!--AUTOVERSION: "version % is used. To do so, follow the [Zephyr getting started guide %](https://docs.zephyrproject.org/%/develop/getting_started/index.html?target=_blank)."/ignore-->
-First, we'll set up a basic Zephyr development environment. This guide assumes version 4.4.0 is used. To do so, follow the [Zephyr getting started guide 4.4.0](https://docs.zephyrproject.org/4.4.0/develop/getting_started/index.html?target=_blank).
+First, we'll set up a basic Zephyr development environment. This guide assumes version 4.2.0 is used. To do so, follow the [Zephyr getting started guide 4.2.0](https://docs.zephyrproject.org/4.2.0/develop/getting_started/index.html?target=_blank).
 
 Next, we'll obtain the reference Zephyr application that integrates Mender. We will use the official **mender-mcu integration example** for this tutorial, which already has Mender support and sample code for the ESP32-S3.
 

--- a/01.Get-started/07.Microcontroller-preview/01.Prepare-an-esp32-s3-with-Zephyr/docs.md
+++ b/01.Get-started/07.Microcontroller-preview/01.Prepare-an-esp32-s3-with-Zephyr/docs.md
@@ -39,8 +39,9 @@ source ~/zephyrproject/.venv/bin/activate
 **Initialize a new west workspace** for the Mender MCU integration project. In the same terminal 
 change your current working directory to a different one than `~/zephyrproject`, e.g. to `~/`, and run:
 
+<!--AUTOVERSION: "--manifest-rev v%-zephyr-%"/ignore-->
 ```bash
-west init ~/mender-mcu-workspace --manifest-url https://github.com/mendersoftware/mender-mcu-integration
+west init ~/mender-mcu-workspace --manifest-url https://github.com/mendersoftware/mender-mcu-integration --manifest-rev v1.0.0-zephyr-4.2.0
 cd ~/mender-mcu-workspace
 west update
 ```

--- a/01.Get-started/07.Microcontroller-preview/docs.md
+++ b/01.Get-started/07.Microcontroller-preview/docs.md
@@ -5,7 +5,7 @@ taxonomy:
     label: tutorial
 ---
 
-We will walk through how to use a Zephyr-based microcontroller (MCU) with Mender and perform an OTA firmware update. We use the **Espressif ESP32-S3-DevKitC** development board running Zephyr 4.4 as our reference implementation. By the end, you will have the device appearing in your Mender Server and deploy new firmware to it.
+We will walk through how to use a Zephyr-based microcontroller (MCU) with Mender and perform an OTA firmware update. We use the **Espressif ESP32-S3-DevKitC** development board running Zephyr 4.2 as our reference implementation. By the end, you will have the device appearing in your Mender Server and deploy new firmware to it.
 
 MCU devices use the **micro device tier** in Mender, which is optimized for resource-constrained devices. The micro tier has longer default polling intervals (1 day for updates, 14 days for inventory) and smaller artifact size limits compared to standard tier Linux devices. See [Device tiers](../../02.Overview/17.Device-tiers/docs.md) for more information.
 

--- a/02.Overview/02.Device-Support/docs.md
+++ b/02.Overview/02.Device-Support/docs.md
@@ -114,7 +114,7 @@ application](https://github.com/mendersoftware/mender-mcu-integration)
 demonstrating how such an integration can be done.
 
 <!--AUTOVERSION: "Zephyr %"/ignore "/v%"/ignore-->
-Currently, [Zephyr 4.4](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.4.0) is supported by the Mender MCU client.
+Currently, [Zephyr 4.2](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.2.0) is supported by the Mender MCU client.
 
 
 #### Board integrations

--- a/06.Operating-System-updates-Zephyr/01.Overview/docs.md
+++ b/06.Operating-System-updates-Zephyr/01.Overview/docs.md
@@ -9,7 +9,7 @@ taxonomy:
 Mender enables robust **firmware updates** on resource-constrained devices by integrating with the Zephyr real-time operating system and the MCUboot bootloader. This allows microcontroller units (MCUs) to perform atomic, **fail-safe OTA updates** with automatic rollback on failure, similar to Mender's updates for Linux devices.
 
 <!--AUTOVERSION: "supports **Zephyr %** on boards"/ignore -->
-Mender's microcontroller client (*Mender MCU* or *mender-mcu*) runs as part of the Zephyr application firmware. It communicates with the Mender server to report device inventory and identity, checks for available updates, downloads new firmware, and coordinates with MCUboot to install updates safely. The reference implementation supports **Zephyr 4.4.0** on boards that use MCUboot as a bootloader, with Espressif's **ESP32-S3-DevKitC** as the reference board.
+Mender's microcontroller client (*Mender MCU* or *mender-mcu*) runs as part of the Zephyr application firmware. It communicates with the Mender server to report device inventory and identity, checks for available updates, downloads new firmware, and coordinates with MCUboot to install updates safely. The reference implementation supports **Zephyr 4.2.0** on boards that use MCUboot as a bootloader, with Espressif's **ESP32-S3-DevKitC** as the reference board.
 
 This section describes integrating Mender into a Zephyr-based MCU project for full firmware image updates. The high-level components for a Mender-enabled microcontroller device are:
 * **Bootloader (MCUboot)**: The device boots via MCUboot, which manages two firmware slots (active and inactive) for A/B updates. MCUboot verifies images and can swap them to a new image and revert them if needed.

--- a/302.Release-information/01.Supported-releases/docs.md
+++ b/302.Release-information/01.Supported-releases/docs.md
@@ -50,7 +50,6 @@ supported by the [Mender MCU Client](https://github.com/mendersoftware/mender-mc
 
 <!--AUTOVERSION: "Zephyr %"/ignore "/v%"/ignore-->
 * [Zephyr 4.2](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.2.0)
-* [Zephyr 4.4](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.4.0)
 
 
 ## Debian family releases supported for Mender Client


### PR DESCRIPTION
We haven't released any support for Zephyr 4.4 and we should start documenting a tagged mender-mcu version rather than using main.