### PR TITLE
fix: broken links to api docs for Retrypollcount

### DIFF
--- a/03.Client-installation/07.Configuration/50.Configuration-options/docs.md
+++ b/03.Client-installation/07.Configuration/50.Configuration-options/docs.md
@@ -199,10 +199,10 @@ The waiting time between the retries is 60 seconds and can't be configured.
 The maximum number of tries that the Mender Client performs when contacting the Mender Server before giving up.
 
 It applies to the following Device APIs:
-* [Check Update](https://docs.mender.io/api/#device-api-deployments-v2-check-update)
-* [Inventory reporting APIs](https://docs.mender.io/api/#device-api-device-inventory)
-* [Update Deployment Status](https://docs.mender.io/api/#device-api-deployments-update-deployment-status)
-  * Only when reporting [status](https://docs.mender.io/api/#device-api-deployments-schemas-deploymentstatus) "commit", "success" and "failure"
+* [Check Update](https://docs.mender.io/api/check-update/)
+* [Inventory reporting APIs](https://docs.mender.io/api/replace-attributes/)
+* [Update Deployment Status](https://docs.mender.io/api/update-deployment-status/)
+  * Only when reporting [status](https://docs.mender.io/api/update-deployment-status/) "commit", "success" and "failure"
     * _for historical reasons, commit gets reported to the server as a second "install"_
 
 


### PR DESCRIPTION
Test:
[link-fix-test.webm](https://github.com/user-attachments/assets/64209ac7-fc3f-423a-9d36-e8d4509c302b)
