### PR TITLE
docs: document Mender Gateway Prometheus metrics endpoint

### DIFF
--- a/10.Server-integration/04.Mender-Gateway/99.Configuration-file/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/99.Configuration-file/docs.md
@@ -56,6 +56,10 @@ This section provides a reference for the configuration variables.
 		"URL": "https://hosted.mender.io",
 		"CACertificate": "/etc/ssl/cert.pem",
 		"InsecureSkipVerify": false
+	},
+	"Metrics": {
+		"Enabled": false,
+		"Listen": ":9102"
 	}
 }
 ```
@@ -207,6 +211,22 @@ This configuration is available from Mender Gateway version <code>1.3.0</code>.
 </dl>
 
 </dl>
+
+### Metrics
+
+<!--AUTOVERSION: "version <code>%</code>"/ignore-->
+!!! Available from Mender Gateway version <code>2.2.0</code>
+
+<dl>
+<dt>Enabled (<code>METRICS_ENABLED</code>)</dt>
+<dd>Expose a Prometheus-compatible <code>/metrics</code> endpoint on a separate HTTP server. Disabled by default.</dd>
+
+<dt>Listen (<code>METRICS_LISTEN</code>)</dt>
+<dd>TCP network address (<code>host:port</code>) the metrics server listens on. Defaults to <code>:9102</code>, which binds every interface; set an IP address to restrict it, for example <code>127.0.0.1:9102</code> for the loopback interface only. An interface name cannot be used.</dd>
+</dl>
+
+! The metrics endpoint is not authenticated. Use the `Listen` address to keep it
+! on a trusted network; do not expose it on the device-facing network.
 
 ### Point Mender Gateway to a proxy
 

--- a/10.Server-integration/04.Mender-Gateway/99.Configuration-file/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/99.Configuration-file/docs.md
@@ -210,8 +210,6 @@ This configuration is available from Mender Gateway version <code>1.3.0</code>.
 <dd>Skip verification of certificate claims.</dd>
 </dl>
 
-</dl>
-
 ### Metrics
 
 <!--AUTOVERSION: "version <code>%</code>"/ignore-->

--- a/10.Server-integration/04.Mender-Gateway/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/docs.md
@@ -148,3 +148,41 @@ authentication. Any device with a valid certificate signed by the Certificate
 Authority (CA) configured on the gateway, is automatically accepted by the
 Mender Server. See the [mTLS user guide](10.Mutual-TLS-authentication/docs.md) for a
 reference mutual TLS setup in a testing environment.
+
+## Monitoring with Prometheus metrics
+Mender Gateway can expose a [Prometheus](https://prometheus.io/)-compatible
+`/metrics` endpoint for monitoring and alerting. The endpoint is served by a
+separate HTTP server, listening on `:9102` by default and independent of the
+device-facing proxy, so if it fails to start the error is logged and the gateway
+keeps serving device traffic. The feature is disabled by default and enabled
+with the `Metrics` section of the [configuration file](99.Configuration-file/):
+
+```json
+{
+	"HTTPS": {
+		"Enabled": true,
+		"Listen": ":443",
+		"ServerCertificate": "/usr/share/doc/mender-gateway/examples/cert/cert.crt",
+		"ServerKey": "/usr/share/doc/mender-gateway/examples/cert/private.key"
+	},
+	"UpstreamServer": {
+		"URL": "https://hosted.mender.io"
+	},
+	"Metrics": {
+		"Enabled": true,
+		"Listen": ":9102"
+	}
+}
+```
+
+The endpoint reports counters for the number of API requests
+(`mender_gateway_http_requests_total`) and the response bytes served
+(`mender_gateway_http_response_bytes_total`), each labelled by request method,
+status code, and the matched route, together with a set of Go runtime and
+process memory gauges and the process start time for detecting restarts. Because
+requests are labelled by the matched route rather than the raw URL, the number
+of time series stays bounded to the gateway's registered routes.
+
+! The metrics endpoint is not authenticated. The default `:9102` binds every
+! interface, so set `Listen` to an address on a trusted network — for example
+! `127.0.0.1:9102` to expose it only on the gateway host.


### PR DESCRIPTION
## What

Documents the optional Prometheus `/metrics` endpoint being added to Mender Gateway ([ME-691](https://northerntech.atlassian.net/browse/ME-691)).

- **Server integration → Mender Gateway** (overview): new *Monitoring with Prometheus metrics* section — how to enable it, the metrics it exposes, and a warning that the endpoint is unauthenticated.
- **Configuration file reference**: documents the `Metrics.Enabled` / `Metrics.Listen` options (and their `METRICS_ENABLED` / `METRICS_LISTEN` environment variables), including that `Listen` is a `host:port` address whose default `:9102` binds every interface.
- Separate commit removes a pre-existing stray `</dl>` in the config reference (unbalanced markup that rendered as an empty paragraph).

## Notes for reviewers

- The *Available from Mender Gateway version* note is set to **2.2.0** (the next release after the current 2.1.0). Please confirm or adjust it to the actual target release.
- This documents the feature implemented in the corresponding `mender-gateway` change (branch `ME-691/master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ME-691]: https://northerntech.atlassian.net/browse/ME-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ