### PR TITLE
ci: migrate mender-docs from dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - commit-message:
-      prefix: chore
-    directory: /
-    package-ecosystem: npm
-    schedule:
-      interval: monthly
-      day: saturday

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,9 @@ include:
       - qa-common/runner.yml
       - qa-common/retry.yml
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
+    inputs:
+      stage: ".pre"
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-python3-format.yml'
   - project: 'Northern.tech/Mender/mendertesting'

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,68 @@
+// renovate.json5 - Mender dependency update configuration for mender-docs
+// See Documentation/dependency-updates.md in mender-qa for the process.
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "extends": [
+    "config:recommended",
+    ":gitSignOff",
+    ":rebaseStalePrs"
+  ],
+
+  // CODEOWNERS assigns qa for package.json and package-lock.json here.
+  "reviewersFromCodeOwners": true,
+
+  // fix(deps): <desc>, per renovate.json5.sample in mender-qa.
+  "semanticCommits": "enabled",
+  "semanticCommitType": "fix",
+  "semanticCommitScope": "deps",
+
+  // Fallback window for weeks with no merges; the renovate CI job is the primary trigger.
+  "schedule": ["after 10pm on Monday", "before 6am on Tuesday"],
+
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 5,
+
+  // master only, matching what Dependabot did. The 1.0.x - 1.3.x branches on the
+  // remote never received dependency PRs.
+  "baseBranchPatterns": ["master"],
+
+  // Security PRs bypass the schedule and automerge when CI is green.
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "automerge": true,
+    "automergeType": "pr",
+    "labels": ["security"]
+  },
+
+  "packageRules": [
+    // config:recommended pulls in :semanticPrefixFixDepsChoreOthers, which forces
+    // semanticCommitType back to "chore" for deps whose manager does not tag them
+    // with an npm/pip style depType. Must stay BEFORE the gitlabci rule: last match
+    // wins.
+    {
+      "matchPackageNames": ["*"],
+      "semanticCommitType": "fix"
+    },
+
+    // CI file updates get ci: instead of fix(deps):
+    {
+      "matchManagers": ["gitlabci", "gitlabci-include"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": ""
+    },
+
+    // npm is the only ecosystem here - two groups to keep the queue small.
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "npm-dev-dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "groupName": "npm-prod-dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
Part of QA-1485

Dropped dependabot and added a renovate config. This repo had no renovate job so the mendertesting component is wired in the pre stage too

CODEOWNERS already assigns qa for package.json so reviewersFromCodeOwners covers it

npm is the only ecosystem here, split into dev and prod groups. master only, matching what dependabot did - the 1.0.x to 1.3.x branches never got dependency PRs

Trigger note - this project has no pipeline schedule so renovate will not run until one is added or mendersoftware/mendertesting#519 lands
