### PR TITLE
chore: Revert "chore: Update mender-gateway example config paths"

### DIFF
--- a/10.Server-integration/04.Mender-Gateway/docs.md
+++ b/10.Server-integration/04.Mender-Gateway/docs.md
@@ -51,8 +51,8 @@ file](99.Configuration-file/) as shown in this example:
 	"HTTPS": {
 		"Enabled": true,
 		"Listen": ":443",
-		"ServerCertificate": "/usr/share/mender-gateway/examples/cert/cert.crt",
-		"ServerKey": "/usr/share/mender-gateway/examples/cert/private.key"
+		"ServerCertificate": "/usr/share/doc/mender-gateway/examples/cert/cert.crt",
+		"ServerKey": "/usr/share/doc/mender-gateway/examples/cert/private.key"
 	},
 	"Features": {
 		"ArtifactsProxy": {
@@ -91,8 +91,8 @@ reported by all devices connected to it. The value of the attribute can be confi
 	"HTTPS": {
 		"Enabled": true,
 		"Listen": ":443",
-		"ServerCertificate": "/usr/share/mender-gateway/examples/cert/cert.crt",
-		"ServerKey": "/usr/share/mender-gateway/examples/cert/private.key"
+		"ServerCertificate": "/usr/share/doc/mender-gateway/examples/cert/cert.crt",
+		"ServerKey": "/usr/share/doc/mender-gateway/examples/cert/private.key"
 	},
 	"Features": {
 		"ArtifactsProxy": {

--- a/12.Downloads/02.Device-components/docs.md
+++ b/12.Downloads/02.Device-components/docs.md
@@ -1339,7 +1339,7 @@ Then install the contents with:
 sudo tar -C / --strip-components=2 -xvf mender-gateway-examples-2.1.0.tar
 ```
 
-<!--AUTOMATION: test=test -d /usr/share/mender-gateway/examples -->
+<!--AUTOMATION: test=test -d /usr/share/doc/mender-gateway/examples -->
 <!--AUTOMATION: test=grep hosted.mender.io /etc/mender/mender-gateway.conf -->
 
 


### PR DESCRIPTION
The changes aren't released, meaning the example paths are for master only.

This reverts commit 8d647f6bd5bff35a95bbb32575417808a4d11e43.